### PR TITLE
Added MeanFlowRecorder and RecorderThresholdParameter.

### DIFF
--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -27,3 +27,9 @@ cdef class NumpyArrayStorageRecorder(StorageRecorder):
 
 cdef class NumpyArrayLevelRecorder(StorageRecorder):
     cdef double[:, :] _data
+
+cdef class MeanFlowRecorder(NodeRecorder):
+    cdef int position
+    cdef int timesteps
+    cdef double[:, :] _memory
+    cdef double[:, :] _data

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -27,9 +27,6 @@ cdef class Recorder:
             self._name = name
 
     def __repr__(self):
-        return '<{} "{}" ({})>'.format(self.__class__.__name__, self.name, hex(id(self)))
-
-    def __str__(self):
         return '<{} "{}">'.format(self.__class__.__name__, self.name)
 
     cpdef setup(self):
@@ -81,10 +78,8 @@ cdef class NodeRecorder(Recorder):
             return self._node
 
     def __repr__(self):
-        return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.node), self.name, hex(id(self)))
-
-    def __repr__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.node, self.name)
+
 recorder_registry.add(NodeRecorder)
 
 
@@ -96,11 +91,13 @@ cdef class StorageRecorder(Recorder):
         self._node = node
         node._recorders.append(self)
 
-    def __repr__(self):
-        return '<{} on {} "{}" ({})>'.format(self.__class__.__name__, repr(self.node), self.name, hex(id(self)))
+    property node:
+        def __get__(self):
+            return self._node
 
     def __repr__(self):
         return '<{} on {} "{}">'.format(self.__class__.__name__, self.node, self.name)
+
 recorder_registry.add(StorageRecorder)
 
 

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -1,6 +1,8 @@
 import numpy as np
 cimport numpy as np
 
+from pywr._core cimport Timestep
+
 import pandas as pd
 
 recorder_registry = set()
@@ -63,8 +65,7 @@ cdef class Recorder:
         except KeyError:
             pass
         else:
-            node = model.nodes[node_name]
-            data["node"] = node
+            data["node"] = model._get_node_from_ref(model, node_name)
         return cls(model, **data)
 
 cdef class NodeRecorder(Recorder):
@@ -194,3 +195,106 @@ cdef class NumpyArrayLevelRecorder(StorageRecorder):
             return np.array(self._data)
 
 recorder_registry.add(NumpyArrayLevelRecorder)
+
+cdef class MeanFlowRecorder(NodeRecorder):
+    """Records the mean flow of a Node for the previous N timesteps
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+    node : `pywr.core.Node`
+        The node to record
+    timesteps : int
+        The number of timesteps to calculate the mean flow for
+    name : str (optional)
+        The name of the recorder
+    """
+    def __init__(self, model, node, timesteps, name=None):
+        super(MeanFlowRecorder, self).__init__(model, node, name=name)
+        self._model = model
+        self.timesteps = timesteps
+        self._data = None
+
+    cpdef setup(self):
+        super(MeanFlowRecorder, self).setup()
+        self._memory = np.zeros([len(self._model.scenarios.combinations), self.timesteps])
+        self.position = 0
+        self._data = np.empty([len(self._model.timestepper), len(self._model.scenarios.combinations)])
+
+    cpdef int save(self) except -1:
+        cdef double mean_flow
+        cdef Timestep timestep
+        # save today's flow
+        self._memory[:, self.position] = self.node.flow
+        # calculate the mean flow
+        timestep = self._model.timestepper.current
+        if timestep.index < self.timesteps:
+            n = timestep.index + 1
+        else:
+            n = self.timesteps
+        mean_flow = np.mean(self._memory[:, 0:n], axis=1)
+        # save the mean flow
+        self._data[<int>(timestep.index), :] = mean_flow
+        # prepare for the next timestep
+        self.position += 1
+        if self.position >= self.timesteps:
+            self.position = 0
+
+    property data:
+        def __get__(self):
+            return np.array(self._data, dtype=np.float64)
+
+    @classmethod
+    def load(cls, model, data):
+        name = data.get("name")
+        node = model._get_node_from_ref(model, data["node"])
+        timesteps = int(data["timesteps"])
+        return cls(model, node, timesteps, name=name)
+
+recorder_registry.add(MeanFlowRecorder)
+
+def load_recorder(model, data):
+    recorder = None
+
+    if isinstance(data, basestring):
+        recorder_name = data
+    else:
+        recorder_name = None
+
+    # check if recorder has already been loaded
+    for rec in model.recorders:
+        if rec.name == recorder_name:
+            recorder = rec
+            break
+
+    if recorder is None and isinstance(data, basestring):
+        # recorder was requested by name, but hasn't been loaded yet
+        if hasattr(model, "_recorders_to_load"):
+            # we're still in the process of loading data from JSON and
+            # the parameter requested hasn't been loaded yet - do it now
+            try:
+                data = model._recorders_to_load[recorder_name]
+            except KeyError:
+                raise KeyError("Unknown recorder: '{}'".format(data))
+            recorder = load_recorder(model, data)
+        else:
+            raise KeyError("Unknown recorder: '{}'".format(data))
+
+    if recorder is None:
+        recorder_type = data['type']
+
+        # lookup the recorder class in the registry
+        cls = None
+        name2 = recorder_type.lower().replace('recorder', '')
+        for recorder_class in recorder_registry:
+            name1 = recorder_class.__name__.lower().replace('recorder', '')
+            if name1 == name2:
+                cls = recorder_class
+
+        if cls is None:
+            raise NotImplementedError('Unrecognised recorder type "{}"'.format(recorder_type))
+
+        del(data["type"])
+        recorder = cls.load(model, data)
+
+    return recorder

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -434,6 +434,19 @@ class Model(object):
                     parameters_to_load[key]["name"] = key
         model._parameters_to_load = parameters_to_load
 
