### PR TITLE
Add ParameterRecorder and IndexParameterRecorder.

### DIFF
--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -39,3 +39,10 @@ cdef class NumpyArrayParameterRecorder(ParameterRecorder):
 
 cdef class NumpyArrayIndexParameterRecorder(IndexParameterRecorder):
     cdef int[:, :] _data
+
+cdef class MeanParameterRecorder(ParameterRecorder):
+    cdef public int timesteps
+    cdef int position
+    cdef double[:, :] _memory
+    cdef double[:, :] _data
+

--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -1,6 +1,7 @@
 cdef class Recorder
 
 from _core cimport Timestep, AbstractNode, Storage, ScenarioIndex
+from .parameters._parameters cimport Parameter, IndexParameter
 
 cdef class Recorder:
     cdef bint _is_objective
@@ -15,9 +16,14 @@ cdef class Recorder:
 cdef class NodeRecorder(Recorder):
     cdef AbstractNode _node
 
-
 cdef class StorageRecorder(Recorder):
     cdef Storage _node
+
+cdef class ParameterRecorder(Recorder):
+    cdef Parameter _param
+
+cdef class IndexParameterRecorder(Recorder):
+    cdef IndexParameter _param
 
 cdef class NumpyArrayNodeRecorder(NodeRecorder):
     cdef double[:, :] _data
@@ -27,3 +33,9 @@ cdef class NumpyArrayStorageRecorder(StorageRecorder):
 
 cdef class NumpyArrayLevelRecorder(StorageRecorder):
     cdef double[:, :] _data
+
+cdef class NumpyArrayParameterRecorder(ParameterRecorder):
+    cdef double[:, :] _data
+
+cdef class NumpyArrayIndexParameterRecorder(IndexParameterRecorder):
+    cdef int[:, :] _data

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -82,7 +82,7 @@ cdef class NodeRecorder(Recorder):
     def __repr__(self):
         return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.node), self.name, hex(id(self)))
 
-    def __repr__(self):
+    def __str__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.node, self.name)
 recorder_registry.add(NodeRecorder)
 
@@ -102,7 +102,7 @@ cdef class StorageRecorder(Recorder):
     def __repr__(self):
         return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.node), self.name, hex(id(self)))
 
-    def __repr__(self):
+    def __str__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.node, self.name)
 recorder_registry.add(StorageRecorder)
 
@@ -122,7 +122,7 @@ cdef class ParameterRecorder(Recorder):
     def __repr__(self):
         return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.parameter), self.name, hex(id(self)))
 
-    def __repr__(self):
+    def __str__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.parameter, self.name)
 recorder_registry.add(ParameterRecorder)
 
@@ -142,7 +142,7 @@ cdef class IndexParameterRecorder(Recorder):
     def __repr__(self):
         return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.parameter), self.name, hex(id(self)))
 
-    def __repr__(self):
+    def __str__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.parameter, self.name)
 recorder_registry.add(IndexParameterRecorder)
 

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -177,42 +177,48 @@ class NodeIterator(object):
         return self
 
 
-class RecorderIterator(object):
-    """ Iterator for Recorder objects in a model that also supports indexing by name """
-
+class NamedIterator(object):
     def __init__(self):
-        self._recorders = []
+        self._objects = []
 
     def __getitem__(self, key):
         """Get a node from the graph by it's name"""
-        for rec in self._recorders:
-            if rec.name == key:
-                return rec
+        for obj in self._objects:
+            if obj.name == key:
+                return obj
         raise KeyError("'{}'".format(key))
 
     def __delitem__(self, key):
         """Remove a node from the graph by it's name"""
-        rec = self[key]
-        self._recorders.remove(rec)
+        obj = self[key]
+        self._objects.remove(rec)
+
+    def __setitem__(self, key, obj):
+        # TODO: check for name collisions / duplication
+        self._objects.append(obj)
 
     def keys(self):
-        for rec in self._recorders:
-            yield rec.name
+        for obj in self._objects:
+            yield obj.name
 
     def values(self):
