### PR TITLE
Fixed a bug whereby named parameters were loaded twice in JSON.

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -8,6 +8,7 @@ from pywr import _core
 from pywr.parameters import *
 from pywr._core import BaseInput, BaseLink, BaseOutput, \
     StorageInput, StorageOutput, Timestep, ScenarioIndex
+from pywr.parameters._parameters import Parameter as BaseParameter
 from pywr._core import Node as BaseNode
 from pywr.recorders import load_recorder
 import os
@@ -488,8 +489,14 @@ class Model(object):
         # load parameters and recorders
         for name, rdata in model._recorders_to_load.items():
             load_recorder(model, rdata)
-        for name, pdata in model._parameters_to_load.items():
-            load_parameter(model, pdata)
+        while True:
+            try:
+                name, pdata = model._parameters_to_load.popitem()
+            except KeyError:
+                break
+            parameter = load_parameter(model, pdata, name)
+            if not isinstance(parameter, BaseParameter):
+                raise TypeError("Named parameters cannot be literal values. Use type \"constant\" instead.")
 
         # load the remaining nodes
         for node_name in list(nodes_to_load.keys()):

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -773,9 +773,8 @@ cdef class RecorderThresholdParameter(IndexParameter):
 
 parameter_registry.add(RecorderThresholdParameter)
 
-def load_parameter(model, data):
+def load_parameter(model, data, parameter_name=None):
     """Load a parameter from a dict"""
-    parameter_name = None
     if isinstance(data, basestring):
         # parameter is a reference
         try:
@@ -788,7 +787,7 @@ def load_parameter(model, data):
                 # the parameter requested hasn't been loaded yet - do it now
                 name = data
                 try:
-                    data = model._parameters_to_load[name]
+                    data = model._parameters_to_load.pop(name)
                 except KeyError:
                     raise KeyError("Unknown parameter: '{}'".format(data))
                 parameter = load_parameter(model, data)

--- a/tests/models/parameter_reference.json
+++ b/tests/models/parameter_reference.json
@@ -12,7 +12,20 @@
         {
             "name": "supply1",
             "type": "Input",
-            "max_flow": "supply_max_flow"
+            "max_flow": "supply_max_flow",
+            "cost": {
+                "type": "constant",
+                "values": 0.0
+            }
+        },
+        {
+            "name": "link1",
+            "type": "link",
+            "max_flow": {
+                "name": "link_max_flow",
+                "type": "constant",
+                "values": 9999
+            }
         },
         {
             "name": "demand1",
@@ -22,10 +35,17 @@
         }
     ],
     "parameters": {
-        "supply_max_flow": 125.0,
-        "demand_cost": -10
+        "supply_max_flow": {
+            "type": "constant",
+            "values": 125.0
+        },
+        "demand_cost": {
+            "type": "constant",
+            "values": -10
+        }
     },
     "edges": [
-        ["supply1", "demand1"]
+        ["supply1", "link1"],
+        ["link1", "demand1"]
     ]
 }

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -517,9 +517,16 @@ def test_parameter_df_json_load(model, tmpdir):
     p.setup(model)
 
 def test_simple_json_parameter_reference(solver):
+    # note that parameters in the "parameters" section cannot be literals
     model = load_model("parameter_reference.json")
-    assert(model.nodes["supply1"].max_flow == 125.0)
-    assert(model.nodes["demand1"].cost == -10)
+    max_flow = model.nodes["supply1"].max_flow
+    assert(isinstance(max_flow, ConstantParameter))
+    assert(max_flow.value(None, None) == 125.0)
+    cost = model.nodes["demand1"].cost
+    assert(isinstance(cost, ConstantParameter))
+    assert(cost.value(None, None) == -10.0)
+
+    assert(len(model.parameters) == 3) # only 3 parameters are named
 
 def test_with_a_better_name():
 


### PR DESCRIPTION
This PR fixes a bug whereby parameters named in the "parameters" section of a JSON document would be loaded into memory twice. i.e. model.parameters would have multiple entires with the same parameter, but different instances.

Also added a constraint that parameters named in the "parameters" section of the JSON document cannot be literals. This was a required side-effect of the fix.