### PR TITLE
If Node.virtual is True don't draw it in the jupyter schematic.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -37,6 +37,7 @@ cdef class AbstractNode:
     cdef object _model
     cdef object _name
     cdef bint _allow_isolated
+    cdef public bint virtual
     cdef public object __data
 
     cdef Parameter _cost_param

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -149,6 +149,7 @@ cdef class AbstractNode:
     """
     def __cinit__(self):
         self._allow_isolated = False
+        self.virtual = False
 
     def __init__(self, model, name, **kwargs):
         self._model = model
@@ -485,6 +486,7 @@ cdef class AggregatedNode(AbstractNode):
     """
     def __cinit__(self, ):
         self._allow_isolated = True
+        self.virtual = True
         self._factors = None
         self._min_flow = -inf
         self._max_flow = inf

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -18,7 +18,7 @@ def nx_to_json(model):
     """Convert a Pywr graph to a structure d3 can display"""
     nodes = []
     for node in model.graph.nodes():
-        if node.parent is None:
+        if node.parent is None and node.virtual is False:
             nodes.append(node.name)
 
     edges = []


### PR DESCRIPTION
This PR adds a `virtual` property to all nodes. If the node is virtual it is not rendered in the schematic.

Closes #175.