### PR TITLE
Renamed ConstantParameter `values` to `value` in JSON

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -153,6 +153,13 @@ cdef class ConstantParameter(Parameter):
 
     cpdef double[:] upper_bounds(self):
         return self._upper_bounds
+
+    @classmethod
+    def load(cls, model, data):
+        value = data.pop("value")
+        parameter = cls(value, **data)
+        return parameter
+
 parameter_registry.add(ConstantParameter)
 
 

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -156,7 +156,10 @@ cdef class ConstantParameter(Parameter):
 
     @classmethod
     def load(cls, model, data):
-        value = data.pop("value")
+        # accept both "value" and "values"
+        value = data.pop("values", None)
+        if value is None:
+            value = data.pop("value")
         parameter = cls(value, **data)
         return parameter
 

--- a/tests/models/demand_saving2.json
+++ b/tests/models/demand_saving2.json
@@ -41,7 +41,7 @@
     "parameters": {
         "demand_baseline": {
             "type": "constant",
-            "values": 50
+            "value": 50
         },
         "demand_profile": {
             "comment": "Monthly demand profile as a factor around the mean demand",
@@ -50,11 +50,11 @@
         },
         "level1": {
             "type": "constant",
-            "values": 0.8
+            "value": 0.8
         },
         "level2": {
             "type": "constant",
-            "values": 0.5
+            "value": 0.5
         },
         "demand_saving_level": {
             "comment": "The demand saving level",
@@ -72,7 +72,7 @@
             "params": [
                 {
                     "type": "constant",
-                    "values": 1.0
+                    "value": 1.0
                 },
                 {
                     "type": "monthlyprofile",

--- a/tests/models/extra2.json
+++ b/tests/models/extra2.json
@@ -12,7 +12,7 @@
     "parameters": {
         "supply2_max_flow": {
             "type": "constant",
-            "values": 50
+            "value": 50
         }
     }
 }

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -91,7 +91,7 @@ class TestPiecewiseControlCurveParameter:
             "control_curves": [
                 {
                     "type": "constant",
-                    "values": 0.8
+                    "value": 0.8
                 },
                 {
                     "type": "monthlyprofile",
@@ -101,15 +101,15 @@ class TestPiecewiseControlCurveParameter:
             "parameters": [
                 {
                     "type": "constant",
-                    "values": 1.0,
+                    "value": 1.0,
                 },
                 {
                     "type": "constant",
-                    "values": 0.7
+                    "value": 0.7
                 },
                 {
                     "type": "constant",
-                    "values": 0.4
+                    "value": 0.4
                 }
             ]
         }

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -252,7 +252,7 @@ class TestAggregatedParameter:
             "parameters": [
                 {
                     "type": "constant",
-                    "values": 0.8
+                    "value": 0.8
                 },
                 {
                     "type": "monthlyprofile",

--- a/tests/test_parameters_cache.py
+++ b/tests/test_parameters_cache.py
@@ -59,7 +59,7 @@ def test_load_cache_both(simple_model):
     data = {
         "cached": "both",
         "type": "constant",
-        "values": 15.0
+        "value": 15.0
     }
 
     inpt = model.nodes["input"]


### PR DESCRIPTION
This PR renames the "values" argument to `ConstantParameter` in JSON to "value". This makes more sense to me, given that the value is singular. Previously the name was inherited from `Parameter`.

This will break a lot of existing models, although the fix is trivial. I don't know if we need to start thinking about version numbers...

An altenative approach is to support both forms ("values" AND "value").