### PR TITLE
parameter_registry is now a dict

### DIFF
--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -72,7 +72,7 @@ cdef class BaseControlCurveParameter(Parameter):
         return node
 
 
-parameter_registry.add(BaseControlCurveParameter)
+BaseControlCurveParameter.register()
 
 
 cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
@@ -174,7 +174,7 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
         parameter = cls(storage_node, control_curves, values)
         return parameter
 
-parameter_registry.add(ControlCurveInterpolatedParameter)
+ControlCurveInterpolatedParameter.register()
 
 cdef class ControlCurveIndexParameter(IndexParameter):
     """Multiple control curve holder which returns an index not a value
@@ -238,4 +238,4 @@ cdef class ControlCurveIndexParameter(IndexParameter):
         storage_node = model._get_node_from_ref(model, data["storage_node"])
         control_curves = [load_parameter(model, data) for data in data["control_curves"]]
         return cls(storage_node, control_curves)
-parameter_registry.add(ControlCurveIndexParameter)
+ControlCurveIndexParameter.register()

--- a/pywr/parameters/control_curves.py
+++ b/pywr/parameters/control_curves.py
@@ -147,7 +147,7 @@ class ControlCurveParameter(BaseControlCurveParameter):
     def upper_bounds(self):
         return self._upper_bounds
 
-parameter_registry.add(ControlCurveParameter)
+ControlCurveParameter.register()
 
 
 class AbstractProfileControlCurveParameter(BaseControlCurveParameter):
@@ -265,7 +265,7 @@ class MonthlyProfileControlCurveParameter(AbstractProfileControlCurveParameter):
     def _profile_index(self, ts, scenario_index):
         return ts.datetime.month - 1
 
-parameter_registry.add(MonthlyProfileControlCurveParameter)
+MonthlyProfileControlCurveParameter.register()
 
 
 class DailyProfileControlCurveParameter(AbstractProfileControlCurveParameter):
@@ -300,4 +300,4 @@ class DailyProfileControlCurveParameter(AbstractProfileControlCurveParameter):
     def _profile_index(self, ts, scenario_index):
         return ts.datetime.dayofyear - 1
 
-parameter_registry.add(DailyProfileControlCurveParameter)
+DailyProfileControlCurveParameter.register()

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -26,7 +26,7 @@ class FunctionParameter(Parameter):
 
     def value(self, ts, scenario_index):
         return self._func(self._parent, ts, scenario_index)
-parameter_registry.add(FunctionParameter)
+FunctionParameter.register()
 
 
 class MonthlyProfileParameter(Parameter):
@@ -50,7 +50,7 @@ class MonthlyProfileParameter(Parameter):
 
     def upper_bounds(self):
         return self._upper_bounds
-parameter_registry.add(MonthlyProfileParameter)
+MonthlyProfileParameter.register()
 
 
 class ScaledProfileParameter(Parameter):
@@ -70,7 +70,7 @@ class ScaledProfileParameter(Parameter):
     def value(self, ts, si):
         p = self.profile.value(ts, si)
         return self.scale * p
-parameter_registry.add(ScaledProfileParameter)
+ScaledProfileParameter.register()
 
 
 def align_and_resample_dataframe(df, datetime_index):
@@ -141,7 +141,7 @@ class DataFrameParameter(Parameter):
 
     def value(self, ts, scenario_index):
         return self._param.value(ts, scenario_index)
-parameter_registry.add(DataFrameParameter)
+DataFrameParameter.register()
 
 
 class InterpolatedLevelParameter(Parameter):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -618,3 +618,26 @@ def test_constant_from_multiindex_df(solver):
 
     np.testing.assert_allclose(model.nodes['demand1'].max_flow.value(ts, si), 10.0)
     np.testing.assert_allclose(model.nodes['demand1'].cost.value(ts, si), -100.0)
+
+def test_parameter_registry_overwrite(model):
+    # define a parameter
+    class NewParameter(BaseParameter):
+        DATA = 42
+    NewParameter.register()
+    
+    # re-define a parameter
+    class NewParameter(IndexParameter):
+        DATA = 43
+        def __init__(self, *args, **kwargs):
+            IndexParameter.__init__(self)
+    NewParameter.register()
+    
+    data = {
+        "type": "new",
+        "values": 0
+    }
+    parameter = load_parameter(model, data)
+
+    # parameter is instance of new class, not old class
+    assert(isinstance(parameter, NewParameter))
+    assert(parameter.DATA == 43)


### PR DESCRIPTION
This PR changes `parameter_registry` from a set to a dict in order to close #215.

Additionally, a `Parameter.register()` method is added to manage the registry, closing #159.