### PR TITLE
Big refactor of control curve classes.

### DIFF
--- a/examples/two_reservoir_moea.py
+++ b/examples/two_reservoir_moea.py
@@ -19,7 +19,7 @@ import datetime
 import inspyred
 from pywr.core import Model, Input, Output, Link, Storage
 from pywr.parameters import ArrayIndexedParameter, MonthlyProfileParameter, AnnualHarmonicSeriesParameter
-from pywr.parameters.control_curves import ControlCurvePiecewiseParameter
+from pywr.parameters.control_curves import ControlCurveParameter
 from pywr.recorders import TotalDeficitNodeRecorder, TotalFlowRecorder, AggregatedRecorder
 from pywr.optimisation.moea import InspyredOptimisationModel
 
@@ -53,7 +53,7 @@ def create_model(harmonic=True):
         control_curve = MonthlyProfileParameter(np.array([0.0]*12), lower_bounds=0.0, upper_bounds=1.0)
 
     control_curve.is_variable = True
-    controller = ControlCurvePiecewiseParameter(control_curve, 0.0, 10.0, storage_node=reservoir1)
+    controller = ControlCurveParameter(control_curve, 0.0, 10.0, storage_node=reservoir1)
     transfer = Link(model, 'transfer', max_flow=controller, cost=-500)
 
     demand1 = Output(model, 'demand1', max_flow=45.0, cost=-101)

--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -1,7 +1,7 @@
 
 from ..core import Node, Domain, Input, Output, Link, Storage, PiecewiseLink
 from pywr.parameters import pop_kwarg_parameter, ConstantParameter, BaseParameter, load_parameter
-from pywr.parameters.control_curves import ControlCurvePiecewiseParameter
+from pywr.parameters.control_curves import ControlCurveParameter
 
 DEFAULT_RIVER_DOMAIN = Domain(name='river', color='#33CCFF')
 
@@ -92,7 +92,7 @@ class Reservoir(RiverDomainMixin, Storage):
             if not isinstance(cost, BaseParameter):
                 # In the case where an above_curve_cost is given and cost is not a Parameter
                 # a default cost Parameter is created.
-                kwargs['cost'] = ControlCurvePiecewiseParameter(control_curve, above_curve_cost, cost)
+                kwargs['cost'] = ControlCurveParameter(control_curve, [above_curve_cost, cost])
             else:
                 raise ValueError('If an above_curve_cost is given cost must not be a Parameter.')
         else:

--- a/pywr/parameters/_control_curves.pxd
+++ b/pywr/parameters/_control_curves.pxd
@@ -3,9 +3,7 @@ from ._parameters cimport Parameter
 
 cdef class BaseControlCurveParameter(Parameter):
     cdef Storage _storage_node
-    cdef Parameter _control_curve
+    cdef list _control_curves
 
 cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
-    cdef double lower_value
-    cdef double curve_value
-    cdef double upper_value
+    cdef double[:] _values

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -1,49 +1,69 @@
 import numpy as np
 cimport numpy as np
-from .parameters import parameter_registry
-from ._parameters import load_parameter
+from .parameters import parameter_registry, ConstantParameter
+from ._parameters import load_parameter, load_parameter_values
+
 
 cdef class BaseControlCurveParameter(Parameter):
     """ Base class for all Parameters that rely on a the attached Node containing a control_curve Parameter
 
     """
-    def __init__(self, control_curve, Storage storage_node=None):
+    def __init__(self, control_curves, Storage storage_node=None):
         """
 
         Parameters
         ----------
-        control_curve : Parameter
-            The Parameter object to use as a control_curve. It should not be shared with other
+        control_curve : iterable of Parameter objects or single Parameter
+            The Parameter objects to use as a control curve(s). These should not be shared with other
             Nodes and Parameters because this object becomes control_curve.parent
         """
         super(BaseControlCurveParameter, self).__init__()
-        if control_curve.parent is not None:
-            raise RuntimeError('control_curve already has a parent.')
-        control_curve.parent = self
-        self._control_curve = control_curve
+        self.control_curves = control_curves
         self._storage_node = storage_node
 
     cpdef setup(self, model):
-        self.control_curve.setup(model)
+        cdef Parameter cc
+        for cc in self.control_curves:
+            cc.setup(model)
         super(BaseControlCurveParameter, self).setup(model)
 
     cpdef reset(self):
-        self.control_curve.reset()
+        cdef Parameter cc
+        for cc in self.control_curves:
+            cc.reset()
         super(BaseControlCurveParameter, self).reset()
 
     cpdef before(self, Timestep ts):
