### PR TITLE
Add a name to Recorder and use RecorderIterator for access in Model.

### DIFF
--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -4,6 +4,7 @@ from _core cimport Timestep, AbstractNode, Storage
 
 cdef class Recorder:
     cdef bint _is_objective
+    cdef object _name
     cdef object _model
     cpdef setup(self)
     cpdef reset(self)

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -5,7 +5,7 @@ cdef class Recorder:
     def __init__(self, model, name=None):
         self._model = model
         if name is None:
-            name == self.__class__.__name__.lower()
+            name = self.__class__.__name__.lower()
         self.name = name
         model.recorders._recorders.append(self)
 

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -2,9 +2,23 @@ import numpy as np
 cimport numpy as np
 
 cdef class Recorder:
-    def __init__(self, model):
+    def __init__(self, model, name=None):
         self._model = model
-        model.recorders.append(self)
+        if name is None:
+            name == self.__class__.__name__.lower()
+        self.name = name
+        model.recorders._recorders.append(self)
+
+    property name:
+        def __get__(self):
+            return self._name
+
+        def __set__(self, name):
+            # check for name collision
+            if name in self.model.recorders.keys():
+                raise ValueError('A recorder with the name "{}" already exists.'.format(name))
+            # apply new name
+            self._name = name
 
     cpdef setup(self):
         pass
@@ -34,8 +48,10 @@ cdef class Recorder:
 
 
 cdef class NodeRecorder(Recorder):
-    def __init__(self, model, AbstractNode node):
-        Recorder.__init__(self, model)
+    def __init__(self, model, AbstractNode node, name=None):
+        if name is None:
+            name = "{}.{}".format(self.__class__.__name__.lower(), node.name)
+        Recorder.__init__(self, model, name=name)
         self._node = node
         node._recorders.append(self)
 
@@ -44,8 +60,10 @@ cdef class NodeRecorder(Recorder):
             return self._node
 
 cdef class StorageRecorder(Recorder):
-    def __init__(self, model, Storage node):
-        Recorder.__init__(self, model)
+    def __init__(self, model, Storage node, name=None):
+        if name is None:
+            name = "{}.{}".format(self.__class__.__name__.lower(), node.name)
+        Recorder.__init__(self, model, name=name)
         self._node = node
         node._recorders.append(self)
 

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -160,6 +160,45 @@ class NodeIterator(object):
         # support for old API
         return self
 
+
+class RecorderIterator(object):
+    """ Iterator for Recorder objects in a model that also supports indexing by name """
+
+    def __init__(self):
+        self._recorders = []
+
+    def __getitem__(self, key):
+        """Get a node from the graph by it's name"""
+        for rec in self._recorders:
+            if rec.name == key:
+                return rec
+        raise KeyError("'{}'".format(key))
+
+    def __delitem__(self, key):
+        """Remove a node from the graph by it's name"""
+        rec = self[key]
+        self._recorders.remove(rec)
+
+    def keys(self):
+        for rec in self._recorders:
+            yield rec.name
+
+    def values(self):
+        for rec in self._recorders:
+            yield rec
+
+    def items(self):
+        for rec in self._recorders:
+            yield (rec.name, rec)
+
+    def __len__(self):
+        """Returns the number of nodes in the model"""
+        return len(self._recorders)
+
+    def __iter__(self):
+        return iter(self._recorders)
+
+
 class Model(object):
     """Model of a water supply network"""
     def __init__(self, **kwargs):
@@ -209,7 +248,7 @@ class Model(object):
             self.solver = SolverMeta.get_default()()
 
         self.group = {}
-        self.recorders = []
+        self.recorders = RecorderIterator()
         self.scenarios = ScenarioCollection()
 
         if kwargs:

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -21,9 +21,9 @@ class CSVRecorder(Recorder):
         object
 
         """
-        super(CSVRecorder, self).__init__(model)
+        super(CSVRecorder, self).__init__(model, **kwargs)
         self.csvfile = csvfile
-        self.scenario_index = 0
+        self.scenario_index = scenario_index
         self.nodes = nodes
         self.csv_kwargs = kwargs.pop('csv_kwargs', {})
         self.node_names = None
@@ -80,7 +80,7 @@ class TablesRecorder(Recorder):
     Each CArray stores the data for all scenarios on the specific node. This
     is useful for analysis of Node statistics across multiple scenarios.
     """
-    def __init__(self, model, parent, nodes=None):
+    def __init__(self, model, parent, nodes=None, **kwargs):
         """
 
         :param model: The model to record nodes from.
@@ -88,7 +88,7 @@ class TablesRecorder(Recorder):
         :param nodes: An iterable of nodes to save data. It defaults
         to None which is all nodes in the model
         """
-        super(TablesRecorder, self).__init__(model)
+        super(TablesRecorder, self).__init__(model, **kwargs)
 
         self.parent = parent
         self.nodes = nodes

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -24,6 +24,14 @@ def test_numpy_recorder(simple_linear_model):
     otpt.cost = -2.0
     rec = NumpyArrayNodeRecorder(model, otpt)
 
+    # test retrieval of recorder
+    assert model.recorders['numpyarraynoderecorder.Output'] == rec
+    # test changing name of recorder
+    rec.name = 'timeseries.Output'
+    assert model.recorders['timeseries.Output'] == rec
+    with pytest.raises(KeyError):
+        model.recorders['numpyarraynoderecorder.Output']
+
     model.run()
 
     assert rec.data.shape == (365, 1)


### PR DESCRIPTION
This approach is similar to NodeIterator but is more simple. RecorderIterator is a wrapper around a list of recorders but provides access through keys and also iteration. The used API for Model.recorders is not significantly changed, but now provides access via name.

Recorders have a default name that is the the lowercase of the class name. NodeRecorder and StorageRecorder provide a default naming include the node's name.