### PR TITLE
Color D3 graph using CSS

### DIFF
--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -77,11 +77,12 @@ def draw_graph(model, width=500, height=400, css=None):
         css = draw_graph_css
 
     js = Javascript(
-        draw_graph_template.render(
+        data=draw_graph_template.render(
             graph=graph,
             width=width,
             height=height,
             css=css.replace("\n","")
         ),
+        lib="http://d3js.org/d3.v3.min.js",
     )
     display(js)

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -1,6 +1,7 @@
 import os
-from IPython.core.display import Javascript, display
+from IPython.core.display import HTML, Javascript, display
 from jinja2 import Template
+from pywr.core import Node
 
 from pywr.core import Model, Input, Output, Link, Storage, StorageInput, StorageOutput
 
@@ -8,6 +9,8 @@ from pywr.core import Model, Input, Output, Link, Storage, StorageInput, Storage
 folder = os.path.dirname(__file__)
 with open(os.path.join(folder, "draw_graph.js"), "r") as f:
     draw_graph_template = Template(f.read())
+with open(os.path.join(folder, "graph.css"), "r") as f:
+    draw_graph_css = f.read()
 
 def nx_to_json(model):
     """Convert a Pywr graph to a structure d3 can display"""
@@ -19,13 +22,13 @@ def nx_to_json(model):
     edges = []
     for edge in model.graph.edges():
         node_source, node_target = edge
-        
+
         # where a link is to/from a subnode, display a link to the parent instead
         if node_source.parent is not None:
             node_source = node_source.parent
         if node_target.parent is not None:
             node_target = node_target.parent
-        
+
         if node_source is node_target:
             # link is between two subnodes
             continue
@@ -34,26 +37,49 @@ def nx_to_json(model):
         index_target = nodes.index(node_target.name)
         edges.append({'source': index_source, 'target': index_target})
 
+    json_nodes = []
+    for n, name in enumerate(nodes):
+        node = {"name": name}
+        classes = []
+        cls = model.node[name].__class__
+        classes.append(cls)
+        while True:
+            for base in cls.__bases__:
+                if issubclass(base, Node) and base is not Node:
+                    classes.append(base)
+            if classes[-1] is cls:
+                break
+            else:
+                cls = classes[-1]
+        classes = classes[::-1]
+        node["clss"] = [cls.__name__.lower() for cls in classes]
+        json_nodes.append(node)
+
     graph = {
-        "nodes": [
-            {
-                "name": name,
-                "color": model.node[name].color,
-            } for n, name in enumerate(nodes)
-        ],
+        "nodes": json_nodes,
         "links": edges}
-    
+
     return graph
 
-def draw_graph(model):
+def draw_graph(model, css=None):
     """Display a Pywr model using D3 in Jupyter
-    
+
     Parameters
     ----------
     model : pywr.core.Model
         The model to display
+    css : string
+        Stylesheet data to use instead of default
     """
     graph = nx_to_json(model)
-    data = draw_graph_template.render(graph=graph)
-    js = Javascript(data=data, lib="http://d3js.org/d3.v3.min.js")
+
+    if css is None:
+        css = draw_graph_css
+
+    js = Javascript(
+        draw_graph_template.render(
+            graph=graph,
+            css=css.replace("\n","")
+        ),
+    )
     display(js)

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -61,7 +61,7 @@ def nx_to_json(model):
 
     return graph
 
-def draw_graph(model, css=None):
+def draw_graph(model, width=500, height=400, css=None):
     """Display a Pywr model using D3 in Jupyter
 
     Parameters
@@ -79,6 +79,8 @@ def draw_graph(model, css=None):
     js = Javascript(
         draw_graph_template.render(
             graph=graph,
+            width=width,
+            height=height,
             css=css.replace("\n","")
         ),
     )

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -5,8 +5,8 @@ style.html("{{ css }}");
 
 var div = d3.selectAll(element).append("div");
 
-var width = 500,
-    height = 400;
+var width = {{ width }},
+    height = {{ height }};
 
 var color = d3.scale.category20();
 

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -1,5 +1,8 @@
 var graph = {{ graph }};
 
+var style = d3.selectAll(element).append("style");
+style.html("{{ css }}");
+
 var div = d3.selectAll(element).append("div");
 
 var width = 500,
@@ -49,9 +52,13 @@ var node = svg.selectAll(".node")
 .enter().append("circle")
   .attr("class", "node")
   .attr("r", node_size)
-  .style("fill", function(d) { return d.color; })
-  .style("stroke", "#333")
-  .style("stoke-width", 0.5)
+  .attr("class", function(d) {
+      var clss = "node";
+      for (var i=0; i < d.clss.length; i++) {
+          clss += " node-"+d.clss[i];
+      };
+      return clss;
+  })
   .call(force.drag);
 
 node.append("title")

--- a/pywr/notebook/graph.css
+++ b/pywr/notebook/graph.css
@@ -1,0 +1,17 @@
+.node {
+    stroke-width: 1.5px;
+    stroke: #333;
+    fill: grey;
+}
+.node-input {
+    fill: dodgerblue;
+}
+.node-link {
+    fill: grey;
+}
+.node-output {
+    fill: gold;
+}
+.node-reservoir {
+    fill: firebrick;
+}

--- a/pywr/notebook/graph.css
+++ b/pywr/notebook/graph.css
@@ -12,6 +12,9 @@
 .node-output {
     fill: gold;
 }
+.node-storage {
+    fill: firebrick;
+}
 .node-reservoir {
     fill: firebrick;
 }

--- a/pywr/notebook/graph.css
+++ b/pywr/notebook/graph.css
@@ -3,6 +3,10 @@
     stroke: #333;
     fill: grey;
 }
+.node:hover {
+    stroke-width: 2.5px;
+    stroke: #222;
+}
 .node-input {
     fill: dodgerblue;
 }


### PR DESCRIPTION
This PR uses CSS to style the D3 graph in Jupyter. It has some default styles, but you can provide your own using the `css` keyword argument to `draw_graph`.

Fixes #150 and #151.