-        self.control_curve.before(ts)
+        cdef Parameter cc
+        for cc in self.control_curves:
+            cc.before(ts)
         super(BaseControlCurveParameter, self).before(ts)
 
     cpdef after(self, Timestep ts):
-        self.control_curve.after(ts)
+        cdef Parameter cc
+        for cc in self.control_curves:
+            cc.after(ts)
         super(BaseControlCurveParameter, self).after(ts)
 
-    property control_curve:
+    property control_curves:
         def __get__(self):
-            return self._control_curve
-        def __set__(self, value):
-            self._control_curve = value
+            return self._control_curves
+        def __set__(self, control_curves):
+            # Accept a single Parameter and convert to a list internally
+            if isinstance(control_curves, Parameter):
+                control_curves = [control_curves]
+
+            _new_control_curves = []
+            for control_curve in control_curves:
+                # Accept numeric inputs and convert to `ConstantParameter`
+                if isinstance(control_curve, (float, int)):
+                    control_curve = ConstantParameter(control_curve)
+
+                if control_curve.parent is not None and control_curve.parent is not self:
+                    raise RuntimeError('control_curve already has a different parent.')
+                control_curve.parent = self
+                _new_control_curves.append(control_curve)
+            self._control_curves = list(_new_control_curves)
 
     property storage_node:
         def __get__(self):
@@ -51,44 +71,95 @@ cdef class BaseControlCurveParameter(Parameter):
         def __set__(self, value):
             self._storage_node = value
 
+    @classmethod
+    def _load_control_curves(cls, model, data):
+        """ Private class method to load control curve data from dict. """
+
+        control_curves = []
+        if 'control_curve' in data:
+            control_curves.append(load_parameter(model, data['control_curve']))
+        elif 'control_curves' in data:
+            for pdata in data['control_curves']:
+                control_curves.append(load_parameter(model, pdata))
+        return control_curves
+
+    @classmethod
+    def _load_storage_node(cls, model, data):
+        """ Private class method to load storage node from dict. """
+        if 'storage_node' in data:
+            return model.node[data['storage_node']]
+        return None
+
+
 parameter_registry.add(BaseControlCurveParameter)
 
 
 cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     """ A control curve Parameter that interpolates between three values.
     """
-    def __init__(self, control_curve, values):
-        super(ControlCurveInterpolatedParameter, self).__init__(control_curve)
-        values = np.array(values)
-        if len(values) != 3:
-            raise ValueError("Three values must be given to define the interpolation knots.")
-        self.lower_value, self.curve_value, self.upper_value = values
+    def __init__(self, control_curves, values):
+        super(ControlCurveInterpolatedParameter, self).__init__(control_curves)
+        # Expected number of values is number of control curves plus one.
+        nvalues = len(self.control_curves) + 2
+        if len(values) != nvalues:
+            raise ValueError('Length of values should be two more than the number of '
+                             'control curves ({}).'.format(nvalues))
+        self.values = values
+
+    property values:
+        def __get__(self):
+            return np.array(self._values)
+        def __set__(self, values):
+            self._values = np.array(values)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         cdef int i = scenario_index._global_id
-        cdef double control_curve = self._control_curve.value(ts, scenario_index)
+        cdef int j
+        cdef Parameter cc_param
+        cdef double cc, cc_prev
         cdef Storage node = self.node if self._storage_node is None else self._storage_node
         # return the interpolated value for the current level.
         cdef double current_pc = node._current_pc[i]
         cdef double weight
+
+        if current_pc > 1.0:
+            return self._values[0]
+
         if current_pc < 0.0:
-            return self.lower_value
-        elif current_pc < control_curve:
-            weight = (control_curve - current_pc) / control_curve
-            return self.lower_value*weight + self.curve_value*(1.0 - weight)
-        elif control_curve == 1.0:
-            return self.curve_value
-        elif current_pc <= 1.0:
-            weight = (1.0 - current_pc) / (1.0 - control_curve)
-            return self.curve_value*weight + self.upper_value*(1.0 - weight)
-        else:
-            return self.upper_value
+            return self._values[-1]
+
+        # Assumes control_curves is sorted highest to lowest
+        # First level 100%
+        cc_prev = 1.0
+        for j, cc_param in enumerate(self._control_curves):
+            cc = cc_param.value(ts, scenario_index)
+            # If level above control curve then return this level's value
+            if current_pc >= cc:
+                try:
+                    weight = (current_pc - cc) / (cc_prev - cc)
+                except ZeroDivisionError:
+                    # Last two control curves identical; return the next value
+                    return self._values[j+1]
+                return self._values[j]*weight + self._values[j+1]*(1.0 - weight)
+            # Update previous value for next iteration
+            cc_prev = cc
+
+        # Current storage is above none of the control curves
+        # Therefore interpolate between last control curve and bottom
+        cc = 0.0
+        try:
+            weight = (current_pc - cc) / (cc_prev - cc)
+        except ZeroDivisionError:
+            # cc_prev == cc  i.e. last control curve is close to 0%
+            return self._values[-2]
+        return self._values[-2]*weight + self._values[-1]*(1.0 - weight)
 
     @classmethod
     def load(cls, model, data):
