### PR TITLE
Nodes can now access current model implicitly

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -95,8 +95,16 @@ cdef class AbstractNode:
     def __cinit__(self):
         self._allow_isolated = False
 
-    def __init__(self, model, name, **kwargs):
+    def __init__(self, name, **kwargs):
+        model = kwargs.pop('model', None)
+        if model is None:
+            # if model was not specified get current
+            from pywr.core import gcm
+            model = gcm()
+            if model is None:
+                raise RuntimeError("A Model must be created before a Node")
         self._model = model
+        
         self.name = name
 
         self._parent = kwargs.pop('parent', None)

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -160,13 +160,13 @@ class NodeIterator(object):
         # support for old API
         return self
 
-model = None
+_model = None
 def gcm():
-    global model
-    return model
+    global _model
+    return _model
 def clm():
-    global model
-    model = None
+    global _model
+    _model = None
 
 class Model(object):
     """Model of a water supply network"""
@@ -224,8 +224,8 @@ class Model(object):
             key = list(kwargs.keys())[0]
             raise TypeError("'{}' is an invalid keyword argument for this function".format(key))
 
-        global model
-        model = self
+        global _model
+        _model = self
 
         self.reset()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,10 +22,10 @@ def simple_linear_model(request, solver):
 
     """
     model = Model(solver=solver)
-    inpt = Input(model, name="Input")
-    lnk = Link(model, name="Link", cost=1.0)
+    inpt = Input(name="Input")
+    lnk = Link(name="Link", cost=1.0)
     inpt.connect(lnk)
-    otpt = Output(model, name="Output")
+    otpt = Output(name="Output")
     lnk.connect(otpt)
 
     return model
@@ -45,9 +45,9 @@ def simple_storage_model(request, solver):
         solver=solver
     )
 
-    inpt = Input(model, name="Input", max_flow=5.0, cost=-1)
-    res = Storage(model, name="Storage", num_outputs=1, num_inputs=1, max_volume=20, volume=10)
-    otpt = Output(model, name="Output", max_flow=8, cost=-999)
+    inpt = Input(model=model, name="Input", max_flow=5.0, cost=-1)
+    res = Storage(model=model, name="Storage", num_outputs=1, num_inputs=1, max_volume=20, volume=10)
+    otpt = Output(model=model, name="Output", max_flow=8, cost=-999)
     
     inpt.connect(res)
     res.connect(otpt)

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -57,13 +57,13 @@ def linear_model_with_storage(request, solver):
     max_volume = 10.0
 
     model = pywr.core.Model(solver=solver)
-    inpt = pywr.core.Input(model, name="Input", min_flow=in_flow, max_flow=in_flow)
-    lnk = pywr.core.Link(model, name="Link", cost=0.1)
+    inpt = pywr.core.Input(model=model, name="Input", min_flow=in_flow, max_flow=in_flow)
+    lnk = pywr.core.Link(model=model, name="Link", cost=0.1)
     inpt.connect(lnk)
-    otpt = pywr.core.Output(model, name="Output", min_flow=out_flow, cost=-out_benefit)
+    otpt = pywr.core.Output(model=model, name="Output", min_flow=out_flow, cost=-out_benefit)
     lnk.connect(otpt)
 
-    strg = pywr.core.Storage(model, name="Storage", max_volume=max_volume, min_volume=min_volume,
+    strg = pywr.core.Storage(model=model, name="Storage", max_volume=max_volume, min_volume=min_volume,
                              volume=current_volume, cost=-strg_benefit)
 
     strg.connect(otpt)
@@ -106,17 +106,17 @@ def two_domain_linear_model(request, solver):
 
     model = pywr.core.Model(solver=solver)
     # Create river network
-    river_inpt = pywr.core.Input(model, name="Catchment", max_flow=river_flow, domain=river_domain)
-    river_lnk = pywr.core.Link(model, name="Reach", domain=river_domain)
+    river_inpt = pywr.core.Input(model=model, name="Catchment", max_flow=river_flow, domain=river_domain)
+    river_lnk = pywr.core.Link(model=model, name="Reach", domain=river_domain)
     river_inpt.connect(river_lnk)
-    river_otpt = pywr.core.Output(model, name="Abstraction", domain=river_domain, cost=0.0)
+    river_otpt = pywr.core.Output(model=model, name="Abstraction", domain=river_domain, cost=0.0)
     river_lnk.connect(river_otpt)
     # Create grid network
-    grid_inpt = pywr.core.Input(model, name="Power Plant", max_flow=power_plant_cap, domain=grid_domain,
+    grid_inpt = pywr.core.Input(model=model, name="Power Plant", max_flow=power_plant_cap, domain=grid_domain,
                                                conversion_factor=1/power_plant_flow_req)
-    grid_lnk = pywr.core.Link(model, name="Transmission", cost=1.0, domain=grid_domain)
+    grid_lnk = pywr.core.Link(model=model, name="Transmission", cost=1.0, domain=grid_domain)
     grid_inpt.connect(grid_lnk)
-    grid_otpt = pywr.core.Output(model, name="Substation", max_flow=power_demand,
+    grid_otpt = pywr.core.Output(model=model, name="Substation", max_flow=power_demand,
                                  cost=-power_benefit, domain=grid_domain)
     grid_lnk.connect(grid_otpt)
     # Connect grid to river
@@ -162,17 +162,17 @@ def two_cross_domain_output_single_input(request, solver):
 
     model = pywr.core.Model(solver=solver)
     # Create grid network
-    grid_inpt = pywr.core.Input(model, name="Input", domain='grid',)
-    grid_lnk = pywr.core.Link(model, name="Link", cost=1.0, domain='grid')
+    grid_inpt = pywr.core.Input(model=model, name="Input", domain='grid',)
+    grid_lnk = pywr.core.Link(model=model, name="Link", cost=1.0, domain='grid')
     grid_inpt.connect(grid_lnk)
-    grid_otpt = pywr.core.Output(model, name="Output", max_flow=50.0, cost=-10.0, domain='grid')
+    grid_otpt = pywr.core.Output(model=model, name="Output", max_flow=50.0, cost=-10.0, domain='grid')
     grid_lnk.connect(grid_otpt)
     # Create river network
     for i in range(2):
-        river_inpt = pywr.core.Input(model, name="Catchment {}".format(i), max_flow=river_flow, domain='river')
-        river_lnk = pywr.core.Link(model, name="Reach {}".format(i), domain='river')
+        river_inpt = pywr.core.Input(model=model, name="Catchment {}".format(i), max_flow=river_flow, domain='river')
+        river_lnk = pywr.core.Link(model=model, name="Reach {}".format(i), domain='river')
         river_inpt.connect(river_lnk)
-        river_otpt = pywr.core.Output(model, name="Abstraction {}".format(i), domain='river', cost=0.0)
+        river_otpt = pywr.core.Output(model=model, name="Abstraction {}".format(i), domain='river', cost=0.0)
         river_lnk.connect(river_otpt)
         # Connect grid to river
         river_otpt.connect(grid_inpt)
@@ -209,14 +209,14 @@ def simple_linear_inline_model(request, solver):
 
     """
     model = pywr.core.Model(solver=solver)