-        for rec in self._recorders:
-            yield rec
+        for obj in self._objects:
+            yield obj
 
     def items(self):
-        for rec in self._recorders:
-            yield (rec.name, rec)
+        for obj in self._objects:
+            yield (obj.name, obj)
 
     def __len__(self):
         """Returns the number of nodes in the model"""
-        return len(self._recorders)
+        return len(self._objects)
 
     def __iter__(self):
-        return iter(self._recorders)
+        return iter(self._objects)
+
+    def append(self, obj):
+        # TODO: check for name collisions / duplication
+        self._objects.append(obj)
 
 
 class Model(object):
@@ -244,7 +250,6 @@ class Model(object):
         self.timestepper = Timestepper(start, end, timestep)
 
         self.data = {}
-        self._parameters = {}
         self.failure = set()
         self.dirty = True
 
@@ -271,7 +276,8 @@ class Model(object):
         self.solver = solver()
 
         self.group = {}
-        self.recorders = RecorderIterator()
+        self.parameters = NamedIterator()
+        self.recorders = NamedIterator()
         self.scenarios = ScenarioCollection()
 
         if kwargs:

--- a/pywr/parameters/_control_curves.pxd
+++ b/pywr/parameters/_control_curves.pxd
@@ -10,4 +10,4 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
 
 cdef class ControlCurveIndexParameter(IndexParameter):
     cdef public AbstractStorage storage_node
-    cdef list control_curves
+    cdef list _control_curves

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -22,6 +22,7 @@ cdef class Parameter:
     cpdef double[:] lower_bounds(self)
     cpdef double[:] upper_bounds(self)
     cdef public basestring name
+    cdef list _recorders
 
 cdef class ArrayIndexedParameter(Parameter):
     cdef double[:] values

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -482,8 +482,8 @@ cdef class AggregatedParameter(AggregatedParameterBase):
     agg_func : callable or str
         The aggregation function, e.g. `sum` or "sum"
     """
-    def __init__(self, parameters, *args, agg_func=None, **kwargs):
-        super(AggregatedParameter, self).__init__(*args, **kwargs)
+    def __init__(self, parameters, agg_func=None, **kwargs):
+        super(AggregatedParameter, self).__init__(**kwargs)
         self._parameters = set(parameters)
         if agg_func is None:
             agg_func = np.mean # default

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -39,6 +39,7 @@ cdef class Parameter:
     def __init__(self):
         self.parents = PairedSet(self)
         self.children = PairedSet(self)
+        self._recorders = []
 
     cpdef setup(self, model):
         cdef Parameter child
@@ -95,6 +96,16 @@ cdef class Parameter:
             for var in self.children:
                 vars.extend(var.variables)
             return vars
+
+    property recorders:
+        """ Returns a list of `Recorder` objects attached to this node.
+
+         See also
+         --------
+         `Recorder`
+         """
+        def __get__(self):
+            return self._recorders
 
     @classmethod
     def load(cls, model, data):

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -36,7 +36,8 @@ class PairedSet(set):
         set.clear(self)
 
 cdef class Parameter:
-    def __init__(self):
+    def __init__(self, name=None):
+        self.name = name
         self.parents = PairedSet(self)
         self.children = PairedSet(self)
         self._recorders = []
@@ -110,15 +111,16 @@ cdef class Parameter:
     @classmethod
     def load(cls, model, data):
         values = load_parameter_values(model, data)
-        return cls(values)
+        name = data.pop("name", None)
+        return cls(values, name=name)
 
 parameter_registry.add(Parameter)
 
 
 cdef class CachedParameter(IndexParameter):
     """Wrapper for Parameters which caches the result"""
-    def __init__(self, parameter):
-        super(IndexParameter, self).__init__()
+    def __init__(self, parameter, *args, **kwargs):
+        super(IndexParameter, self).__init__(*args, **kwargs)
         self.parameter = parameter
         self.timestep = None
         self.scenario_index = None
@@ -152,8 +154,8 @@ cdef class ArrayIndexedParameter(Parameter):
 
     The values in this parameter are constant across all scenarios.
     """