+        # collect recorders to load
+        # the recorders are loaded immediately, as they may not be referenced
+        # anywhere else
+        try:
+            recorders_to_load = data["recorders"]
+        except KeyError:
+            recorders_to_load = []
+        else:
+            for key, value in recorders_to_load.items():
+                if isinstance(value, dict):
+                    recorders_to_load[key]["name"] = key
+                load_recorder(model, recorders_to_load[key])
+
         # load the remaining nodes
         for node_name in list(nodes_to_load.keys()):
             node = cls._get_node_from_ref(model, node_name)

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -1,3 +1,4 @@
+from pywr._recorders cimport Recorder
 
 # Forward declations
 cdef class Parameter
@@ -86,3 +87,9 @@ cdef class AggregatedParameter(AggregatedParameterBase):
 
 cdef class AggregatedIndexParameter(AggregatedParameterBase):
     pass
+
+cdef class RecorderThresholdParameter(Parameter):
+    cdef Recorder recorder
+    cdef double threshold
+    cdef double[:] values
+    cdef int predicate

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -5,6 +5,14 @@ import pandas
 from libc.math cimport cos, M_PI
 from past.builtins import basestring
 
+cdef enum Predicates:
+    LT = 0
+    GT = 1
+    EQ = 2
+    LE = 3
+    GE = 4
+_predicate_lookup = {"LT": Predicates.LT, "GT": Predicates.GT, "EQ": Predicates.EQ, "LE": Predicates.LE, "GE": Predicates.GE}
+
 parameter_registry = set()
 
 class PairedSet(set):
@@ -537,6 +545,70 @@ cdef class AggregatedIndexParameter(AggregatedParameterBase):
 
 parameter_registry.add(AggregatedIndexParameter)
 
