### PR TITLE
Added check for isolated nodes in model structure, and refactored...

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -31,6 +31,7 @@ cdef class AbstractNode:
     cdef AbstractNode _parent
     cdef object _model
     cdef object _name
+    cdef bint _allow_isolated
 
     cdef Parameter _cost_param
     cpdef get_cost(self, Timestep ts, int[:] scenario_indices=*)

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -80,6 +80,9 @@ cdef class Domain:
         self.name = name
 
 cdef class AbstractNode:
+    def __cinit__(self):
+        self._allow_isolated = False
+
     def __init__(self, model, name, **kwargs):
         self._model = model
         model.graph.add_node(self)
@@ -91,6 +94,12 @@ cdef class AbstractNode:
         self._recorders = []
 
         self._flow = np.empty([0,], np.float64)
+
+    property allow_isolated:
+        def __get__(self):
+            return self._allow_isolated
+        def __set__(self, value):
+            self._allow_isolated = value
 
     property cost:
         """The cost per unit flow via the node
@@ -401,6 +410,7 @@ cdef class Storage(AbstractNode):
         self._max_volume_param = None
         self._cost_param = None
         self._domain = None
+        self._allow_isolated = True
 
     property volume:
         def __get__(self, ):

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -95,6 +95,10 @@ cdef class AbstractNode:
 
         self._flow = np.empty([0,], np.float64)
 
+        # there shouldn't be any unhandled keyword arguments by this point
+        if kwargs:
+            raise TypeError("__init__() got an unexpected keyword argument '{}'".format(list(kwargs.items())[0]))
+
     property allow_isolated:
         def __get__(self):
             return self._allow_isolated

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -630,21 +630,29 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, BaseN
         name : string
             A unique name for the node
         """
-        super(Node, self).__init__(model, name, **kwargs)
-        self.color = 'black'
 
-        try:
-            x = float(kwargs['x'])
-            y = float(kwargs['y'])
-            self.position = (x, y,)
-        except KeyError:
-            pass
+        x = kwargs.pop('x', None)
+        y = kwargs.pop('y', None)
+        if x is not None and y is not None:
+            position = (float(x), float(y),)
+        else:
+            position = None
+
+        color = kwargs.pop('color', 'black')
+        min_flow = pop_kwarg_parameter(kwargs, 'min_flow', 0.0)
+        max_flow = pop_kwarg_parameter(kwargs, 'max_flow', float('inf'))
+        cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
+        conversion_factor = pop_kwarg_parameter(kwargs, 'conversion_factor', 1.0)
+
+        super(Node, self).__init__(model, name, **kwargs)
 
         self.slots = {}
-        self.min_flow = pop_kwarg_parameter(kwargs, 'min_flow', 0.0)
-        self.max_flow = pop_kwarg_parameter(kwargs, 'max_flow', float('inf'))
-        self.cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
-        self.conversion_factor = pop_kwarg_parameter(kwargs, 'conversion_factor', 1.0)
+        self.color = color
+        self.min_flow = min_flow
+        self.max_flow = max_flow
+        self.cost = cost
+        self.conversion_factor = conversion_factor
+        self.position = position
 
     def __repr__(self):
         if self.name:
