### PR TITLE
Speedup for GLPK solver

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -36,6 +36,7 @@ cdef class AbstractNode:
     cdef object _model
     cdef object _name
     cdef bint _allow_isolated
+    cdef public object __data
 
     cdef Parameter _cost_param
 


### PR DESCRIPTION
This PR includes a few speedups in the GLPK solver. Changes include:

- When calculating the cost of a route, all of the node costs are calculated and cached in advance.
- Added a placeholder on `AbstractNode` to store solver-specific data.
- Where feasible moved to `cvarray` instead of `list`.

I suspect additional speedups might be possible if we manage to translate the `routes` list into something more C-ish. However this is not especially easy as it's a list of list of Nodes, with heterogenous length.

This was benchmarked using a model with 143 nodes and 239 routes (the most complex to date!). The changes result in a 2x increase in speed!