+cdef class RecorderThresholdParameter(Parameter):
+    """Returns one of two values depending on a Recorder value and a threshold
+
+    Parameters
+    ----------
+    recorder : `pywr.recorder.Recorder`
+    threshold : double
+        Threshold to compare the value of the recorder to
+    values : iterable of doubles
+        If the predicate evaluates False the zeroth value is returned,
+        otherwise the first value is returned.
+    predicate : string
+        One of {"LT", "GT", "EQ", "LE", "GE"}.
+
+    Notes
+    -----
+    On the first day of the model run the recorder will not have a value for
+    the previous day. In this case the predicate evaluates to True.
+    """
+
+    def __init__(self, Recorder recorder, threshold, values, predicate=None):
+        super(RecorderThresholdParameter, self).__init__()
+        self.recorder = recorder
+        self.threshold = threshold
+        self.values = np.array(values, np.float64)
+        if predicate is None:
+            predicate = Predicates.LT
+        elif isinstance(predicate, basestring):
+            predicate = _predicate_lookup[predicate.upper()]
+        self.predicate = predicate
+
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        cdef int index = timestep.index
+        cdef double x, v
+        cdef int ind
+        if index == 0:
+            # on the first day the recorder doesn't have a value so we have no
+            # threshold to compare to
+            v = self.values[1]
+        else:
+            x = self.recorder.data[index-1, scenario_index.global_id]
+            if self.predicate == Predicates.LT:
+                ind = x < self.threshold
+            elif self.predicate == Predicates.GT:
+                ind = x > self.threshold
+            elif self.predicate == Predicates.LE:
+                ind = x <= self.threshold
+            elif self.predicate == Predicates.GE:
+                ind = x >= self.threshold
+            else:
+                ind = x == self.threshold
+            v = self.values[ind]
+        return v
+
+    @classmethod
+    def load(cls, model, data):
+        from pywr._recorders import load_recorder  # delayed to prevent circular reference
+        recorder = load_recorder(model, data["recorder"])
+        threshold = data["threshold"]
+        values = data["values"]
+        predicate = data.get("predicate", None)
+        return cls(recorder, threshold, values, predicate)
+
+parameter_registry.add(RecorderThresholdParameter)
 
 def load_parameter(model, data):
     """Load a parameter from a dict"""

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -6,7 +6,7 @@ from ._parameters import (
     ArrayIndexedParameter, ConstantScenarioParameter,
     ArrayIndexedScenarioMonthlyFactorsParameter,
     DailyProfileParameter, ArrayIndexedScenarioParameter,
-    IndexParameter, CachedParameter,
+    IndexParameter, CachedParameter, RecorderThresholdParameter,
     AggregatedParameter, AggregatedIndexParameter,
     load_parameter, load_parameter_values, load_dataframe)
 from past.builtins import basestring

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -1,9 +1,12 @@
 import sys
 import numpy as np
 from pywr._recorders import (Recorder, NodeRecorder, StorageRecorder,
-    NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayLevelRecorder)
-from pywr._recorders import recorder_registry
+    NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayLevelRecorder,
+    MeanFlowRecorder)
+from pywr._recorders import recorder_registry, load_recorder
 from pywr._core import Storage
+
+from past.builtins import basestring
 
 
 class CSVRecorder(Recorder):
@@ -266,23 +269,3 @@ class AggregatedRecorder(Recorder):
         print(rec.name)
 
 recorder_registry.add(AggregatedRecorder)
-
-
-def load_recorder(model, data):
-    recorder_type = data['type']
-    
-    # lookup the recorder class in the registry
-    cls = None
-    name2 = recorder_type.lower().replace('recorder', '')
-    for recorder_class in recorder_registry:
-        name1 = recorder_class.__name__.lower().replace('recorder', '')
-        if name1 == name2:
-            cls = recorder_class
-
-    if cls is None:
-        raise NotImplementedError('Unrecognised recorder type "{}"'.format(recorder_type))
-
-    del(data["type"])
-    rec = cls.load(model, data)
-    
-    return rec  # not strictly needed

--- a/tests/models/mean_flow_recorder.json
+++ b/tests/models/mean_flow_recorder.json
@@ -1,0 +1,62 @@
+{
+    "metadata": {
+        "title": "Mean flow recorder",
+        "description": "A test of recorders in JSON"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-04",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 1
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+          "name": "supply2",
+          "type": "Input",
+          "max_flow": 100,
+          "cost": 0
+        },
+        {
+            "name": "demand_with_threshold",
+            "type": "Output",
+            "max_flow": {
+                "type": "recorderthreshold",
+                "recorder": "Mean Flow",
+                "threshold": 2.5,
+                "values": [60.0, 50.0],
+                "predicate": "LT"
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["supply2", "demand_with_threshold"]
+    ],
+    "recorders": {
+        "Supply": {
+            "type": "NumpyArrayNode",
+            "node": "supply1"
+        },
+        "Mean Flow": {
+            "type": "MeanFlow",
+            "node": "supply1",
+            "timesteps": 3
+        },
+        "Supply 2": {
+            "type": "NumpyArrayNode",
+            "node": "supply2"
+        }
+    }
+}

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -6,8 +6,9 @@ from pywr.core import Model, Timestep, Scenario, ScenarioIndex, Storage, Link, I
 from pywr.parameters import (BaseParameter, ArrayIndexedParameter, ConstantScenarioParameter,
     ArrayIndexedScenarioMonthlyFactorsParameter, MonthlyProfileParameter, DailyProfileParameter,
     DataFrameParameter, AggregatedParameter, ConstantParameter, CachedParameter,
-    IndexParameter, AggregatedIndexParameter,
+    IndexParameter, AggregatedIndexParameter, RecorderThresholdParameter,
     FunctionParameter, AnnualHarmonicSeriesParameter, load_parameter)
+from pywr.recorders import Recorder
 
 from helpers import load_model
 
@@ -506,3 +507,34 @@ def test_with_a_better_name():
             ]
         }
     }
