### PR TITLE
Catch invalid dataframe index earlier.

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -812,6 +812,10 @@ def load_dataframe(model, data):
     elif filetype == "hdf":
         df = pandas.read_hdf(url, columns=[column], **data)
 
+    if df.index.dtype.name == "object":
+        # catch dates that haven't been parsed yet
+        raise TypeError("Invalid DataFrame index type \"{}\" in \"{}\".".format(df.index.dtype.name, url))
+
     # clean up
     data.pop("parse_dates", None)
     data.pop("dayfirst", None)


### PR DESCRIPTION
This change catches dataframes that have a string for an index instead of a date object. I'm not sure the message is as helpful as it could be?

Without this you don't know what's wrong until you run the model.