-    def __init__(self, values):
-        super(ArrayIndexedParameter, self).__init__()
+    def __init__(self, values, *args, **kwargs):
+        super(ArrayIndexedParameter, self).__init__(*args, **kwargs)
         self.values = np.asarray(values, dtype=np.float64)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
@@ -168,11 +170,11 @@ cdef class ArrayIndexedScenarioParameter(Parameter):
 
     The values in this parameter are vary in time based on index and vary within a single Scenario.
     """
-    def __init__(self, Scenario scenario, values):
+    def __init__(self, Scenario scenario, values, *args, **kwargs):
         """
         values should be an iterable that is the same length as scenario.size
         """
-        super(ArrayIndexedScenarioParameter, self).__init__()
+        super(ArrayIndexedScenarioParameter, self).__init__(*args, **kwargs)
         cdef int i
         values = np.asarray(values, dtype=np.float64)
         if values.ndim != 2:
@@ -201,11 +203,11 @@ cdef class ConstantScenarioParameter(Parameter):
 
     The values in this parameter are constant in time, but vary within a single Scenario.
     """
-    def __init__(self, Scenario scenario, values):
+    def __init__(self, Scenario scenario, values, *args, **kwargs):
         """
         values should be an iterable that is the same length as scenario.size
         """
-        super(ConstantScenarioParameter, self).__init__()
+        super(ConstantScenarioParameter, self).__init__(*args, **kwargs)
         cdef int i
         if scenario._size != len(values):
             raise ValueError("The number of values must equal the size of the scenario.")
@@ -233,13 +235,13 @@ cdef class ArrayIndexedScenarioMonthlyFactorsParameter(Parameter):
     """Time varying parameter using an array and Timestep._index with
     multiplicative factors per Scenario
     """
-    def __init__(self, Scenario scenario, values, factors):
+    def __init__(self, Scenario scenario, values, factors, *args, **kwargs):
         """
         values is the baseline timeseries data that is perturbed by a factor. The
         factor is taken from factors which is shape (scenario.size, 12). Therefore
         factors vary with the individual scenarios in scenario and month.
         """
-        super(ArrayIndexedScenarioMonthlyFactorsParameter, self).__init__()
+        super(ArrayIndexedScenarioMonthlyFactorsParameter, self).__init__(*args, **kwargs)
 
         values = np.asarray(values, dtype=np.float64)
         factors = np.asarray(factors, dtype=np.float64)
@@ -271,8 +273,8 @@ parameter_registry.add(ArrayIndexedScenarioMonthlyFactorsParameter)
 
 
 cdef class DailyProfileParameter(Parameter):
-    def __init__(self, values):
-        super(DailyProfileParameter, self).__init__()
+    def __init__(self, values, *args, **kwargs):
+        super(DailyProfileParameter, self).__init__(*args, **kwargs)
         v = np.squeeze(np.array(values))
         if v.ndim != 1:
             raise ValueError("values must be 1-dimensional.")
@@ -363,8 +365,8 @@ cdef class AnnualHarmonicSeriesParameter(Parameter):
         length as amplitudes.
 
     """
-    def __init__(self, mean, amplitudes, phases, **kwargs):
-        super(AnnualHarmonicSeriesParameter, self).__init__()
+    def __init__(self, mean, amplitudes, phases, *args, **kwargs):
+        super(AnnualHarmonicSeriesParameter, self).__init__(*args, **kwargs)
         if len(amplitudes) != len(phases):
             raise ValueError("The number  of amplitudes and phases must be the same.")
         n = len(amplitudes)
@@ -480,8 +482,8 @@ cdef class AggregatedParameter(AggregatedParameterBase):
     agg_func : callable or str
         The aggregation function, e.g. `sum` or "sum"
     """