-        control_curve = load_parameter(model, data["control_curve"])
-        values = data["values"]
-        parameter = cls(control_curve, values)
+        control_curves = super(ControlCurveInterpolatedParameter, cls)._load_control_curves(model, data)
+        storage_node = super(ControlCurveInterpolatedParameter, cls)._load_storage_node(model, data)
+        values = load_parameter_values(data["values"])
+        parameter = cls(control_curves, values)
         return parameter
 
 parameter_registry.add(ControlCurveInterpolatedParameter)

--- a/pywr/parameters/control_curves.py
+++ b/pywr/parameters/control_curves.py
@@ -3,74 +3,137 @@ This module contains a set of pywr._core.Parameter subclasses for defining contr
 """
 
 from ._control_curves import BaseControlCurveParameter, ControlCurveInterpolatedParameter
-from .parameters import parameter_registry
+from .parameters import parameter_registry, load_parameter_values, load_parameter
 import numpy as np
 
 
-class ControlCurvePiecewiseParameter(BaseControlCurveParameter):
-    """ A control curve Parameter that returns one of two values depending on whether the current
-    volume is above or below the control curve.
+class ControlCurveParameter(BaseControlCurveParameter):
+    """ A generic multi-levelled control curve Parameter.
+
+     This parameter can be used to return different values when a `Storage` node's current
+      volumes is at different percentage of `max_volume` relative to predefined control curves.
+      Control curves must be defined in the range [0, 1] corresponding to 0% and 100% volume.
+
+     By default this parameter returns an integer sequence from zero if the first control curve
+      is passed, and incrementing by one for each control curve (or "level") the `Storage` node
+      is below.
+
+    Parameters
+    ----------
+    control_curves : `float`, `int` or `Parameter` object, or iterable thereof
+        The position of the control curves. Internally `float` or `int` types are cast to
+        `ConstantParameter`. Multiple values correspond to multiple control curve positions.
+        These should be specified in descending order.
+    values : array_like or `None`, optional
+        The values to return if the `Storage` object is above the correspond control curve.
+        I.e. the first value is returned if the current volume is above the first control curve,
+        and second value if above the second control curve, and so on. The length of `values`
+        must be one more than than the length of `control_curves`. I
+    parameters : iterable `Parameter` objects or `None`, optional
+        If `values` is `None` then `parameters` can specify a `Parameter` object to use at level
+        of the control curves. In the same way as `values` the first `Parameter` is used if
+        `Storage` is above the first control curve, and second `Parameter` if above the
+        second control curve, and so on.
+    storage_node : `Storage` or `None`, optional
+        An optional `Storage` node that can be used to query the current percentage volume. If
+        not specified it is assumed that this object is attached to a `Storage` node and therefore
+        `self.node` is used.
+
+    Notes
+    -----
+    If `values` and `parameters` are both `None`, the default, then `values` defaults to
+     a range of integers, starting at zero, one more than length of `control_curves`.
+
+    See also
+    --------
+    `BaseControlCurveParameter`
 
     """
-    def __init__(self, control_curve, above_curve_value, below_curve_value, storage_node=None,
-                 above_curve_upper_bounds=None, above_curve_lower_bounds=None,
-                 below_curve_upper_bounds=None, below_curve_lower_bounds=None):
+    def __init__(self, control_curves, values=None, parameters=None, storage_node=None,
+                 upper_bounds=None, lower_bounds=None):
         """
 
-        :param control_curve: Parameter to use as the control curve
-        :param above_curve_value: Value to return when storage >= control_curve
-        :param below_curve_value: Value to return when storage < control_curve
-        :param storage_node: Optional Storage node to compare with the control_curve. If None
-            self.node is used (i.e. the Node this object is attached to).
-        """
-        super(ControlCurvePiecewiseParameter, self).__init__(control_curve, storage_node=storage_node)
 
