### PR TITLE
Added schematic and geographic position attributes to Node

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -750,12 +750,7 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
             A unique name for the node
         """
 
-        schematic_position = kwargs.pop("schematic_position", None)
-        geographic_position = kwargs.pop("geographic_position", None)
-        if schematic_position is not None:
-            schematic_position = tuple(schematic_position)
-        if geographic_position is not None:
-            geographic_position = tuple(geographic_position)
+        position = kwargs.pop("position", {})
 
         color = kwargs.pop('color', 'black')
         min_flow = pop_kwarg_parameter(kwargs, 'min_flow', 0.0)
@@ -773,8 +768,7 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
         self.max_flow = max_flow
         self.cost = cost
         self.conversion_factor = conversion_factor
-        self.schematic_position = schematic_position
-        self.geographic_position = geographic_position
+        self.position = position
 
     def check(self):
         """Check the node is valid
@@ -791,13 +785,8 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
         min_flow = data.pop('min_flow', None)
         max_flow = data.pop('max_flow', None)
 
-        schematic_position = data.pop("schematic_position", None)
-        geographic_position = data.pop("geographic_position", None)
-
         data.pop('type')
         node = cls(model=model, name=name,
-                   schematic_position=schematic_position,
-                   geographic_position=geographic_position,
                    **data)
 
         cost = load_parameter(model, cost)
@@ -944,12 +933,7 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, _core.Storage)):
             initial_volume = kwargs.pop('initial_volume', 0.0)
         cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
 
-        x = kwargs.pop('x', None)
-        y = kwargs.pop('y', None)
-        if x is not None and y is not None:
-            position = (float(x), float(y),)
-        else:
-            position = None
+        position = kwargs.pop("position", {})
 
         super(Storage, self).__init__(model, name, **kwargs)
 
@@ -1029,17 +1013,11 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, _core.Storage)):
         if min_volume is not None:
             min_volume = float(min_volume)
         cost = data.pop('cost', 0.0)
-        try:
-            x = float(data.pop('x'))
-            y = float(data.pop('y'))
-        except KeyError:
-            x = None
-            y = None
         data.pop('type', None)
         node = cls(
             model=model, name=name, num_inputs=num_inputs,
             num_outputs=num_outputs, initial_volume=initial_volume,
-            max_volume=max_volume, min_volume=min_volume, x=x, y=y,
+            max_volume=max_volume, min_volume=min_volume,
             **data
         )
 

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -750,12 +750,12 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
             A unique name for the node
         """
 
-        x = kwargs.pop('x', None)
-        y = kwargs.pop('y', None)
-        if x is not None and y is not None:
-            position = (float(x), float(y),)
-        else:
-            position = None
+        schematic_position = kwargs.pop("schematic_position", None)
+        geographic_position = kwargs.pop("geographic_position", None)
+        if schematic_position is not None:
+            schematic_position = tuple(schematic_position)
+        if geographic_position is not None:
+            geographic_position = tuple(geographic_position)
 
         color = kwargs.pop('color', 'black')
         min_flow = pop_kwarg_parameter(kwargs, 'min_flow', 0.0)
@@ -773,7 +773,8 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
         self.max_flow = max_flow
         self.cost = cost
         self.conversion_factor = conversion_factor
-        self.position = position
+        self.schematic_position = schematic_position
+        self.geographic_position = geographic_position
 
     def check(self):
         """Check the node is valid
@@ -790,21 +791,15 @@ class Node(with_metaclass(NodeMeta, Drawable, Connectable, BaseNode)):
         min_flow = data.pop('min_flow', None)
         max_flow = data.pop('max_flow', None)
 
-        try:
-            x = float(data.pop('x'))
-            y = float(data.pop('y'))
-        except KeyError:
-            try:
-                position = data.pop('position')
-                x, y = position
-                x = float(x)
-                y = float(y)
-            except KeyError:
-                x = None
-                y = None
+        schematic_position = data.pop("schematic_position", None)
+        geographic_position = data.pop("geographic_position", None)
+
         data.pop('type')