-    def __init__(self, parameters, agg_func=None):
-        super(AggregatedParameter, self).__init__()
+    def __init__(self, parameters, *args, agg_func=None, **kwargs):
+        super(AggregatedParameter, self).__init__(*args, **kwargs)
         self._parameters = set(parameters)
         if agg_func is None:
             agg_func = np.mean # default
@@ -526,8 +528,8 @@ cdef class AggregatedIndexParameter(AggregatedParameterBase):
     agg_func : callable or str
         The aggregation function, e.g. `sum` or "sum"
     """
-    def __init__(self, parameters, agg_func=None):
-        super(AggregatedIndexParameter, self).__init__()
+    def __init__(self, parameters, agg_func=None, **kwargs):
+        super(AggregatedIndexParameter, self).__init__(**kwargs)
         self._parameters = set(parameters)
         if agg_func is None:
             agg_func = sum # default
@@ -555,7 +557,7 @@ def load_parameter(model, data):
     if isinstance(data, basestring):
         # parameter is a reference
         try:
-            parameter = model._parameters[data]
+            parameter = model.parameters[data]
         except KeyError:
             parameter = None
         if parameter is None:
@@ -608,7 +610,7 @@ def load_parameter(model, data):
     if parameter_name is not None:
         # TODO FIXME: memory leak if parameter is subsequently removed from the model
         parameter.name = parameter_name
-        model._parameters[parameter_name] = parameter
+        model.parameters[parameter_name] = parameter
 
     return parameter
 

--- a/pywr/parameters/control_curves.py
+++ b/pywr/parameters/control_curves.py
@@ -2,7 +2,7 @@
 This module contains a set of pywr._core.Parameter subclasses for defining control curve based parameters.
 """
 
-from ._control_curves import BaseControlCurveParameter, ControlCurveInterpolatedParameter
+from ._control_curves import BaseControlCurveParameter, ControlCurveInterpolatedParameter, ControlCurveIndexParameter
 from .parameters import parameter_registry, load_parameter_values, load_parameter, BaseParameter
 import numpy as np
 

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -18,8 +18,8 @@ class Parameter(BaseParameter):
         raise NotImplementedError()
 
 class ConstantParameter(Parameter):
