### PR TITLE
Added debug infomation for infeasible problems in GLPK.

### DIFF
--- a/pywr/solvers/glpk.pxi
+++ b/pywr/solvers/glpk.pxi
@@ -44,6 +44,10 @@ cdef extern from "glpk.h":
         pass
     ctypedef struct glp_smcp:
         int msg_lev
+        int presolve
+
+    int GLP_ON = 1 # on
+    int GLP_OFF = 0 # off
 
     int GLP_MIN = 1 # minimization
     int GLP_MAX = 2 # maximization
@@ -77,6 +81,9 @@ cdef extern from "glpk.h":
     void glp_set_mat_row(glp_prob *P, int i, int len, const int ind[], const double val[]);
     void glp_set_mat_col(glp_prob *P, int j, int len, const int ind[], const double val[]);
 
+    void glp_set_row_name(glp_prob *P, int i, const char *name)
+    void glp_set_col_name(glp_prob *P, int j, const char *name)
+
     void glp_set_row_bnds(glp_prob *P, int i, int type, double lb, double ub)
     void glp_set_col_bnds(glp_prob *P, int j, int type, double lb, double ub)
 
@@ -88,5 +95,13 @@ cdef extern from "glpk.h":
 
     int glp_get_status(glp_prob *P)
     
+    int glp_get_mat_row(glp_prob *P, int i, int ind[], double val[])
+
+    int glp_get_num_cols(glp_prob *P)
+    int glp_get_num_rows(glp_prob *P)
+
     double glp_get_row_prim(glp_prob *P, int i)
     double glp_get_col_prim(glp_prob *P, int j)
+
+    const char *glp_get_row_name(glp_prob *P, int i)
+    const char *glp_get_col_name(glp_prob *P, int j)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -450,6 +450,16 @@ def test_run_until_date(solver):
     assert(timestep.index == 20)
 
 
+def test_run_is_infeasible(solver):
+    model = pywr.core.Model(solver=solver)
+    catchment = pywr.core.Input(model, name="Input", min_flow=10.0, max_flow=10.0, cost=1)
+    demand = pywr.core.Output(model, name="Demand", max_flow=5.0, cost=-500)
+    catchment.connect(demand)
+    # problem is infeasible, because catchment.min_flow > demand.max_flow
+    with pytest.raises(RuntimeError):
+        model.run()
+
+
 def test_select_solver_xml():
     """Test specifying the solver in XML"""
     solver_names = list(pywr.solvers.SolverMeta.solvers.keys())


### PR DESCRIPTION
This PR adds some debugging information for infeasible problems when using the GLPK solver, using slack variables.

Can you think of a good way to provide access to the information as an argument to the exception? Is a formatted message enough? I'm thinking that it may need to be accessed from a UI in which case just `print()`ing isn't enough.

Also enabled the GLPK presolver, not that it seems to do much. I can't imagine it being a bad thing though.