-        self.above_curve_value = above_curve_value
-        self.below_curve_value = below_curve_value
+        """
+        super(ControlCurveParameter, self).__init__(control_curves, storage_node=storage_node)
+        # Expected number of values is number of control curves plus one.
+        self.size = nvalues = len(self.control_curves) + 1
+        self.values = None
+        self.parameters = None
+        if values is not None:
+            if len(values) != nvalues:
+                raise ValueError('Length of values should be one more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self.values = np.array(values)
+        elif parameters is not None:
+            if len(parameters) != nvalues:
+                raise ValueError('Length of parameters should be one more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self.parameters = list(parameters)
+        else:
+            # No values or parameters given, default to sequence of integers
+            self.values = np.arange(nvalues)
+
+        # Default values
+        self._upper_bounds = None
+        self._lower_bounds = None
 
         # Bounds for use as a variable (i.e. when self.is_variable = True)
-        self.above_curve_upper_bounds = above_curve_upper_bounds
-        self.above_curve_lower_bounds = above_curve_lower_bounds
-        self.below_curve_upper_bounds = below_curve_upper_bounds
-        self.below_curve_lower_bounds = below_curve_lower_bounds
-        self._update_variable_properties()
+        if upper_bounds is not None:
+            if self.values is None:
+                raise ValueError('Upper bounds can only be specified if `values` is not `None`.')
+            if len(upper_bounds) != nvalues:
+                raise ValueError('Length of upper_bounds should be one more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self._upper_bounds = np.array(upper_bounds)
 
-    def _update_variable_properties(self):
-        size = 0
-        lower_bounds = []
-        upper_bounds = []
-        if self.above_curve_upper_bounds is not None and self.above_curve_lower_bounds is not None:
-            size += 1
-            lower_bounds.append(self.above_curve_lower_bounds)
-            upper_bounds.append(self.above_curve_upper_bounds)
+        if lower_bounds is not None:
+            if self.values is None:
+                raise ValueError('Lower bounds can only be specified if `values` is not `None`.')
+            if len(lower_bounds) != nvalues:
+                raise ValueError('Length of lower_bounds should be one more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self._lower_bounds = np.array(lower_bounds)
 
-        if self.below_curve_upper_bounds is not None and self.below_curve_lower_bounds is not None:
-            size += 1
-            lower_bounds.append(self.below_curve_lower_bounds)
-            upper_bounds.append(self.below_curve_upper_bounds)
+    @classmethod
+    def load(cls, model, data):
+        control_curves = super(ControlCurveParameter, cls)._load_control_curves(model, data)
+        storage_node = super(ControlCurveParameter, cls)._load_storage_node(model, data)
 
-        self.size = size
-        self._lower_bounds = np.array(lower_bounds)
-        self._upper_bounds = np.array(upper_bounds)
+        parameters = None
+        values = None
+        if 'values' in data:
+            values = load_parameter_values(model, data)
+        elif 'parameters' in data:
+            # Load parameters
+            parameters_data = data['parameters']
+            parameters = []
+            for pdata in parameters_data:
+                parameters.append(load_parameter(model, pdata))
+
+        return cls(control_curves, values=values, parameters=parameters, storage_node=storage_node)
 
     def value(self, ts, scenario_index):
         i = scenario_index.global_id
-        control_curve = self.control_curve.value(ts, scenario_index)
         node = self.node if self.storage_node is None else self.storage_node
-        # If level above control curve then return above_curve_cost
-        if node.current_pc[i] >= control_curve:
-            return self.above_curve_value
-        return self.below_curve_value
+
+        # Assumes control_curves is sorted highest to lowest
+        for j, cc_param in enumerate(self.control_curves):
+            cc = cc_param.value(ts, scenario_index)
+            # If level above control curve then return this level's value
+            if node.current_pc[i] >= cc:
+                if self.parameters is not None:
+                    return self.parameters[j].value(ts, scenario_index)
+                else:
+                    return self.values[j]
+
+        if self.parameters is not None:
+            return self.parameters[-1].value(ts, scenario_index)
+        else:
+            return self.values[-1]
 
     def update(self, values):
-        i = 0
-        if self.above_curve_upper_bounds is not None and self.above_curve_lower_bounds is not None:
-            self.above_curve_value = values[i]
-            i += 1
-
-        if self.below_curve_upper_bounds is not None and self.below_curve_lower_bounds is not None:
-            self.below_curve_value = values[i]
-            i += 1
+        self.values = np.array(values)
 
     def lower_bounds(self):
         return self._lower_bounds
@@ -78,4 +141,4 @@ class ControlCurvePiecewiseParameter(BaseControlCurveParameter):
     def upper_bounds(self):
         return self._upper_bounds
 
-parameter_registry.add(ControlCurvePiecewiseParameter)
+parameter_registry.add(ControlCurveParameter)

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -14,20 +14,48 @@ class Parameter(BaseParameter):
     def value(self, ts, scenario_index):
         raise NotImplementedError()
 
-class ParameterCollection(Parameter):
+
+# TODO shared dict with pywr.recorders
+agg_funcs = {
+    "mean": np.mean,
+    "sum": np.sum,
+    "max": np.max,
+    "min": np.min,
+    "product": np.product,
+}
+class AggregatedParameter(Parameter):
     """A collection of Parameters
 
     This object behaves like a set. Licenses can be added to or removed from it.
 
     """
-    def __init__(self, parameters=None):
-        super(ParameterCollection, self).__init__()
+    def __init__(self, parameters=None, agg_func='mean'):
+        super(AggregatedParameter, self).__init__()
         if parameters is None:
             self._parameters = set()
         else:
             self._parameters = set(parameters)
             for param in self._parameters:
                 param.parent = self
+
+        self.agg_func = agg_func
+        if isinstance(self.agg_func, str):
+            self.agg_func = agg_funcs[self.agg_func]
+
+    @classmethod
+    def load(cls, model, data):
+
+        try:
+            parameters_data = data['parameters']
+        except KeyError:
+            parameters_data = []
+
+        parameters = []
+        for pdata in parameters_data:
+            parameters.append(load_parameter(model, pdata))
+
+        agg_func = data.get('agg_func', 'mean')
+        return cls(parameters=parameters, agg_func=agg_func)
 
     def add(self, parameter):
         self._parameters.add(parameter)
@@ -40,8 +68,9 @@ class ParameterCollection(Parameter):
     def __len__(self):
         return len(self._parameters)
 
-    def value(self, timestep, scenario_index):
-        raise NotImplementedError()
+    def value(self, ts, si):
+        values = [p.value(ts, si) for p in self._parameters]
+        return self.agg_func(values)
 
     def setup(self, model):
         for parameter in self._parameters:
@@ -54,25 +83,7 @@ class ParameterCollection(Parameter):
     def reset(self):
         for parameter in self._parameters:
             parameter.reset()
-parameter_registry.add(ParameterCollection)
-
-
-class MinimumParameterCollection(ParameterCollection):
-    def value(self, timestep, scenario_index):
-        min_available = float('inf')
-        for parameter in self._parameters:
-            min_available = min(parameter.value(timestep, scenario_index), min_available)
-        return min_available
-parameter_registry.add(MinimumParameterCollection)
-
-
-class MaximumParameterCollection(ParameterCollection):
-    def value(self, timestep, scenario_index):
-        max_available = -float('inf')
-        for parameter in self._parameters:
-            max_available = max(parameter.value(timestep, scenario_index), max_available)
-        return max_available
-parameter_registry.add(MaximumParameterCollection)
+parameter_registry.add(AggregatedParameter)
 
 
 class ConstantParameter(Parameter):
@@ -95,6 +106,7 @@ class ConstantParameter(Parameter):
     def upper_bounds(self):
         return self._upper_bounds
 parameter_registry.add(ConstantParameter)
+
 
 class FunctionParameter(Parameter):
     def __init__(self, parent, func):
@@ -129,6 +141,27 @@ class MonthlyProfileParameter(Parameter):
     def upper_bounds(self):
         return self._upper_bounds
 parameter_registry.add(MonthlyProfileParameter)
+
+
+class ScaledProfileParameter(Parameter):
+    def __init__(self, scale, profile):
+        super(ScaledProfileParameter, self).__init__()
+        self.scale = scale
+
+        if profile.parent is not None and profile.parent is not self:
+            raise RuntimeError('profile Parameter already has a different parent.')
+            profile.parent = self
+        self.profile = profile
+
+    def value(self, ts, si):
+        p = self.profile.value(ts, si)
+        return self.scale * p
+
+
+
+
+
+
 
 
 class AnnualHarmonicSeriesParameter(Parameter):

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -201,6 +201,7 @@ agg_funcs = {
     "sum": np.sum,
     "max": np.max,
     "min": np.min,
+    "product": np.product,
 }
 class AggregatedRecorder(Recorder):
     """

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -1,6 +1,6 @@
 from pywr.core import Model, Storage, Link, ScenarioIndex
