### PR TITLE
Fixed bug in MeanFlowRecorder related to days->timesteps

### DIFF
--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -552,13 +552,13 @@ cdef class MeanFlowRecorder(NodeRecorder):
 
     cpdef setup(self):
         super(MeanFlowRecorder, self).setup()
-        self._memory = np.zeros([len(self._model.scenarios.combinations), self.timesteps])
         self.position = 0
         self._data = np.empty([len(self._model.timestepper), len(self._model.scenarios.combinations)])
         if self.days:
             self.timesteps = self.days // self._model.timestepper.delta.days
         if self.timesteps == 0:
             raise ValueError("Timesteps property of MeanFlowRecorder is less than 1.")
+        self._memory = np.zeros([len(self._model.scenarios.combinations), self.timesteps])
 
     cpdef int save(self) except -1:
         cdef double mean_flow

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -361,7 +361,7 @@ def test_mean_flow_recorder_days(solver):
 
     rec_mean = MeanFlowRecorder(model, node=inpt, days=31)
 
-    model.setup()
+    model.run()
     assert(rec_mean.timesteps == 4)
 
 def test_mean_flow_recorder_json(solver):


### PR DESCRIPTION
Fixed a bug in MeanFlowRecorder in the conversion of days to timesteps.

Need to add a test for this to prevent regressions.