### PR TITLE
Timestepper arguments are less fussy about the type passed.

### DIFF
--- a/examples/simple_model.py
+++ b/examples/simple_model.py
@@ -1,30 +1,31 @@
 #!/bin/python
 """
 This script sets up and runs the most simple model possible.
+
+  A -->-- B -->-- C
+
 """
-import pywr.core
-import pandas
+from pywr.core import Model, Input, Link, Output
 
-def make_model(solver='glpk'):
-    """
-    Make a simple model with a single Input and Output.
+def create_model():
+    # create a model
+    model = Model(start="2016-01-01", end="2019-12-31", timestep=7)
 
-    Input -> Link -> Output
+    # create three nodes (an input, a link, and an output)
+    A = Input(model, name="A", max_flow=10.0)
+    B = Link(model, name="B", cost=1.0)
+    C = Output(model, name="C", max_flow=5.0, cost=-2.0)
 
-    """
-    model = pywr.core.Model(solver=solver, parameters={
-            'timestamp_start': pandas.to_datetime('2015-01-01'),
-            'timestamp_finish': pandas.to_datetime('2115-12-31')
-    })
-    inpt = pywr.core.Input(model, name="Input", max_flow=10.0)
-    lnk = pywr.core.Link(model, name="Link", cost=1.0)
-    inpt.connect(lnk)
-    otpt = pywr.core.Output(model, name="Output", max_flow=5.0, cost=-2.0)
-    lnk.connect(otpt)
+    # connect nodes
+    A.connect(B)
+    B.connect(C)
 
     return model
 
-
 if __name__ == '__main__':
-    model = make_model()
+    model = create_model()
+    model.check()
     model.run()
+
+    # check result was as expected
+    assert(abs(model.nodes["A"].flow[0] - 5.0) < 0.000001)

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -25,12 +25,13 @@ warnings.simplefilter(action = "ignore", category = UnicodeWarning)
 
 
 class Timestepper(object):
-    def __init__(self, start=pandas.to_datetime('2015-01-01'),
-                       end=pandas.to_datetime('2015-12-31'),
-                       delta=datetime.timedelta(1)):
-        self.start = start
-        self.end = end
-        self.delta = delta
+    def __init__(self, start="2015-01-01", end="2015-12-31", delta=1):
+        self.start = pandas.to_datetime(start)
+        self.end = pandas.to_datetime(end)
+        try:
+            self.delta = pandas.Timedelta(days=delta)
+        except TypeError:
+            self.delta = pandas.to_timedelta(delta)
         self._last_length = None
         self.reset()
 
@@ -237,11 +238,9 @@ class Model(object):
         solver_name = kwargs.pop('solver', None)
 
         # time arguments
-        start = self.start = kwargs.pop('start', pandas.to_datetime('2015-01-01'))
-        end = self.end = kwargs.pop('end', pandas.to_datetime('2015-12-31'))
-        timestep = self.timestep = kwargs.pop('timestep', 1)
-        if not isinstance(timestep, datetime.timedelta):
-            timestep = datetime.timedelta(timestep)
+        start = kwargs.pop("start", "2015-01-01")
+        end = kwargs.pop("end", "2015-12-31")
+        timestep = kwargs.pop("timestep", 1)
         self.timestepper = Timestepper(start, end, timestep)
 
         self.data = {}
@@ -608,7 +607,7 @@ class Model(object):
                 return timestep
             elif until_date and timestep.datetime > until_date:
                 return timestep
-            elif timestep.datetime > self.end:
+            elif timestep.datetime > self.timestepper.end:
                 return timestep
         self.finish()
         try:


### PR DESCRIPTION
This PR tweaks the keyword arguments to timestepper (and model) to be a little more intuitive. You can now pass a datetime object or a datetime-like string to `Model` and it will do the right thing.

This partly addresses #177 in that it fixes `simple_model.py`. It doesn't run as part of the CI however. This change benefits from the change to timestepper arguments.