-from pywr.parameters import ConstantParameter
-from pywr.parameters.control_curves import ControlCurvePiecewiseParameter, ControlCurveInterpolatedParameter
+from pywr.parameters import ConstantParameter, load_parameter
+from pywr.parameters.control_curves import ControlCurveParameter, ControlCurveInterpolatedParameter
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -11,55 +11,201 @@ def model(solver):
     return Model(solver=solver)
 
 
-def test_control_curve_piecewise(model):
-    m = model
-    si = ScenarioIndex(0, np.array([0], dtype=np.int32))
-    s = Storage(m, 'Storage', max_volume=100.0)
+class TestPiecewiseControlCurveParameter:
+    """Tests for ControlCurveParameter """
 
-    cc = ConstantParameter(0.8)
-    # Return 10.0 when above 0.0 when below
-    s.cost = ControlCurvePiecewiseParameter(cc, 10.0, 0.0)
-    s.setup(m)
+    @staticmethod
+    def _assert_results(m, s):
+        """ Correct results for the following tests """
+        s.setup(m)  # Init memory view on storage (bypasses usual `Model.setup`)
 
-    s.initial_volume = 90.0
-    m.reset()
-    assert_allclose(s.get_cost(m.timestepper.current, si), 10.0)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        s.initial_volume = 90.0
+        m.reset()
+        assert_allclose(s.get_cost(m.timestepper.current, si), 1.0)
 