-    def __init__(self, value, *args, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
-        super(ConstantParameter, self).__init__(*args, **kwargs)
+    def __init__(self, value, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
+        super(ConstantParameter, self).__init__(**kwargs)
         self._value = value
         self.size = 1
         self._lower_bounds = np.ones(self.size) * lower_bounds
@@ -51,8 +51,8 @@ parameter_registry.add(FunctionParameter)
 
 
 class MonthlyProfileParameter(Parameter):
-    def __init__(self, values, *args, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
-        super(MonthlyProfileParameter, self).__init__(*args, **kwargs)
+    def __init__(self, values, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
+        super(MonthlyProfileParameter, self).__init__(**kwargs)
         self.size = 12
         if len(values) != self.size:
             raise ValueError("12 values must be given for a monthly profile.")
@@ -121,8 +121,8 @@ def align_and_resample_dataframe(df, datetime_index):
 
 
 class DataFrameParameter(Parameter):
-    def __init__(self, df, *args, scenario=None, metadata=None, **kwargs):
-        super(DataFrameParameter, self).__init__(*args, **kwargs)
+    def __init__(self, df, scenario=None, metadata=None, **kwargs):
+        super(DataFrameParameter, self).__init__(**kwargs)
         self.df = df
         if metadata is None:
             metadata = {}
@@ -169,8 +169,8 @@ class InterpolatedLevelParameter(Parameter):
     """
     Level parameter calculated by interpolation from current volume
     """
-    def __init__(self, node, volumes, levels, *args, kind='linear', **kwargs):
-        super(InterpolatedLevelParameter, self).__init__(*args, **kwargs)
+    def __init__(self, node, volumes, levels, kind='linear', **kwargs):
+        super(InterpolatedLevelParameter, self).__init__(**kwargs)
         from scipy.interpolate import interp1d
         # Create level interpolator
         self.interp = interp1d(volumes, levels, bounds_error=True, kind=kind)

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -18,8 +18,8 @@ class Parameter(BaseParameter):
         raise NotImplementedError()
 
 class ConstantParameter(Parameter):
-    def __init__(self, value=None, lower_bounds=0.0, upper_bounds=np.inf):
-        super(ConstantParameter, self).__init__()
+    def __init__(self, value, *args, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
+        super(ConstantParameter, self).__init__(*args, **kwargs)
         self._value = value
         self.size = 1
         self._lower_bounds = np.ones(self.size) * lower_bounds
@@ -40,8 +40,8 @@ parameter_registry.add(ConstantParameter)
 
 
 class FunctionParameter(Parameter):
-    def __init__(self, parent, func):
-        super(FunctionParameter, self).__init__()
+    def __init__(self, parent, func, *args, **kwargs):
+        super(FunctionParameter, self).__init__(*args, **kwargs)
         self._parent = parent
         self._func = func
 
@@ -51,8 +51,8 @@ parameter_registry.add(FunctionParameter)
 
 
 class MonthlyProfileParameter(Parameter):
-    def __init__(self, values, lower_bounds=0.0, upper_bounds=np.inf):
-        super(MonthlyProfileParameter, self).__init__()
+    def __init__(self, values, *args, lower_bounds=0.0, upper_bounds=np.inf, **kwargs):
+        super(MonthlyProfileParameter, self).__init__(*args, **kwargs)
         self.size = 12
         if len(values) != self.size:
             raise ValueError("12 values must be given for a monthly profile.")
@@ -75,8 +75,8 @@ parameter_registry.add(MonthlyProfileParameter)
 
 
 class ScaledProfileParameter(Parameter):
-    def __init__(self, scale, profile):
-        super(ScaledProfileParameter, self).__init__()
+    def __init__(self, scale, profile, *args, **kwargs):
+        super(ScaledProfileParameter, self).__init__(*args, **kwargs)
         self.scale = scale
 
         profile.parents.add(self)
@@ -84,9 +84,9 @@ class ScaledProfileParameter(Parameter):
 
     @classmethod
     def load(cls, model, data):
-        scale = float(data['scale'])
-        profile = load_parameter(model, data['profile'])
-        return cls(scale, profile)
+        scale = float(data.pop("scale"))
+        profile = load_parameter(model, data.pop("profile"))
+        return cls(scale, profile, **data)
 
     def value(self, ts, si):
         p = self.profile.value(ts, si)
@@ -121,8 +121,8 @@ def align_and_resample_dataframe(df, datetime_index):
 
 
 class DataFrameParameter(Parameter):
-    def __init__(self, df, scenario=None, metadata=None):
-        super(DataFrameParameter, self).__init__()
+    def __init__(self, df, *args, scenario=None, metadata=None, **kwargs):
+        super(DataFrameParameter, self).__init__(*args, **kwargs)
         self.df = df
         if metadata is None:
             metadata = {}
@@ -169,7 +169,8 @@ class InterpolatedLevelParameter(Parameter):
     """
     Level parameter calculated by interpolation from current volume
     """
-    def __init__(self, node, volumes, levels, kind='linear'):
+    def __init__(self, node, volumes, levels, *args, kind='linear', **kwargs):
+        super(InterpolatedLevelParameter, self).__init__(*args, **kwargs)
         from scipy.interpolate import interp1d
         # Create level interpolator
         self.interp = interp1d(volumes, levels, bounds_error=True, kind=kind)

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -1,7 +1,8 @@
 import sys
 import numpy as np
-from pywr._recorders import (Recorder, NodeRecorder, StorageRecorder,
-    NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayLevelRecorder)
+from pywr._recorders import (Recorder, NodeRecorder, StorageRecorder, ParameterRecorder, IndexParameterRecorder,
+    NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayLevelRecorder, NumpyArrayParameterRecorder,
+    NumpyArrayIndexParameterRecorder)
 from pywr._recorders import recorder_registry
 from pywr._core import Storage
 

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 from pywr._recorders import (Recorder, NodeRecorder, StorageRecorder, ParameterRecorder, IndexParameterRecorder,
     NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayLevelRecorder, NumpyArrayParameterRecorder,
-    NumpyArrayIndexParameterRecorder)
+    NumpyArrayIndexParameterRecorder, MeanParameterRecorder)
 from pywr._recorders import recorder_registry
 from pywr._core import Storage
 

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -12,7 +12,8 @@ import pytest
 from numpy.testing import assert_allclose
 from fixtures import simple_linear_model, simple_storage_model
 from pywr.recorders import NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, AggregatedRecorder, \
-                           CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder, TotalFlowRecorder
+                           CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder, TotalFlowRecorder, \
+                           NumpyArrayParameterRecorder, NumpyArrayIndexParameterRecorder
 
 
 def test_numpy_recorder(simple_linear_model):
@@ -63,6 +64,62 @@ def test_numpy_storage_recorder(simple_storage_model):
     df = rec.to_dataframe()
     assert df.shape == (5, 1)
     assert_allclose(df.values, np.array([[7, 4, 1, 0, 0]]).T, atol=1e-7)
+
+
+def test_numpy_parameter_recorder(simple_linear_model):
+    """
+    Test the NumpyArrayParameterRecorder
+    """
+    from pywr.parameters import DailyProfileParameter
+
+    model = simple_linear_model
+    otpt = model.node['Output']
+
+    p = DailyProfileParameter(np.arange(366, dtype=np.float64), )
+    p.name = 'daily profile'
+    model.node['Input'].max_flow = p
+    otpt.cost = -2.0
+    rec = NumpyArrayParameterRecorder(model, model.node['Input'].max_flow)
+
+    # test retrieval of recorder
+    assert model.recorders['numpyarrayparameterrecorder.daily profile'] == rec
+
+    model.run()
+
+    assert rec.data.shape == (365, 1)
+    assert_allclose(rec.data, np.arange(365, dtype=np.float64)[:, np.newaxis])
+
+    df = rec.to_dataframe()
+    assert df.shape == (365, 1)
+    assert_allclose(df.values, np.arange(365, dtype=np.float64)[:, np.newaxis])
+
+
+def test_numpy_index_parameter_recorder(simple_storage_model):
+    """
+    Test the NumpyArrayIndexParameterRecorder
+    """
+    from pywr.parameters.control_curves import ControlCurveIndexParameter
+
+    model = simple_storage_model
+
+    res = model.node['Storage']
+
+    p = ControlCurveIndexParameter(res, [5.0/20.0, 2.5/20.0])
+
+    res_rec = NumpyArrayStorageRecorder(model, res)
+    lvl_rec = NumpyArrayIndexParameterRecorder(model, p)
+
+    model.run()
+
+    assert(res_rec.data.shape == (5, 1))
+    assert_allclose(res_rec.data, np.array([[7, 4, 1, 0, 0]]).T, atol=1e-7)
+    assert (lvl_rec.data.shape == (5, 1))
+    assert_allclose(lvl_rec.data, np.array([[0, 1, 2, 2, 2]]).T, atol=1e-7)
+
+
+    df = lvl_rec.to_dataframe()
+    assert df.shape == (5, 1)
+    assert_allclose(df.values, np.array([[0, 1, 2, 2, 2]]).T, atol=1e-7)
 
 
 def test_concatenated_dataframes(simple_storage_model):


### PR DESCRIPTION
This commit adds Recorder subclasses for Parameter and IndexParameter. Currently there are NumpyArray... versions of these base classes implemented and tested. Parameters now have access to the _recorders list to find out which Recorder objects are looking at them.

Spotted a couple of bugs on ControlCurveIndexParameter as well that are fixed.

TODO
- Currently there is no way to give a Parameter a name via keyword arguments to __init__.
- More subclasses to use the new Recorders.