### PR TITLE
MeanFlowRecorder `timesteps` can be set using `days` property.

### DIFF
--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -49,6 +49,7 @@ cdef class MeanParameterRecorder(ParameterRecorder):
 
 cdef class MeanFlowRecorder(NodeRecorder):
     cdef int position
-    cdef int timesteps
+    cdef public int timesteps
+    cdef public int days
     cdef double[:, :] _memory
     cdef double[:, :] _data

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -305,14 +305,14 @@ cdef class MeanParameterRecorder(ParameterRecorder):
     def __init__(self, model, Parameter param, int timesteps, *args, **kwargs):
         super(MeanParameterRecorder, self).__init__(model, param, *args, **kwargs)
         self.timesteps = timesteps
-    
+
     cpdef setup(self):
         cdef int ncomb = len(self._model.scenarios.combinations)
         cdef int nts = len(self._model.timestepper)
         self._data = np.zeros((nts, ncomb,), np.float64)
         self._memory = np.empty((nts, ncomb,), np.float64)
         self.position = 0
-    
+
     cpdef reset(self):
         self._data[...] = 0
         self.position = 0
@@ -322,15 +322,15 @@ cdef class MeanParameterRecorder(ParameterRecorder):
         cdef double[:] mean_value
         cdef ScenarioIndex scenario_index
         cdef Timestep timestep = self._model.timestepper.current
-        
+
         for i, scenario_index in enumerate(self._model.scenarios.combinations):
             self._memory[self.position, i] = self._param.value(timestep, scenario_index)
-        
+
         if timestep.index < self.timesteps:
             n = timestep.index + 1
         else:
             n = self.timesteps
-        
+
         self._data[<int>(timestep.index), :] = np.mean(self._memory[0:n, :], axis=0)
 
         self.position += 1
@@ -367,10 +367,19 @@ cdef class MeanFlowRecorder(NodeRecorder):
     name : str (optional)
         The name of the recorder
     """
-    def __init__(self, model, node, timesteps, name=None, **kwargs):
+    def __init__(self, model, node, timesteps=None, days=None, name=None, **kwargs):
         super(MeanFlowRecorder, self).__init__(model, node, name=name, **kwargs)
         self._model = model
-        self.timesteps = timesteps
+        if not timesteps and not days:
+            raise ValueError("Either `timesteps` or `days` must be specified.")
+        if timesteps:
+            self.timesteps = int(timesteps)
+        else:
+            self.timesteps = 0
+        if days:
+            self.days = int(days)
+        else:
+            self.days = 0
         self._data = None
 
     cpdef setup(self):
@@ -378,6 +387,10 @@ cdef class MeanFlowRecorder(NodeRecorder):
         self._memory = np.zeros([len(self._model.scenarios.combinations), self.timesteps])
         self.position = 0
         self._data = np.empty([len(self._model.timestepper), len(self._model.scenarios.combinations)])
+        if self.days:
+            self.timesteps = self.days // self._model.timestepper.delta.days
+        if self.timesteps == 0:
+            raise ValueError("Timesteps property of MeanFlowRecorder is less than 1.")
 
     cpdef int save(self) except -1:
         cdef double mean_flow
@@ -406,8 +419,15 @@ cdef class MeanFlowRecorder(NodeRecorder):
     def load(cls, model, data):
         name = data.get("name")
         node = model._get_node_from_ref(model, data["node"])
-        timesteps = int(data["timesteps"])
-        return cls(model, node, timesteps, name=name)
+        if "timesteps" in data:
+            timesteps = int(data["timesteps"])
+        else:
+            timesteps = None
+        if "days" in data:
+            days = int(data["days"])
+        else:
+            days = None
+        return cls(model, node, timesteps=timesteps, days=days, name=name)
 
 recorder_registry.add(MeanFlowRecorder)
 

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -342,6 +342,19 @@ def test_mean_flow_recorder(solver):
     for value, expected_value in zip(rec_mean.data, expected):
         assert_allclose(value, expected_value)
 
+def test_mean_flow_recorder_days(solver):
+    model = Model(solver=solver)
+    model.timestepper.delta = 7
+
+    inpt = Input(model, "input")
+    otpt = Output(model, "output")
+    inpt.connect(otpt)
+
+    rec_mean = MeanFlowRecorder(model, node=inpt, days=31)
+
+    model.setup()
+    assert(rec_mean.timesteps == 4)
+
 def test_mean_flow_recorder_json(solver):
     model = load_model("mean_flow_recorder.json", solver=solver)
 


### PR DESCRIPTION
This PR adds the MeanFlowRecorder.days attribute/kwarg, which lets the user specify the window in days rather than timesteps. The number of timesteps is calculated at runtime (rounding down if needed).

Closes #196.