### PR TITLE
Added CachedParameter and fixed bug when loading shared params.

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -382,6 +382,10 @@ class Model(object):
             parameters_to_load = data["parameters"]
         except KeyError:
             parameters_to_load = {}
+        else:
+            for key, value in parameters_to_load.items():
+                if isinstance(value, dict):
+                    parameters_to_load[key]["name"] = key
         model._parameters_to_load = parameters_to_load
 
         # load the remaining nodes

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -21,6 +21,7 @@ cdef class Parameter:
     cpdef update(self, double[:] values)
     cpdef double[:] lower_bounds(self)
     cpdef double[:] upper_bounds(self)
+    cdef public str name
 
 cdef class ArrayIndexedParameter(Parameter):
     cdef double[:] values
@@ -45,8 +46,18 @@ cdef class DailyProfileParameter(Parameter):
     cdef double[:] _values
 
 cdef class IndexParameter(Parameter):
-    cpdef int index(elf, Timestep timestep, ScenarioIndex scenario_index) except? -1
+    cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
 
 cdef class IndexedArrayParameter(Parameter):
     cdef public Parameter index_parameter
     cdef public list params
+
+cdef class CachedParameter(IndexParameter):
+    cdef public Parameter parameter
+    cdef Timestep timestep
+    cdef ScenarioIndex scenario_index
+    cdef double cached_value
+    cdef int cached_index
+    cpdef reset(self)
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
+    cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -61,3 +61,6 @@ cdef class CachedParameter(IndexParameter):
     cpdef reset(self)
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
+
+cdef class CachedTimeParameter(CachedParameter):
+    pass

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -6,7 +6,8 @@ from ._parameters import (
     ArrayIndexedParameter, ConstantScenarioParameter,
     ArrayIndexedScenarioMonthlyFactorsParameter,
     DailyProfileParameter, ArrayIndexedScenarioParameter,
-    IndexParameter, CachedParameter,
+    IndexParameter,
+    CachedParameter, CachedTimeParameter,
     load_parameter, load_parameter_values, load_dataframe)
 import numpy as np
 import pandas

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -6,6 +6,7 @@ from ._parameters import (
     ArrayIndexedParameter, ConstantScenarioParameter,
     ArrayIndexedScenarioMonthlyFactorsParameter,
     DailyProfileParameter, ArrayIndexedScenarioParameter,
+    IndexParameter, CachedParameter,
     load_parameter, load_parameter_values, load_dataframe)
 import numpy as np
 import pandas

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,10 +1,11 @@
 """
 Test for individual Parameter classes
 """
-from pywr.core import Model, Timestep, Scenario, ScenarioIndex, Storage, Link
+from pywr.core import Model, Timestep, Scenario, ScenarioIndex, Storage, Link, Input, Output
 from pywr.parameters import (BaseParameter, ArrayIndexedParameter, ConstantScenarioParameter,
     ArrayIndexedScenarioMonthlyFactorsParameter, MonthlyProfileParameter, DailyProfileParameter,
-    DataFrameParameter, AggregatedParameter, load_parameter)
+    DataFrameParameter, AggregatedParameter, ConstantParameter, CachedParameter,
+    FunctionParameter, load_parameter)
 
 from helpers import load_model
 
@@ -13,6 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import itertools
+from numpy.testing import assert_allclose
 
 @pytest.fixture
 def model(solver):
@@ -414,6 +416,58 @@ def test_parameter_df_json_load(model, tmpdir):
     p = load_parameter(model, data)
     p.setup(model)
 
+def test_cached_parameter(model):
+    """
+    Test cached parameters are loaded correctly and do not affect the
+    result of the model. Also tests the cache is useful by reducing the
+    number of function calls to shared parameters.
+    """
+    inpt = Input(model, "Input")
+    otpt = Output(model, "Output", max_flow=20, cost=-1000)
+    inpt.connect(otpt)
+
+    model.timestepper.start = pd.to_datetime("2016-01-01")
+    model.timestepper.end = pd.to_datetime("2016-01-01")
+
+    data = {
+        "cached": True,
+        "type": "constant",
+        "values": 15.0
+    }
+
+    inpt.max_flow = load_parameter(model, data)
+    assert(isinstance(inpt.max_flow, CachedParameter))
+    assert(isinstance(inpt.max_flow.parameter, ConstantParameter))
+
+    model.run()
+    assert_allclose(inpt.flow, 15)
+
+    # create a parameter that tracks how many times it is called
+    def func(parent, ts, si):
+        func.count += 1
+        return 10.0
+    func.count = 0
+    parameter = FunctionParameter(inpt, func)
+
+    inpt.max_flow = parameter
+    otpt.max_flow = parameter
+
+    model.run()
+
+    # parameter is used by two nodes so called twice
+    assert(func.count == 2)
+    func.count = 0
+
+    # cache the parameter
+    cached_parameter = CachedParameter(parameter)
+    inpt.max_flow = cached_parameter
+    otpt.max_flow = cached_parameter
+
+    model.run()
+    assert_allclose(inpt.flow, 10)
+
+    # parameter is now cached, so only called once
+    assert(func.count == 1)
 
 def test_simple_json_parameter_reference(solver):
     model = load_model("parameter_reference.json")

