### PR TITLE
Faster calculation of day of year in _core.Timestep

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -23,6 +23,7 @@ cdef class Timestep:
     cdef object _datetime
     cdef int _index
     cdef double _days
+    cdef readonly dayofyear
 
 cdef class Domain:
     cdef object name

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -121,6 +121,7 @@ cdef class Timestep:
         self._datetime = pd.Timestamp(datetime)
         self._index = index
         self._days = days
+        self.dayofyear = self.datetime.timetuple().tm_yday
 
     property datetime:
         """Timestep representation as a `datetime.datetime` object"""

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -72,8 +72,9 @@ cdef class CachedParameter(IndexParameter):
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
 
 cdef class AggregatedParameterBase(IndexParameter):
-    cdef set _parameters
+    cdef public set parameters
     cdef object agg_func
+    cdef int _agg_func
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cpdef add(self, Parameter parameter)

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -270,7 +270,7 @@ cdef class DailyProfileParameter(Parameter):
         self._values = v
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef int i = ts.datetime.dayofyear-1
+        cdef int i = ts.dayofyear - 1
         return self._values[i]
 parameter_registry.add(DailyProfileParameter)
 


### PR DESCRIPTION
This change has a significant impact on the speed of my large (150 node, 250 edges) model. It goes from 1250 timesteps/second to 1900 timesteps/second - a 50% speedup for 3 lines of code!