+
+def test_threshold_parameter(model):
+    class DummyRecorder(Recorder):
+        def __init__(self, *args, **kwargs):
+            super(DummyRecorder, self).__init__(*args, **kwargs)
+            self.data = np.array([[0.0]], dtype=np.float64)
+
+    rec = DummyRecorder(model)
+
+    timestep = Timestep(datetime.datetime(2016, 1, 2), 1, 1)
+    si = ScenarioIndex(0, np.array([0]))
+
+    threshold = 10.0
+    values = [50.0, 60.0]
+
+    expected = [
+        ("LT", (1, 0, 0)),
+        ("GT", (0, 0, 1)),
+        ("EQ", (0, 1, 0)),
+        ("LE", (1, 1, 0)),
+        ("GE", (0, 1, 1)),
+    ]
+
+    for predicate, (value_lt, value_eq, value_gt) in expected:
+        param = RecorderThresholdParameter(rec, threshold, values, predicate)
+        rec.data[...] = threshold - 5  # data is below threshold
+        assert_allclose(param.value(timestep, si), values[value_lt])
+        rec.data[...] = threshold  # data is at threshold
+        assert_allclose(param.value(timestep, si), values[value_eq])
+        rec.data[...] = threshold + 5  # data is above threshold
+        assert_allclose(param.value(timestep, si), values[value_gt])

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -517,7 +517,7 @@ def test_threshold_parameter(model):
     rec = DummyRecorder(model)
 
     timestep = Timestep(datetime.datetime(2016, 1, 2), 1, 1)
-    si = ScenarioIndex(0, np.array([0]))
+    si = ScenarioIndex(0, np.array([0], dtype=np.int32))
 
     threshold = 10.0
     values = [50.0, 60.0]

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -11,8 +11,12 @@ import pandas
 import pytest
 from numpy.testing import assert_allclose
 from fixtures import simple_linear_model, simple_storage_model
-from pywr.recorders import NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, AggregatedRecorder, \
-                           CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder, TotalFlowRecorder
+from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
+    AggregatedRecorder, CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder,
+    TotalFlowRecorder, MeanFlowRecorder)
+from pywr.parameters import FunctionParameter
+
+from helpers import load_model
 
 
 def test_numpy_recorder(simple_linear_model):
@@ -219,3 +223,47 @@ def test_reset_timestepper_recorder(solver):
     model.timestepper.end = pandas.to_datetime("2016-01-02")
 
     model.run()
+
+def test_mean_flow_recorder(solver):
+    model = Model(solver=solver)
+    model.timestepper.start = pandas.to_datetime("2016-01-01")
+    model.timestepper.end = pandas.to_datetime("2016-01-04")
+
+    inpt = Input(model, "input")
+    otpt = Output(model, "output")
+    inpt.connect(otpt)
+
+    rec_flow = NumpyArrayNodeRecorder(model, inpt)
+    rec_mean = MeanFlowRecorder(model, node=inpt, timesteps=3)
+
+    inpt.max_flow = inpt.min_flow = FunctionParameter(inpt, lambda model, t, si: 2 + t.index)
+    model.run()
+
+    expected = [
+        2.0,
+        (2.0 + 3.0) / 2,
+        (2.0 + 3.0 + 4.0) / 3,
+        (3.0 + 4.0 + 5.0) / 3,  # zeroth day forgotten
+    ]
+
+    for value, expected_value in zip(rec_mean.data, expected):
+        assert_allclose(value, expected_value)
+
+def test_mean_flow_recorder_json(solver):
+    model = load_model("mean_flow_recorder.json", solver=solver)
+
+    # TODO: it's not possible to define a FunctionParameter in JSON yet
+    supply1 = model.nodes["supply1"]
+    supply1.max_flow = supply1.min_flow = FunctionParameter(supply1, lambda model, t, si: 2 + t.index)
+
+    assert(len(model.recorders) == 3)
+
+    rec_flow = model.recorders["Supply"]
+    rec_mean = model.recorders["Mean Flow"]
+    rec_check = model.recorders["Supply 2"]
+
+    model.run()
+
+    assert_allclose(rec_flow.data[:,0], [2.0, 3.0, 4.0, 5.0])
+    assert_allclose(rec_mean.data[:,0], [2.0, 2.5, 3.0, 4.0])
+    assert_allclose(rec_check.data[:,0], [50.0, 50.0, 60.0, 60.0])


### PR DESCRIPTION
This PR adds a `MeanFlowRecorder` which records the mean flow of a node for the past N timesteps, and `RecorderThresholdParameter` which returns one of two values depending on the value of a recorder vs a threshold.

This required a refactor of `load_recorder` to be more in line with `load_parameter`, as recorders can now be a dependency of parameters.

This implements the second point in #155.