--- a/tests/test_parameters_cache.py
+++ b/tests/test_parameters_cache.py
@@ -1,0 +1,113 @@
+from pywr.core import Model, Input, Output, Link, Scenario
+from pywr.parameters import (CachedParameter, CachedTimeParameter,
+    load_parameter, ConstantParameter, FunctionParameter)
+from pywr.parameters._parameters import Parameter as BaseParameter
+import pytest
+from numpy.testing import assert_allclose
+import pandas
+
+@pytest.fixture
+def model(solver):
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime("2016-01-01"),
+        end=pandas.to_datetime("2016-01-10"),
+    )
+    return model
+
+@pytest.fixture
+def simple_model(model):
+    inpt = Input(model, "input")
+    otpt = Output(model, "output", max_flow=20, cost=-1000)
+    inpt.connect(otpt)
+    return model
+
+def create_function(data, model=None):
+    def func(self, timestep, scenario_index):
+        func.count += 1
+        if isinstance(data, BaseParameter):
+            value = data.value(timestep, scenario_index)
+        else:
+            value = data
+        return value
+    func.count = 0
+    return func
+
+def test_cache_both(simple_model):
+    """
+    Example of caching when it isn't needed - the function is only called
+    once per timestep anyway
+    """
+    model = simple_model
+    func = create_function(15.0)
+    param = FunctionParameter(None, func)
+
+    inpt = model.nodes["input"]
+    inpt.max_flow = CachedParameter(param)
+
+    model.run()
+    assert_allclose(inpt.flow, 15.0)
+
+    assert(func.count == 10)
+
+def test_load_cache_both(simple_model):
+    """
+    As previous, but loading the parameter using `load_parameter`
+    """
+    model = simple_model
+
+    data = {
+        "cached": "both",
+        "type": "constant",
+        "values": 15.0
+    }
+
+    inpt = model.nodes["input"]
+    inpt.max_flow = load_parameter(model, data)
+    assert(inpt.max_flow.__class__ is CachedParameter)
+    assert(isinstance(inpt.max_flow.parameter, ConstantParameter))
+
+    model.run()
+    assert_allclose(inpt.flow, 15)
+
+def test_cache_both_shared(simple_model):
+    """
+    When a cached parameter is shared between nodes it should only be
+    called once per timestep
+    """
+    model = simple_model
+    func = create_function(15.0)
+    param = FunctionParameter(None, func)
+
+    inpt = model.nodes["input"]
+    otpt = model.nodes["output"]
+    inpt.max_flow = param
+    otpt.max_flow = param
+
+    model.run()
+    assert_allclose(inpt.flow, 15.0)
+
+    # inefficient - parameter is called twice per timestep
+    assert(func.count == 20)
+
+    func2 = create_function(25.0)
+    param = FunctionParameter(None, func2)
+    cached = CachedParameter(param)
+
+    inpt.max_flow = cached
+    otpt.max_flow = cached
+
+    model.run()
+    assert_allclose(inpt.flow, 25.0)
+
+    # parameter is only called once per timestep
+    assert(func2.count == 10)
+
+def test_unknown_cache_type(model):
+    data = {
+        "cached": "fail",
+        "type": "constant",
+        "values": 42.0
+    }
+    with pytest.raises(ValueError):
+        parameter = load_parameter(model, data)


### PR DESCRIPTION
This PR addresses #122. Parameters can now be cached easily using the `CachedParameter` class. In JSON this can be written as:

```
{
    "cached": true,
    "type": ...
    "values": ...
}
```

The cache is refreshed if the timestep or scenario index is changed. A future change might be to create a subclass which only refreshes if the timestep changes, for parameters that are time-varying but constant between scenarios and expensive to calculate, e.g. a catchmod boundary condition.

As a benchmark, caching the demand saving level in the London model resulted in a speed increase of 10%.

The PR also fixes an issue with the revised loading of parameters of JSON, whereby parameters that were used more than once were loaded multiple times.