-        node = cls(model=model, name=name, x=x, y=y, **data)
-        
+        node = cls(model=model, name=name,
+                   schematic_position=schematic_position,
+                   geographic_position=geographic_position,
+                   **data)
+
         cost = load_parameter(model, cost)
         min_flow = load_parameter(model, min_flow)
         max_flow = load_parameter(model, max_flow)
@@ -1047,7 +1042,7 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, _core.Storage)):
             max_volume=max_volume, min_volume=min_volume, x=x, y=y,
             **data
         )
-        
+
         cost = load_parameter(model, cost)
         if cost is None:
             cost = 0.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,23 +139,52 @@ def test_slots_connect_disconnect(solver):
 def test_node_position(solver):
     model = Model(solver=solver)
 
-    node1 = Input(model, "input", schematic_position=(10, 20), geographic_position=(-1, 52))
+    # node position, from kwargs
+
+    node1 = Input(model, "input", position={"schematic": (10, 20), "geographic": (-1, 52)})
+
+    # node position, from JSON
 
     data = {
         "name": "output",
         "type": "output",
-        "schematic_position": [30, 40],
-        "geographic_position": [-1.5, 52.2],
+        "position": {
+            "schematic": (30, 40),
+            "geographic": (-1.5, 52.2),
+        }
     }
     node2 = Node.load(data, model)
 
-    assert(node1.schematic_position == (10, 20))
-    assert(node1.geographic_position == (-1, 52))
-    assert(node2.schematic_position == (30, 40))
-    assert(node2.geographic_position == (-1.5, 52.2))
+    assert(node1.position["schematic"] == (10, 20))
+    assert(node1.position["geographic"] == (-1, 52))
+    assert(node2.position["schematic"] == (30, 40))
+    assert(node2.position["geographic"] == (-1.5, 52.2))
 
-    node1.schematic_position = (50, 60)
-    assert(node1.schematic_position == (50, 60))
+    node1.position["schematic"] = (50, 60)
+    assert(node1.position["schematic"] == (50, 60))
+
+    # node without position
+
+    node3 = Node(model, "node3")
+    assert(node3.position == {})
+
+    # reservoir position, from JSON
+
+    data = {
+        "name": "reservoir",
+        "type": "storage",
+        "position": {
+            "schematic": (99, 70),
+            "geographic": (-2.5, 55.6),
+        },
+        "max_volume": 1000,
+        "initial_volume": 500
+    }
+
+    storage = Storage.load(data, model)
+
+    assert(storage.position["schematic"] == (99, 70))
+    assert(storage.position["geographic"] == (-2.5, 55.6))
 
 # TODO Update this test. RiverSplit is deprecated.
 @pytest.mark.xfail

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,6 +136,27 @@ def test_slots_connect_disconnect(solver):
         supply1.disconnect(storage)
 
 
+def test_node_position(solver):
+    model = Model(solver=solver)
+
+    node1 = Input(model, "input", schematic_position=(10, 20), geographic_position=(-1, 52))
+
+    data = {
+        "name": "output",
+        "type": "output",
+        "schematic_position": [30, 40],
+        "geographic_position": [-1.5, 52.2],
+    }
+    node2 = Node.load(data, model)
+
+    assert(node1.schematic_position == (10, 20))
+    assert(node1.geographic_position == (-1, 52))
+    assert(node2.schematic_position == (30, 40))
+    assert(node2.geographic_position == (-1.5, 52.2))
+
+    node1.schematic_position = (50, 60)
+    assert(node1.schematic_position == (50, 60))
+
 # TODO Update this test. RiverSplit is deprecated.
 @pytest.mark.xfail
 def test_slots_from(solver):


### PR DESCRIPTION
This commit implements the schematic and geographic position attributes discussed in #154.

Note that it's still valid for these properties to be `None` (or `null` in JSON). I don't want to enforce providing them as it's unnecessary for simple models.