### PR TITLE
Fixed issue with circular route around Storage in GLPK solver.

### DIFF
--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -140,8 +140,8 @@ cdef class CythonGLPKSolver:
         if len(storages):
             self.idx_row_storages = glp_add_rows(self.prob, len(storages))
         for col, storage in enumerate(storages):
-            cols_output = [n for n, route in enumerate(routes) if route[-1] in storage.outputs]
-            cols_input = [n for n, route in enumerate(routes) if route[0] in storage.inputs]
+            cols_output = [n for n, route in enumerate(routes) if route[-1] in storage.outputs and route[0] not in storage.inputs]
+            cols_input = [n for n, route in enumerate(routes) if route[0] in storage.inputs and route[-1] not in storage.outputs]
             ind = <int*>malloc((1+len(cols_output)+len(cols_input)) * sizeof(int))
             val = <double*>malloc((1+len(cols_output)+len(cols_input)) * sizeof(double))
             for n, c in enumerate(cols_output):


### PR DESCRIPTION
Fixes issue #140.

The problem was when a reservoir has a route that goes from one of it's Inputs to another of it's Outputs.

In the GLPK solver this resulted in the algorithm trying to set the value for the row that constrains changes in the volume of the reservoir twice: +1 for one, -1 for the other.

The fix is to detect this condition and not modify the matrix (i.e. default to 0). I *think* this is the correct thing to do, although if the +1 and -1 didn't cancel out, perhaps due to some loss in the route (which we don't currently implement) this may need more though.

Please you you review this @jetuk. It's the kind of thing that's easy to screw up.