-    s.initial_volume = 50.0
-    m.reset()
-    assert_allclose(s.get_cost(m.timestepper.current, si), 0.0)
+        s.initial_volume = 70.0
+        m.reset()
+        assert_allclose(s.get_cost(m.timestepper.current, si), 0.7)
 
-    # Now test if the parameter is used on a non storage node
+        s.initial_volume = 40.0
+        m.reset()
+        assert_allclose(s.get_cost(m.timestepper.current, si), 0.4)
 
-    l = Link(m, 'Link')
-    cc = ConstantParameter(0.8)
-    l.cost = ControlCurvePiecewiseParameter(cc, 10.0, 0.0, storage_node=s)
-    assert_allclose(l.get_cost(m.timestepper.current, si), 0.0)
-    # When storage volume changes, the cost of the link changes.
-    s.initial_volume = 90.0
-    m.reset()
-    assert_allclose(l.get_cost(m.timestepper.current, si), 10.0)
+    def test_with_values(self, model):
+        """Test with `values` keyword argument"""
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        # Return 10.0 when above 0.0 when below
+        s.cost = ControlCurveParameter([0.8, 0.6], [1.0, 0.7, 0.4])
+        self._assert_results(m, s)
+
+    def test_with_parameters(self, model):
+        """ Test with `parameters` keyword argument. """
+        m = model
+
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        # Two different control curves
+        cc = [ConstantParameter(0.8), ConstantParameter(0.6)]
+        # Three different parameters to return
+        params = [
+            ConstantParameter(1.0), ConstantParameter(0.7), ConstantParameter(0.4)
+        ]
+        s.cost = ControlCurveParameter(cc, parameters=params)
+
+        self._assert_results(m, s)
+
+    def test_values_load(self, model):
+        """ Test load of float lists. """
+
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        data = {
+            "type": "controlcurve",
+            "control_curves": [0.8, 0.6],
+            "values": [1.0, 0.7, 0.4]
+        }
+
+        s.cost = p = load_parameter(model, data)
+        assert isinstance(p, ControlCurveParameter)
+        self._assert_results(m, s)
+
+    def test_parameters_load(self, model):
+        """ Test load of parameter lists for 'control_curves' and 'parameters' keys. """
+
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        data = {
+            "type": "controlcurve",
+            "control_curves": [
+                {
+                    "type": "constant",
+                    "values": 0.8
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [0.6]*12
+                }
+            ],
+            "parameters": [
+                {
+                    "type": "constant",
+                    "values": 1.0,
+                },
+                {
+                    "type": "constant",
+                    "values": 0.7
+                },
+                {
+                    "type": "constant",
+                    "values": 0.4
+                }
+            ]
+        }
+
+        s.cost = p = load_parameter(model, data)
+        assert isinstance(p, ControlCurveParameter)
+        self._assert_results(m, s)
+
+    def test_single_cc_load(self, model):
+        """ Test load from dict with 'control_curve' key
+
+        This is different to the above test by using singular 'control_curve' key in the dict
+        """
+
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        data = {
+            "type": "controlcurve",
+            "control_curve": 0.8,
+        }
+
+        s.cost = p = load_parameter(model, data)
+        assert isinstance(p, ControlCurveParameter)
+
+        s.setup(m)  # Init memory view on storage (bypasses usual `Model.setup`)
+
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        s.initial_volume = 90.0
+        m.reset()
+        assert_allclose(s.get_cost(m.timestepper.current, si), 0)
+
+        s.initial_volume = 70.0
+        m.reset()
+        assert_allclose(s.get_cost(m.timestepper.current, si), 1)
+
+    def test_with_nonstorage(self, model):
+        """ Test usage on non-`Storage` node. """
+        # Now test if the parameter is used on a non storage node
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+
+        l = Link(m, 'Link')
+        cc = ConstantParameter(0.8)
+        l.cost = ControlCurveParameter(cc, [10.0, 0.0], storage_node=s)
+
+        s.setup(m)  # Init memory view on storage (bypasses usual `Model.setup`)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        assert_allclose(l.get_cost(m.timestepper.current, si), 0.0)
+        # When storage volume changes, the cost of the link changes.
+        s.initial_volume = 90.0
+        m.reset()
+        assert_allclose(l.get_cost(m.timestepper.current, si), 10.0)
+
+    def test_with_nonstorage_load(self, model):
+        """ Test load from dict with 'storage_node' key. """
+        m = model
+        s = Storage(m, 'Storage', max_volume=100.0)
+        l = Link(m, 'Link')
+
+        data = {
+            "type": "controlcurve",
+            "control_curve": 0.8,
+            "values": [10.0, 0.0],
+            "storage_node": "Storage"
+        }
+
+        l.cost = p = load_parameter(model, data)
+        assert isinstance(p, ControlCurveParameter)
+
+        s.setup(m)  # Init memory view on storage (bypasses usual `Model.setup`)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        assert_allclose(l.get_cost(m.timestepper.current, si), 0.0)
+        # When storage volume changes, the cost of the link changes.
+        s.initial_volume = 90.0
+        m.reset()
+        assert_allclose(l.get_cost(m.timestepper.current, si), 10.0)
 
 
 def test_control_curve_interpolated(model):
     m = model
     si = ScenarioIndex(0, np.array([0], dtype=np.int32))
 
