### PR TITLE
Fix #130; Unhelpful exception when Storage.max_volume == 0

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -589,8 +589,10 @@ cdef class Storage(AbstractNode):
             # Ensure variable maximum volume is taken in to account
             if self._max_volume_param is not None:
                 mxv = self._max_volume_param.value(self.model.timestepper.current, si)
-
-            self._current_pc[i] = self._volume[i] / mxv
+            try:
+                self._current_pc[i] = self._volume[i] / mxv
+            except ZeroDivisionError:
+                raise ValueError("Zero maximum volume is invalid on Storage object: {}".format(self))
 
     cpdef before(self, Timestep ts):
         """Called at the beginning of the timestep"""

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -592,7 +592,7 @@ cdef class Storage(AbstractNode):
             try:
                 self._current_pc[i] = self._volume[i] / mxv
             except ZeroDivisionError:
-                raise ValueError("Zero maximum volume is invalid on Storage object: {}".format(self))
+                self._current_pc[i] = np.nan
 
     cpdef before(self, Timestep ts):
         """Called at the beginning of the timestep"""
@@ -620,6 +620,9 @@ cdef class Storage(AbstractNode):
             # Ensure variable maximum volume is taken in to account
             if self._max_volume_param is not None:
                 mxv = self._max_volume_param.value(self.model.timestepper.current, si)
-            self._current_pc[i] = self._volume[i] / mxv
+            try:
+                self._current_pc[i] = self._volume[i] / mxv
+            except ZeroDivisionError:
+                self._current_pc[i] = np.nan
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -312,3 +312,23 @@ def test_check_isolated_nodes_storage(solver):
     demand = Output(model, 'demand')
     storage.connect(demand, from_slot=0)
     model.check()
+
+def test_invalid_max_storage_volume_exception(solver):
+    """Test a useful exception is raised when Storage has an invalid volume during a solve
+
+    """
+
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime('2016-01-01'),
+        end=pandas.to_datetime('2016-01-01')
+    )
+
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    otpt = Output(model, 'output', max_flow=99999, cost=-99999)
+    storage.connect(otpt)
+
+    storage.max_volume = 0
+
+    with pytest.raises(ValueError):
+        model.run()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -313,8 +313,8 @@ def test_check_isolated_nodes_storage(solver):
     storage.connect(demand, from_slot=0)
     model.check()
 
-def test_invalid_max_storage_volume_exception(solver):
-    """Test a useful exception is raised when Storage has an invalid volume during a solve
+def test_storage_max_volume_zero(solver):
+    """Test a that an max_volume of zero results in a NaN for current_pc and no exception
 
     """
 
@@ -330,5 +330,5 @@ def test_invalid_max_storage_volume_exception(solver):
 
     storage.max_volume = 0
 
-    with pytest.raises(ValueError):
-        model.run()
+    model.run()
+    assert np.isnan(storage.current_pc)


### PR DESCRIPTION
As per subject. Fixed by raising a `ValueError` instead.