### PR TITLE
Added warning for IE about d3 graph arrows. Closes #227.

### DIFF
--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -5,6 +5,9 @@ var ua = window.navigator.userAgent;
 var browser;
 if ((ua.indexOf("MSIE") != -1) || (ua.indexOf("Trident") != -1)) {
     browser = "ie";
+    var p = d3.selectAll(element).append("p");
+    p.html("Warning: Internet Explorer doesn't support directional arrows on the graph.");
+    p.style("color", "#d00");
 } else {
     browser = "something better than ie";
 }


### PR DESCRIPTION
Added warning for IE about d3 graph arrows. Closes #227.

![ie_warning](https://cloud.githubusercontent.com/assets/3883947/18916211/8f6ed344-858b-11e6-9e11-0802b157c117.png)
