### PR TITLE
Display model structure in Jupyter using D3.

### DIFF
--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -1,0 +1,55 @@
+import os
+from IPython.core.display import Javascript, display
+from jinja2 import Template
+
+from pywr.core import Model, Input, Output, Link, Storage, StorageInput, StorageOutput
+
+# load javascript template for d3 graph
+folder = os.path.dirname(__file__)
+with open(os.path.join(folder, "draw_graph.js"), "r") as f:
+    draw_graph_template = Template(f.read())
+
+def nx_to_json(model):
+    """Convert a Pywr graph to a structure d3 can display"""
+    nodes = []
+    for node in model.graph.nodes():
+        if not isinstance(node, (StorageInput, StorageOutput)):
+            nodes.append(node.name)
+
+    edges = []
+    for edge in model.graph.edges():
+        node_source, node_target = edge
+        
+        # where a link is to/from a subnode, display a link to the parent instead
+        if isinstance(node_source, (StorageInput, StorageOutput)):
+            node_source = node_source.parent
+        if isinstance(node_target, (StorageInput, StorageOutput)):
+            node_target = node_target.parent
+
+        index_source = nodes.index(node_source.name)
+        index_target = nodes.index(node_target.name)
+        edges.append({'source': index_source, 'target': index_target})
+
+    graph = {
+        "nodes": [
+            {
+                "name": name,
+                "color": model.node[name].color,
+            } for n, name in enumerate(nodes)
+        ],
+        "links": edges}
+    
+    return graph
+
+def draw_graph(model):
+    """Display a Pywr model using D3 in Jupyter
+    
+    Parameters
+    ----------
+    model : pywr.core.Model
+        The model to display
+    """
+    graph = nx_to_json(model)
+    data = draw_graph_template.render(graph=graph)
+    js = Javascript(data=data, lib="http://d3js.org/d3.v3.min.js")
+    display(js)

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -1,0 +1,52 @@
+var graph = {{ graph }};
+
+var div = d3.selectAll(element).append("div");
+
+var width = 500,
+    height = 400;
+
+var color = d3.scale.category20();
+
+var force = d3.layout.force()
+    .charge(-120)
+    .linkDistance(20)
+    .size([width, height]);
+
+var svg = div.append("svg")
+    .attr("width", width)
+    .attr("height", height);
+
+force
+  .nodes(graph.nodes)
+  .links(graph.links)
+  .start();
+
+var link = svg.selectAll(".link")
+  .data(graph.links)
+.enter().append("line")
+  .attr("class", "link")
+  .style("stroke", "#333")
+  .style("stroke-width", 1);
+
+var node = svg.selectAll(".node")
+  .data(graph.nodes)
+.enter().append("circle")
+  .attr("class", "node")
+  .attr("r", 5)
+  .style("fill", function(d) { return d.color; })
+  .style("stroke", "#333")
+  .style("stoke-width", 0.5)
+  .call(force.drag);
+
+node.append("title")
+  .text(function(d) { return d.name; });
+
+force.on("tick", function() {
+    link.attr("x1", function(d) { return d.source.x; })
+        .attr("y1", function(d) { return d.source.y; })
+        .attr("x2", function(d) { return d.target.x; })
+        .attr("y2", function(d) { return d.target.y; });
+
+node.attr("cx", function(d) { return d.x; })
+    .attr("cy", function(d) { return d.y; });
+});


### PR DESCRIPTION
This PR adds basic support for displaying a model network in Jupyter using D3 (#125). The usage is simple:

```
from pywr.notebook import draw_graph
draw_graph(model)
```

I think there is a lot of potential using this approach. For example, it should be possible to display model results as attributes on the nodes.

Currently the layout of the graph is force-directed. This could be optional, using the `position` property of the nodes instead.

However I think this is ready to be merged now as it's useful as-is.

<img width="659" alt="screen shot 2016-05-31 at 23 32 24" src="https://cloud.githubusercontent.com/assets/3883947/15692787/649e80a8-2788-11e6-9ad9-8ad32389b03b.png"> 