-
     s = Storage(m, 'Storage', max_volume=100.0)
 
     cc = ConstantParameter(0.8)
-    values = [0.0, 5.0, 20.0]
+    values = [20.0, 5.0, 0.0]
     s.cost = ControlCurveInterpolatedParameter(cc, values)
     s.setup(m)
 
     for v in (0.0, 10.0, 50.0, 80.0, 90.0, 100.0):
         s.initial_volume = v
         s.reset()
-        assert_allclose(s.get_cost(m.timestepper.current, si), np.interp(v/100.0, [0.0, 0.8, 1.0], values))
+        assert_allclose(s.get_cost(m.timestepper.current, si), np.interp(v/100.0, [0.0, 0.8, 1.0], values[::-1]))
 
     # special case when control curve is 100%
     cc._value = 1.0
     s.initial_volume == 100.0
     s.reset()
     assert_allclose(s.get_cost(m.timestepper.current, si), values[1])
+
+    # special case when control curve is 0%
+    cc._value = 0.0
+    s.initial_volume == 0.0
+    s.reset()
+    assert_allclose(s.get_cost(m.timestepper.current, si), values[0])

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -4,7 +4,7 @@ Test for individual Parameter classes
 from pywr.core import Model, Timestep, Scenario, ScenarioIndex
 from pywr.parameters import BaseParameter, ArrayIndexedParameter, ConstantScenarioParameter, \
     ArrayIndexedScenarioMonthlyFactorsParameter, MonthlyProfileParameter, DailyProfileParameter, \
-    MinimumParameterCollection, MaximumParameterCollection
+    AggregatedParameter, load_parameter
 
 import datetime
 import numpy as np
@@ -113,43 +113,73 @@ def test_parameter_daily_profile(model):
         np.testing.assert_allclose(p.value(ts, si), values[iday])
 
 
-def test_parameter_min(model):
-    # Add two scenarios
-    scA = Scenario(model, 'Scenario A', size=2)
-    scB = Scenario(model, 'Scenario B', size=5)
+class TestAggregatedParameter:
+    """ Tests for AggregatedParameter"""
 
-    values = np.arange(366, dtype=np.float64)
-    p1 = DailyProfileParameter(values)
-    p2 = ConstantScenarioParameter(scB, np.arange(scB.size, dtype=np.float64))
+    def test_min(self, model):
+        # Add two scenarios
+        scA = Scenario(model, 'Scenario A', size=2)
+        scB = Scenario(model, 'Scenario B', size=5)
 
-    p = MinimumParameterCollection([p1, ])
-    p.add(p2)
+        values = np.arange(366, dtype=np.float64)
+        p1 = DailyProfileParameter(values)
+        p2 = ConstantScenarioParameter(scB, np.arange(scB.size, dtype=np.float64))
 
-    p.setup(model)
-    for ts in model.timestepper:
-        iday = ts.datetime.dayofyear - 1
-        for i in range(scB.size):
-            si = ScenarioIndex(i, np.array([0, i], dtype=np.int32))
-            np.testing.assert_allclose(p.value(ts, si), min(values[iday], i))
+        p = AggregatedParameter([p1, ], agg_func='min')
+        p.add(p2)
 