-    inpt0 = pywr.core.Input(model, name="Input 0")
-    inpt1 = pywr.core.Input(model, name="Input 1")
+    inpt0 = pywr.core.Input(model=model, name="Input 0")
+    inpt1 = pywr.core.Input(model=model, name="Input 1")
     inpt0.connect(inpt1)
-    lnk = pywr.core.Link(model, name="Link", cost=1.0)
+    lnk = pywr.core.Link(model=model, name="Link", cost=1.0)
     inpt1.connect(lnk)
-    otpt0 = pywr.core.Output(model, name="Output 0")
+    otpt0 = pywr.core.Output(model=model, name="Output 0")
     lnk.connect(otpt0)
-    otpt1 = pywr.core.Output(model, name="Output 1")
+    otpt1 = pywr.core.Output(model=model, name="Output 1")
     otpt0.connect(otpt1)
 
     return model
@@ -263,10 +263,10 @@ def bidirectional_model(request, solver):
     """
     model = pywr.core.Model(solver=solver)
     for i in range(2):
-        inpt = pywr.core.Input(model, name="Input {}".format(i))
-        lnk = pywr.core.Link(model, name="Link {}".format(i))
+        inpt = pywr.core.Input(model=model, name="Input {}".format(i))
+        lnk = pywr.core.Link(model=model, name="Link {}".format(i))
         inpt.connect(lnk)
-        otpt = pywr.core.Output(model, name="Output {}".format(i))
+        otpt = pywr.core.Output(model=model, name="Output {}".format(i))
         lnk.connect(otpt)
 
     # Create bidirectional link (i.e. a cycle)
@@ -321,14 +321,14 @@ def make_simple_model(supply_amplitude, demand, frequency,
         t = parent.model.timestamp.timetuple().tm_yday
         return S*np.cos(t*w)+S
 
-    supply = pywr.core.Supply(model, name='supply', max_flow=supply_func)
-    demand = pywr.core.Demand(model, name='demand', demand=demand)
-    res = pywr.core.Reservoir(model, name='reservoir')
+    supply = pywr.core.Supply(model=model, name='supply', max_flow=supply_func)
+    demand = pywr.core.Demand(model=model, name='demand', demand=demand)
+    res = pywr.core.Reservoir(model=model, name='reservoir')
     res.properties['max_volume'] = pywr.parameters.ParameterConstant(1e6)
     res.properties['current_volume'] = pywr.core.Variable(initial_volume)
 
-    supply_res_link = pywr.core.Link(model, name='link1')
-    res_demand_link = pywr.core.Link(model, name='link2')
+    supply_res_link = pywr.core.Link(model=model, name='link1')
+    res_demand_link = pywr.core.Link(model=model, name='link2')
 
     supply.connect(supply_res_link)
     supply_res_link.connect(res)

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -19,11 +19,11 @@ def simple_piecewise_model(request, solver):
     min_flow_req = 5.0
 
     model = pywr.core.Model(solver=solver)
-    inpt = pywr.core.Input(model, name="Input", max_flow=in_flow)
-    lnk = pywr.core.PiecewiseLink(model, name="Link", cost=[-1.0, 0.0], max_flow=[min_flow_req, None])
+    inpt = pywr.core.Input(model=model, name="Input", max_flow=in_flow)
+    lnk = pywr.core.PiecewiseLink(model=model, name="Link", cost=[-1.0, 0.0], max_flow=[min_flow_req, None])
 
     inpt.connect(lnk)
-    otpt = pywr.core.Output(model, name="Output", min_flow=out_flow, cost=-benefit)
+    otpt = pywr.core.Output(model=model, name="Output", min_flow=out_flow, cost=-benefit)
     lnk.connect(otpt)
 
     default = inpt.domain

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -25,10 +25,10 @@ def simple_gauge_model(request, solver):
     min_flow_req = 5.0
 
     model = pywr.core.Model(solver=solver)
-    inpt = river.Catchment(model, name="Catchment", flow=in_flow)
-    lnk = river.RiverGauge(model, name="Gauge", mrf=min_flow_req, mrf_cost=-1.0)
+    inpt = river.Catchment(model=model, name="Catchment", flow=in_flow)
+    lnk = river.RiverGauge(model=model, name="Gauge", mrf=min_flow_req, mrf_cost=-1.0)
     inpt.connect(lnk)
-    otpt = river.DemandCentre(model, name="Demand", max_flow=out_flow, cost=-benefit)
+    otpt = river.DemandCentre(model=model, name="Demand", max_flow=out_flow, cost=-benefit)
     lnk.connect(otpt)
 
     default = inpt.domain
@@ -67,14 +67,14 @@ def test_control_curve(solver):
     in_flow = 8
 
     model = pywr.core.Model(solver=solver)
-    catchment = river.Catchment(model, name="Catchment", flow=in_flow)
-    lnk = river.River(model, name="River")
+    catchment = river.Catchment(model=model, name="Catchment", flow=in_flow)
+    lnk = river.River(model=model, name="River")
     catchment.connect(lnk)
-    demand = river.DemandCentre(model, name="Demand", cost=-10.0, max_flow=10)
+    demand = river.DemandCentre(model=model, name="Demand", cost=-10.0, max_flow=10)
     lnk.connect(demand)
     from pywr.parameters import ParameterConstant
     control_curve = ParameterConstant(0.8)
-    reservoir = river.Reservoir(model, name="Reservoir", max_volume=10, cost=-20, above_curve_cost=0.0,
+    reservoir = river.Reservoir(model=model, name="Reservoir", max_volume=10, cost=-20, above_curve_cost=0.0,
                                 control_curve=control_curve, volume=10)
     reservoir.inputs[0].max_flow = 2.0
     reservoir.outputs[0].max_flow = 2.0

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -286,13 +286,13 @@ def test_run_blender2(solver):
 def test_run_demand_discharge(solver):
     """Test demand discharge node"""
     model = pywr.core.Model(solver=solver)
-    catchment = pywr.core.Catchment(model, 'catchment', flow=10.0)
-    abstraction1 = pywr.core.RiverAbstraction(model, 'abstraction1', max_flow=100)
-    demand1 = pywr.core.Demand(model, 'demand1', demand=8.0)
-    discharge = pywr.core.DemandDischarge(model, 'discharge')
-    abstraction2 = pywr.core.RiverAbstraction(model, 'abstraction2', max_flow=100)
-    demand2 = pywr.core.Demand(model, 'demand2', demand=5.0)
-    term = pywr.core.Terminator(model, 'term')
+    catchment = pywr.core.Catchment(model=model, name='catchment', flow=10.0)
+    abstraction1 = pywr.core.RiverAbstraction(model=model, name='abstraction1', max_flow=100)
+    demand1 = pywr.core.Demand(model=model, name='demand1', demand=8.0)
+    discharge = pywr.core.DemandDischarge(model=model, name='discharge')
+    abstraction2 = pywr.core.RiverAbstraction(model=model, name='abstraction2', max_flow=100)
+    demand2 = pywr.core.Demand(model=model, name='demand2', demand=5.0)
+    term = pywr.core.Terminator(model=model, name='term')
     catchment.connect(abstraction1)
     abstraction1.connect(demand1)
     abstraction1.connect(discharge)
@@ -326,12 +326,12 @@ def test_new_storage(solver):
         solver=solver
     )
 
-    supply1 = pywr.core.Input(model, 'supply1')
+    supply1 = pywr.core.Input(model=model, name='supply1')
 
-    splitter = pywr.core.Storage(model, 'splitter', num_outputs=1, num_inputs=2, max_volume=10, volume=5)
+    splitter = pywr.core.Storage(model=model, name='splitter', num_outputs=1, num_inputs=2, max_volume=10, volume=5)
 
-    demand1 = pywr.core.Output(model, 'demand1')
-    demand2 = pywr.core.Output(model, 'demand2')
+    demand1 = pywr.core.Output(model=model, name='demand1')
+    demand2 = pywr.core.Output(model=model, name='demand2')
 
     supply1.connect(splitter)
 
@@ -369,12 +369,12 @@ def test_storage_spill_compensation(solver):
     """
     model = pywr.core.Model(solver=solver)
 
