### PR TITLE
Added coverage support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+plugins = Cython.Coverage
+omit = *.pxd

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,18 @@ To run the unit tests:
 
     (env)$ py.test tests
 
+To run coverage analysis on the tests (requires `coverage` module), first build with tracing:
+
+.. code-block:: console
+
+    $ python setup.py --enable-trace --with-glpk --with-lpsolve develop
+
+.. code-block:: console
+
+    $ coverage run --source pywr -m py.test tests
+    $ coverage report
+    $ coverage html
+
 License
 =======
 

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,8 @@ setup_kwargs = {
     'packages': ['pywr', 'pywr.solvers', 'pywr.domains', 'pywr.parameters', 'pywr.notebook'],
 }
 
-extensions = [
-    Extension('pywr._core', ['pywr/_core.pyx'],
-              include_dirs=[np.get_include()],),
-    Extension('pywr.parameters._parameters', ['pywr/parameters/_parameters.pyx'],
-              include_dirs=[np.get_include()],),
-    Extension('pywr._recorders', ['pywr/_recorders.pyx'],
-              include_dirs=[np.get_include()],),
-    Extension('pywr.parameters._control_curves', ['pywr/parameters/_control_curves.pyx'],
-              include_dirs=[np.get_include()],),
-]
+
+define_macros = []
 
 # HACK: optional features are too difficult to do properly
 # http://stackoverflow.com/a/4056848/1300519
@@ -56,15 +48,36 @@ if '--enable-profiling' in sys.argv:
      compiler_directives['profile'] = True
      sys.argv.remove('--enable-profiling')
 
+if '--enable-trace' in sys.argv:
+    print('Tracing is enabled.')
+    compiler_directives['linetrace'] = True
+    define_macros.append(('CYTHON_TRACE', '1'))
+sys.argv.remove('--enable-trace')
+
+extensions = [
+    Extension('pywr._core', ['pywr/_core.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
+    Extension('pywr.parameters._parameters', ['pywr/parameters/_parameters.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
+    Extension('pywr._recorders', ['pywr/_recorders.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
+    Extension('pywr.parameters._control_curves', ['pywr/parameters/_control_curves.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
+]
+
 extensions_optional = []
 if 'glpk' in optional:
     extensions_optional.append(
         Extension('pywr.solvers.cython_glpk', ['pywr/solvers/cython_glpk.pyx'],
                   include_dirs=[np.get_include()],
-                  libraries=['glpk'],),
+                  libraries=['glpk'],
+                  define_macros=define_macros),
     )
 if 'lpsolve' in optional:
-    define_macros = []
     if os.name == 'nt':
         define_macros.append(('WIN32', 1))
     extensions_optional.append(

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if '--enable-trace' in sys.argv:
     print('Tracing is enabled.')
     compiler_directives['linetrace'] = True
     define_macros.append(('CYTHON_TRACE', '1'))
-sys.argv.remove('--enable-trace')
+    sys.argv.remove('--enable-trace')
 
 extensions = [
     Extension('pywr._core', ['pywr/_core.pyx'],


### PR DESCRIPTION
Some support for coverage is better than none, even if it's not working 100% correctly for Cython.

Build cython modules with tracing enabled:

```
python setup.py --with-glpk --with-lpsolve --enable-tracing develop
```

Then run coverage on tests
```
coverage run --source pywr py.test tests
coverage report
coverage html
```

#86 