+        p.setup(model)
+        for ts in model.timestepper:
+            iday = ts.datetime.dayofyear - 1
+            for i in range(scB.size):
+                si = ScenarioIndex(i, np.array([0, i], dtype=np.int32))
+                np.testing.assert_allclose(p.value(ts, si), min(values[iday], i))
 
-def test_parameter_max(model):
-    # Add two scenarios
-    scA = Scenario(model, 'Scenario A', size=2)
-    scB = Scenario(model, 'Scenario B', size=5)
+    def test_max(self, model):
+        # Add two scenarios
+        scA = Scenario(model, 'Scenario A', size=2)
+        scB = Scenario(model, 'Scenario B', size=5)
 
-    values = np.arange(366, dtype=np.float64)
-    p1 = DailyProfileParameter(values)
-    p2 = ConstantScenarioParameter(scB, np.arange(scB.size, dtype=np.float64))
+        values = np.arange(366, dtype=np.float64)
+        p1 = DailyProfileParameter(values)
+        p2 = ConstantScenarioParameter(scB, np.arange(scB.size, dtype=np.float64))
 
-    p = MaximumParameterCollection([p1, p2])
-    p.setup(model)
+        p = AggregatedParameter([p1, p2], agg_func='max')
+        p.setup(model)
 
-    for ts in model.timestepper:
-        iday = ts.datetime.dayofyear - 1
-        for i in range(scB.size):
-            si = ScenarioIndex(i, np.array([0, i], dtype=np.int32))
-            np.testing.assert_allclose(p.value(ts, si), max(values[iday], i))
+        for ts in model.timestepper:
+            iday = ts.datetime.dayofyear - 1
+            for i in range(scB.size):
+                si = ScenarioIndex(i, np.array([0, i], dtype=np.int32))
+                np.testing.assert_allclose(p.value(ts, si), max(values[iday], i))
+
+    def test_load(self, model):
+        """ Test load from JSON dict"""
+        data = {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                {
+                    "type": "constant",
+                    "values": 0.8
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": list(range(12))
+                }
+            ]
+        }
+
+        p = load_parameter(model, data)
+        # Correct instance is loaded
+        assert isinstance(p, AggregatedParameter)
+
+        # Test correct aggregation is performed
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        for mth in range(1, 13):
+            ts = Timestep(datetime.datetime(2016, mth, 1), 366, 1.0)
+            np.testing.assert_allclose(p.value(ts, si), (mth-1)*0.8)
+
 
 
 def test_parameter_child_variables():
@@ -201,3 +231,27 @@ def test_parameter_child_variables():
     assert c1 not in c1.variables
     assert c2 in c1.variables
     assert len(c1.variables) == 1
+
+
+def test_with_a_better_name():
+
+    data = {
+        'type': 'scaledprofile',
+        'scale': 50.0,
+        'profile': {
+            'type': 'aggregated',
+            'agg_func': 'product',
+            'parameters': [
+                {
+                    'type': 'monthlyprofile',
+                    'values': [1.0]*12
+                },
+                {
+                    'type': 'controlcurvemonthlyprofile',
+                    'control_curve': [0.8, 0.6],
+                    'values': [[1.05]*12,
+                               [1.1]*12]
+                }
+            ]
+        }
+    }

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -124,11 +124,11 @@ def test_control_curve(solver):
     assert(reservoir.volume == 8)
     assert(demand.flow == 6)
     # Set the above_curve_cost function to keep filling
-    from pywr.parameters.control_curves import ControlCurvePiecewiseParameter
+    from pywr.parameters.control_curves import ControlCurveParameter
     # We know what we're doing with the control_curve Parameter so unset its parent before overriding
     # the cost parameter.
     control_curve.parent = None
-    reservoir.cost = ControlCurvePiecewiseParameter(control_curve, -20.0, -20.0)
+    reservoir.cost = ControlCurveParameter(control_curve, [-20.0, -20.0])
     model.step()
     assert(reservoir.volume == 10)
     assert(demand.flow == 6)


### PR DESCRIPTION
The following is included here:
- Allow `BaseControlCurveParameter` to accept multiple control curves
- Initialisation of control curves from floats, ints or `Parameter` objects
- Private classmethods `_load_control_curves` and `_load_storage_node` to load their respective items from a dict of data - intended for JSON support.
- Refactored `ControlCurvePiecewiseParameter` to `ControlCurveParameter`.
  - This is now the basic generic control curve class.
  - It supports returning either values from an array or values from other `Parameters`.
  - Can be loaded from a dict.
  - Test of this are included.
- Refactored `ParameterCollection` to `AggregatedParameter`
  - Similar approach `AggregatedRecorder`.
  - No separate subclasses. Instead the user specifies the `agg_func` to use.
  - Includes dict loading.

I think this fixes 143. Though it probably needs an example of how to do that.