-    catchment = pywr.core.Input(model, name="Input", min_flow=10.0, max_flow=10.0, cost=1)
-    reservoir = pywr.core.Storage(model, name="Storage", max_volume=100, volume=100.0)
-    spill = pywr.core.Link(model, name="Spill", cost=1.0)
-    compensation = pywr.core.Link(model, name="Compensation", max_flow=3.0, cost=-999)
-    terminator = pywr.core.Output(model, name="Terminator", cost=-1.0)
-    demand = pywr.core.Output(model, name="Demand", max_flow=5.0, cost=-500)
+    catchment = pywr.core.Input(model=model, name="Input", min_flow=10.0, max_flow=10.0, cost=1)
+    reservoir = pywr.core.Storage(model=model, name="Storage", max_volume=100, volume=100.0)
+    spill = pywr.core.Link(model=model, name="Spill", cost=1.0)
+    compensation = pywr.core.Link(model=model, name="Compensation", max_flow=3.0, cost=-999)
+    terminator = pywr.core.Output(model=model, name="Terminator", cost=-1.0)
+    demand = pywr.core.Output(model=model, name="Demand", max_flow=5.0, cost=-500)
 
     catchment.connect(reservoir)
     reservoir.connect(spill)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -98,9 +98,9 @@ def test_scenario_storage(solver):
     """
     model = Model(solver=solver)
 
-    i = Input(model, 'input', max_flow=999)
-    s = Storage(model, 'storage', num_inputs=1, num_outputs=1, max_volume=1000, volume=500)
-    o = Output(model, 'output', max_flow=999)
+    i = Input(model=model, name='input', max_flow=999)
+    s = Storage(model=model, name='storage', num_inputs=1, num_outputs=1, max_volume=1000, volume=500)
+    o = Output(model=model, name='output', max_flow=999)
 
     scenario_input = pywr.core.Scenario(model, 'Inflow', size=2)
     i.min_flow = pywr.parameters.ParameterConstantScenario(scenario_input, [5.0, 10.0])


### PR DESCRIPTION
Globals are bad, but I'm stick of having to type `model` every time I create a `Node`. Now you can do this:

```
model = Model(solver='glpk')
supply = Input('supply1', max_flow=20)
```

I think this makes the model API generally look cleaner. Most of the time we'll be working with just one `Model` object anyway.

The current model is tracked by a global variable, accessable via `pywr.core.gcm()`. You can also clear the current model with `clm()`.

I've had to update all the tests to work with this, as most passed model as a sequential argument not a keyword argument. However, I've also added some new tests - have a look at the end of `test_core.py`:

https://github.com/pywr/pywr/blob/implicit_model/tests/test_core.py#L277-L324

If you try to create a `Node` before `Model` it will raise an exception. If you try to connect a node to another node in a different model it will also complain.