@@ -786,12 +794,24 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, _c
     sub-nodes record flow as normal.
     """
     def __init__(self, model, name, num_outputs=1, num_inputs=1, *args, **kwargs):
-        super(Storage, self).__init__(model, name, **kwargs)
-
         # cast number of inputs/outputs to integer
         # this is needed if values come in as strings from xml
         num_outputs = int(num_outputs)
         num_inputs = int(num_inputs)
+
+        min_volume = pop_kwarg_parameter(kwargs, 'min_volume', 0.0)
+        max_volume = pop_kwarg_parameter(kwargs, 'max_volume', 0.0)
+        volume = kwargs.pop('volume', 0.0)
+        cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
+
+        x = kwargs.pop('x', None)
+        y = kwargs.pop('y', None)
+        if x is not None and y is not None:
+            position = (float(x), float(y),)
+        else:
+            position = None
+
+        super(Storage, self).__init__(model, name, **kwargs)
 
         self.outputs = []
         for n in range(0, num_outputs):
@@ -801,10 +821,11 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, _c
         for n in range(0, num_inputs):
             self.inputs.append(StorageInput(model, name="{} Input #{}".format(self.name, n), parent=self))
 
-        self.min_volume = pop_kwarg_parameter(kwargs, 'min_volume', 0.0)
-        self.max_volume = pop_kwarg_parameter(kwargs, 'max_volume', 0.0)
-        self.volume = kwargs.pop('volume', 0.0)
-        self.cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
+        self.min_volume = min_volume
+        self.max_volume = max_volume
+        self.volume = volume
+        self.cost = cost
+        self.position = position
 
         # TODO: keyword arguments for input and output nodes specified with prefix
         '''

--- a/tests/models/reservoir1.xml
+++ b/tests/models/reservoir1.xml
@@ -7,7 +7,7 @@
         </description>
     </metadata>
     <nodes>
-        <reservoir name="supply1" x="1" y="1">
+        <reservoir name="supply1" x="1" y="1" num_inputs="1" num_outputs="0">
             <parameter type="constant" key="max_volume">35</parameter>
             <parameter type="constant" key="volume">35</parameter>
         </reservoir>
@@ -18,7 +18,7 @@
         </demandcentre>
     </nodes>
     <edges>
-        <edge from="supply1" to="link1" />
+        <edge from="supply1" to="link1" from_slot="0" />
         <edge from="link1" to="demand1" />
     </edges>
 </pywr>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,6 +43,21 @@ def test_names(solver):
         node4 = Input(model)
 
 
+def test_unexpected_kwarg(solver):
+    model = Model(solver=solver)
+
+    with pytest.raises(TypeError):
+        node = Node(model, 'test_node', invalid=True)
+    with pytest.raises(TypeError):
+        inpt = Input(model, 'test_input', invalid=True)
+    with pytest.raises(TypeError):
+        storage = Storage(model, 'test_storage', invalid=True)
+    # none of the nodes should have been added to the model as they all
+    # raised exceptions during __init__
+    # TODO FIXME: nodes are still added, even if __init__ raises exception
+    # assert(not model.nodes())
+
+
 # TODO Update this test. Blender is not implemented.
 @pytest.mark.xfail
 def test_slots_to(solver):
@@ -194,9 +209,9 @@ def test_check_isolated_nodes(simple_linear_model):
     # add a node, but don't connect it to the network
     isolated_node = Input(model, 'isolated')
     with pytest.raises(ModelStructureError):
-        model.check
+        model.check()
 
-def test_check_isolated_nodes(solver):
+def test_check_isolated_nodes_storage(solver):
     """Test model structure checker with Storage
     
     The Storage node itself doesn't have any connections, but it's child

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import pytest
+from fixtures import simple_linear_model
 from pywr._core import Timestep
 
 from pywr.core import *
@@ -182,3 +183,34 @@ def test_reset_before_run(solver):
     model = Model(solver=solver)
     node = Node(model, 'node')
     model.reset()
+
+
+def test_check_isolated_nodes(simple_linear_model):
+    """Test model storage checker"""
+    # the simple model shouldn't have any isolated nodes
+    model = simple_linear_model
+    model.check()
+    
+    # add a node, but don't connect it to the network
+    isolated_node = Input(model, 'isolated')
+    with pytest.raises(ModelStructureError):
+        model.check
+
+def test_check_isolated_nodes(solver):
+    """Test model structure checker with Storage
+    
+    The Storage node itself doesn't have any connections, but it's child
+    nodes do need to be connected.
+    """
+    model = Model(solver=solver)
+    
+    # add a storage, but don't connect it's outflow to anything
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    with pytest.raises(ModelStructureError):
+        model.check()
+
+    # add a demand node and connect it to the storage outflow
+    demand = Output(model, 'demand')
+    storage.connect(demand, from_slot=0)
+    model.check()
+


### PR DESCRIPTION
This PR has two changes bundled into 1 commit (that was written on the train). The main purpose was to add a check for nodes that weren't part of a valid route to `Model.check`. This highlighted a reservoir in one of the tests which had nothing connected to it's only output. I fixed that by making `num_outputs=0` valid, but then needed a way to pass that information from XML. The easiest way to do this was to have `Node` accept any keyword arguments. The side effect of this is that it now will accept ANY keyword argument, even if it's not valid/used. This opens the door for typographic errors. However, I'm not sure how to check for "unused" arguments because of the way the objects are subclassed. I think that's focus for another issue/PR.