### PR TITLE
Clarified the purpose of `volume` and `initial_volume` on Storage

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -397,21 +397,14 @@ cdef class Storage(AbstractNode):
 
     property volume:
         def __get__(self, ):
-            return self._volume[0]
-
-        def __set__(self, value):
-            # This actually sets the initial volume
-            # TODO provide a method to set the _volume for a given scenario(s).
-            import warnings
-            warnings.warn("Setting volume property directly is not supported. This method is updating the initial storage volume.")
-            self._initial_volume = value
+            return np.asarray(self._volume)
 
     property initial_volume:
         def __get__(self, ):
             return self._initial_volume
 
         def __set__(self, value):
-            self._initial_volume
+            self._initial_volume = value
 
     property min_volume:
         def __set__(self, value):

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -877,7 +877,11 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, _c
 
         min_volume = pop_kwarg_parameter(kwargs, 'min_volume', 0.0)
         max_volume = pop_kwarg_parameter(kwargs, 'max_volume', 0.0)
-        volume = kwargs.pop('volume', 0.0)
+        if 'volume' in kwargs:
+            # support older API where volume kwarg was the initial volume
+            initial_volume = kwargs.pop('volume')
+        else:
+            initial_volume = kwargs.pop('initial_volume', 0.0)
         cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
 
         x = kwargs.pop('x', None)
@@ -899,7 +903,7 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, XMLSeriaizable, _c
 
         self.min_volume = min_volume
         self.max_volume = max_volume
-        self.volume = volume
+        self.initial_volume = initial_volume
         self.cost = cost
         self.position = position
 

--- a/tests/models/reservoir1.xml
+++ b/tests/models/reservoir1.xml
@@ -9,7 +9,7 @@
     <nodes>
         <reservoir name="supply1" x="1" y="1" num_inputs="1" num_outputs="0">
             <parameter type="constant" key="max_volume">35</parameter>
-            <parameter type="constant" key="volume">35</parameter>
+            <parameter type="constant" key="initial_volume">35</parameter>
         </reservoir>
         <river name="link1" x="2" y="1" />
         <demandcentre name="demand1" x="3" y="1">

--- a/tests/models/reservoir2.xml
+++ b/tests/models/reservoir2.xml
@@ -9,7 +9,7 @@
     <nodes>
         <reservoir name="supply1" x="1" y="1">
             <parameter type="constant" key="max_volume">35</parameter>
-            <parameter type="constant" key="volume">35</parameter>
+            <parameter type="constant" key="initial_volume">35</parameter>
             <parameter type="constant" key="cost">-5</parameter>
         </reservoir>
         <river name="link1" x="2" y="1" />


### PR DESCRIPTION
This PR resolves #99.

`Storage.volume` now returns an array, instead of just the state of the first scenario. The `Storage.volume` property is now read-only. `Storage.__init__` continues to support `volume` as a keyword argument, but also accepts `initial_volume`.

I've also added a test to check the behaviour of storage volume in under different inflow scenarios. This helped to confirm it was doing the right thing with the numbers.