### PR TITLE
Improvements to TablesRecorder

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -346,8 +346,6 @@ class Model(object):
     def nodes(self):
         """Returns a model node iterator"""
         return NodeIterator(self)
-    # support for old API
-    node = nodes
 
     def edges(self):
         """Returns a list of Edges in the model

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -36,7 +36,7 @@ class CSVRecorder(Recorder):
         """
 
         if self.nodes is None:
-            self.node_names = sorted(self.model.node.keys())
+            self.node_names = sorted(self.model.nodes.keys())
         else:
             self.node_names = sorted(n.name for n in self.nodes)
 
@@ -57,7 +57,7 @@ class CSVRecorder(Recorder):
 
         values = [self.model.timestepper.current.datetime.isoformat()]
         for node_name in self.node_names:
-            node = self.model.node[node_name]
+            node = self.model.nodes[node_name]
             if isinstance(node, Node):
                 values.append(node.flow[self.scenario_index])
             elif isinstance(node, Storage):
@@ -167,7 +167,7 @@ class TablesRecorder(Recorder):
 
         # Default to all nodes if None given.
         if self.nodes is None:
-            nodes = [(self.where, n) for n in self.model.node.values()]
+            nodes = [(self.where, n) for n in self.model.nodes.values()]
         else:
             nodes = []
             for n in self.nodes:
@@ -233,4 +233,3 @@ class TablesRecorder(Recorder):
             else:
                 raise ValueError("Unrecognised Node type '{}' for TablesRecorder".format(type(node)))
 recorder_registry.add(TablesRecorder)
-

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -113,6 +113,12 @@ class TablesRecorder(Recorder):
 
         h5opened = False
         if isinstance(h5file, basestring):
+            # HACK Python 2 workaround
+            # Note sure how else to deal with str / unicode requirements in pytables
+            # See this issue: https://github.com/PyTables/PyTables/issues/522
+            import sys
+            if sys.version_info[0] == 2 and 'complib' in filter_kwds:
+                filter_kwds['complib'] = filter_kwds['complib'].encode()
             filters = tables.Filters(**filter_kwds)
             h5fh = tables.open_file(h5file, mode=mode, filters=filters)
             h5opened = True

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -117,15 +117,27 @@ class TablesRecorder(Recorder):
         if self.nodes is None:
             nodes = self.model.node.values()
         else:
-            nodes = self.nodes
+            nodes = []
+            for n in self.nodes:
+                # Accept a str, and lookup node by name instead.
+                if isinstance(n, basestring):
+                    nodes.append(self.model.nodes[n])
+                else:
+                    # Otherwise assume it is a node object
+                    nodes.append(n)
 
         nodes = list(nodes)
 
         if self.parameters is not None:
             for p in self.parameters:
-                if p.name is None:
+                if isinstance(p, basestring):
+                    param = self.model.parameters[p]
+                else:
+                    param = p
+
+                if param.name is None:
                     raise ValueError('Can only record named Parameter objects.')
-                nodes.append(p)
+                nodes.append(param)
 
         for node in nodes:
             if isinstance(node, IndexParameter):

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -125,14 +125,14 @@ class TablesRecorder(Recorder):
         """
         Save data to the tables
         """
-        from pywr._core import Node, Storage
+        from pywr._core import AbstractNode, AbstractStorage
         idx = self.model.timestepper.current.index
 
         for node, ca in self._arrays.items():
-            if isinstance(node, Node):
-                ca[idx, :] = node.flow
-            elif isinstance(node, Storage):
+            if isinstance(node, AbstractStorage):
                 ca[idx, :] = node.volume
+            elif isinstance(node, AbstractNode):
+                ca[idx, :] = node.flow
             else:
                 raise ValueError("Unrecognised Node type '{}' for TablesRecorder".format(type(node)))
 recorder_registry.add(TablesRecorder)

--- a/tests/models/demand_saving_with_tables_recorder.json
+++ b/tests/models/demand_saving_with_tables_recorder.json
@@ -1,0 +1,155 @@
+{
+    "metadata": {
+        "title": "Demand Saving",
+        "description": "Demand saving using an IndexedArrayParameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "type": "catchment",
+            "name": "Inflow",
+            "flow": 0.0
+        },
+        {
+            "type": "reservoir",
+            "name": "Reservoir",
+            "max_volume": 1000,
+            "initial_volume": 1000
+        },
+        {
+            "type": "output",
+            "name": "Spill",
+            "cost": 10
+        },
+        {
+            "comment": "The only demand in the model",
+            "type": "output",
+            "name": "Demand",
+            "max_flow": "demand_max_flow",
+            "cost": -500
+        }
+    ],
+    "edges": [
+        ["Inflow", "Reservoir"],
+        ["Reservoir", "Demand"],
+        ["Reservoir", "Spill"]
+    ],
+    "parameters": {
+        "demand_baseline": {
+            "type": "constant",
+            "value": 50
+        },
+        "demand_profile": {
+            "comment": "Monthly demand profile as a factor around the mean demand",
+            "type": "monthlyprofile",
+            "values": [
+                0.9,
+                0.9,
+                0.9,
+                0.9,
+                1.2,
+                1.2,
+                1.2,
+                1.2,
+                0.9,
+                0.9,
+                0.9,
+                0.9
+            ]
+        },
+        "level1": {
+            "type": "constant",
+            "value": 0.8
+        },
+        "level2": {
+            "type": "constant",
+            "value": 0.5
+        },
+        "demand_saving_level": {
+            "comment": "The demand saving level",
+            "type": "controlcurveindex",
+            "storage_node": "Reservoir",
+            "control_curves": [
+                "level1",
+                "level2"
+            ]
+        },
+        "demand_saving_factor": {
+            "comment": "Demand saving as a factor of the base demand",
+            "type": "indexedarray",
+            "index_parameter": "demand_saving_level",
+            "params": [
+                {
+                    "type": "constant",
+                    "value": 1.0
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.90,
+                        0.90,
+                        0.90,
+                        0.90,
+                        0.95,
+                        0.95,
+                        0.95,
+                        0.95
+                    ]
+                },
+                {
+                    "type": "monthlyprofile",
+                    "values": [
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.4,
+                        0.4,
+                        0.4,
+                        0.4,
+                        0.5,
+                        0.5,
+                        0.5,
+                        0.5
+                    ]
+                }
+            ]
+        },
+        "demand_max_flow": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "demand_baseline",
+                "demand_profile",
+                "demand_saving_factor"
+            ]
+        }
+    },
+    "recorders": {
+        "database": {
+            "type": "TablesRecorder",
+            "url": "output.h5",
+            "nodes": [
+                ["/outputs/demand", "Demand"],
+                ["/storage/reservoir", "Reservoir"]
+            ],
+            "parameters": [
+                ["/parameters/demand_saving_level", "demand_saving_level"]
+            ],
+            "mode": "w",
+            "filter_kwds": {
+                "complevel": 5,
+                "complib": "zlib"
+            }
+        }
+    }
+}

--- a/tests/test_aggregated_nodes.py
+++ b/tests/test_aggregated_nodes.py
@@ -9,8 +9,8 @@ def test_aggregated_storage(three_storage_model):
     """ Test `AggregatedStorage` correct sums multiple `Storage`. """
     m = three_storage_model
 
-    agg_stg = m.node['Total Storage']
-    stgs = [m.node['Storage {}'.format(num)] for num in range(3)]
+    agg_stg = m.nodes['Total Storage']
+    stgs = [m.nodes['Storage {}'.format(num)] for num in range(3)]
     # Check initial volume is aggregated correclty
     np.testing.assert_allclose(agg_stg.initial_volume, np.sum(s.initial_volume for s in stgs))
 
@@ -39,10 +39,10 @@ def test_aggregated_storage_scenarios(three_storage_model):
     m = three_storage_model
     sc = Scenario(m, 'A', size=5)
 
-    agg_stg = m.node['Total Storage']
-    stgs = [m.node['Storage {}'.format(num)] for num in range(3)]
+    agg_stg = m.nodes['Total Storage']
+    stgs = [m.nodes['Storage {}'.format(num)] for num in range(3)]
     # Setup scenario
-    inpt1 = m.node['Input 1'].max_flow = ConstantScenarioParameter(sc, range(sc.size))
+    inpt1 = m.nodes['Input 1'].max_flow = ConstantScenarioParameter(sc, range(sc.size))
 
     m.setup()
     m.step()
@@ -65,8 +65,8 @@ def test_aggregated_storage_scenarios(three_storage_model):
 def test_aggregated_storage_connectivity(three_storage_model):
     """ Test `AggregatedStorage` has the correct attributes. """
     m = three_storage_model
-    agg_stg = m.node['Total Storage']
-    inpt = m.node['Input 1']
+    agg_stg = m.nodes['Total Storage']
+    inpt = m.nodes['Input 1']
 
     with pytest.raises(AttributeError):
         agg_stg.connect()
@@ -79,7 +79,7 @@ def test_aggregated_storage_connectivity(three_storage_model):
 def test_aggregated_storage_attributes(three_storage_model):
     """ Test `AggregatedStorage` has the correct attributes. """
     m = three_storage_model
-    agg_stg = m.node['Total Storage']
+    agg_stg = m.nodes['Total Storage']
 
     with pytest.raises(AttributeError):
         agg_stg.get_max_volume()
@@ -128,8 +128,8 @@ def test_aggregated_node(three_storage_model):
     """ Test `AggregatedNode` correct sums multiple `Node`. """
     m = three_storage_model
 
-    agg_otpt = m.node['Total Output']
-    otpts = [m.node['Output {}'.format(num)] for num in range(3)]
+    agg_otpt = m.nodes['Total Output']
+    otpts = [m.nodes['Output {}'.format(num)] for num in range(3)]
 
     m.setup()
     m.step()
@@ -150,10 +150,10 @@ def test_aggregated_node_scenarios(three_storage_model):
     m = three_storage_model
     sc = Scenario(m, 'A', size=5)
 
-    agg_otpt = m.node['Total Output']
-    otpts = [m.node['Output {}'.format(num)] for num in range(3)]
+    agg_otpt = m.nodes['Total Output']
+    otpts = [m.nodes['Output {}'.format(num)] for num in range(3)]
     # Setup scenario
-    inpt1 = m.node['Input 1'].max_flow = ConstantScenarioParameter(sc, range(sc.size))
+    inpt1 = m.nodes['Input 1'].max_flow = ConstantScenarioParameter(sc, range(sc.size))
 
     m.setup()
     m.step()
@@ -170,8 +170,8 @@ def test_aggregated_node_scenarios(three_storage_model):
 def test_aggregated_node_connectivity(three_storage_model):
     """ Test `AggregatedStorage` has the correct attributes. """
     m = three_storage_model
-    agg_otpt = m.node['Total Output']
-    inpt = m.node['Input 1']
+    agg_otpt = m.nodes['Total Output']
+    inpt = m.nodes['Input 1']
 
     with pytest.raises(AttributeError):
         agg_otpt.connect()
@@ -184,7 +184,7 @@ def test_aggregated_node_connectivity(three_storage_model):
 def test_aggregated_node_attributes(three_storage_model):
     """ Test `AggregatedStorage` has the correct attributes. """
     m = three_storage_model
-    agg_otpt = m.node['Total Output']
+    agg_otpt = m.nodes['Total Output']
 
     with pytest.raises(AttributeError):
         agg_otpt.get_max_volume()

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -23,9 +23,9 @@ def test_linear_model(simple_linear_model, in_flow, out_flow, benefit):
     Test the simple_linear_model with different basic input and output values
     """
 
-    simple_linear_model.node["Input"].max_flow = in_flow
-    simple_linear_model.node["Output"].min_flow = out_flow
-    simple_linear_model.node["Output"].cost = -benefit
+    simple_linear_model.nodes["Input"].max_flow = in_flow
+    simple_linear_model.nodes["Output"].min_flow = out_flow
+    simple_linear_model.nodes["Output"].cost = -benefit
 
     expected_sent = in_flow if benefit > 1.0 else out_flow
 
@@ -230,13 +230,13 @@ def test_simple_linear_inline_model(simple_linear_inline_model, in_flow_1, out_f
     Test the test_simple_linear_inline_model with different flow constraints
     """
     model = simple_linear_inline_model
-    model.node["Input 0"].max_flow = 10.0
-    model.node["Input 1"].max_flow = in_flow_1
-    model.node["Link"].max_flow = link_flow
-    model.node["Output 0"].max_flow = out_flow_0
-    model.node["Input 1"].cost = 1.0
-    model.node["Output 0"].cost = -10.0
-    model.node["Output 1"].cost = -5.0
+    model.nodes["Input 0"].max_flow = 10.0
+    model.nodes["Input 1"].max_flow = in_flow_1
+    model.nodes["Link"].max_flow = link_flow
+    model.nodes["Output 0"].max_flow = out_flow_0
+    model.nodes["Input 1"].cost = 1.0
+    model.nodes["Output 0"].cost = -10.0
+    model.nodes["Output 1"].cost = -5.0
 
     expected_sent = min(link_flow, 10+in_flow_1)
 
@@ -270,8 +270,8 @@ def bidirectional_model(request, solver):
         lnk.connect(otpt)
 
     # Create bidirectional link (i.e. a cycle)
-    model.node['Link 0'].connect(model.node['Link 1'])
-    model.node['Link 1'].connect(model.node['Link 0'])
+    model.nodes['Link 0'].connect(model.nodes['Link 1'])
+    model.nodes['Link 1'].connect(model.nodes['Link 0'])
 
     return model
 
@@ -281,14 +281,14 @@ def test_bidirectional_model(bidirectional_model):
     Test the simple_linear_model with different basic input and output values
     """
     model = bidirectional_model
-    model.node["Input 0"].max_flow = 10.0
-    model.node["Input 1"].max_flow = 10.0
-    model.node["Output 0"].max_flow = 10.0
-    model.node["Output 1"].max_flow = 15.0
-    model.node["Output 0"].cost = -5.0
-    model.node["Output 1"].cost = -10.0
-    model.node["Link 0"].cost = 1.0
-    model.node["Link 1"].cost = 1.0
+    model.nodes["Input 0"].max_flow = 10.0
+    model.nodes["Input 1"].max_flow = 10.0
+    model.nodes["Output 0"].max_flow = 10.0
+    model.nodes["Output 1"].max_flow = 15.0
+    model.nodes["Output 0"].cost = -5.0
+    model.nodes["Output 1"].cost = -10.0
+    model.nodes["Link 0"].cost = 1.0
+    model.nodes["Link 1"].cost = 1.0
 
     expected_node_results = {
         "Input 0": 10.0,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,16 +20,16 @@ def test_names(solver):
 
     node1 = Input(model, name='A')
     node2 = Output(model, name='B')
-    assert(model.node['A'] is node1)
-    assert(model.node['B'] is node2)
+    assert(model.nodes['A'] is node1)
+    assert(model.nodes['B'] is node2)
 
     nodes = sorted(model.nodes(), key=lambda node: node.name)
     assert(nodes == [node1, node2])
 
     # rename node
     node1.name = 'C'
-    assert(model.node['C'] is node1)
-    assert('A' not in model.node)
+    assert(model.nodes['C'] is node1)
+    assert('A' not in model.nodes)
 
     # attempt name collision (via rename)
     with pytest.raises(ValueError):
@@ -38,7 +38,7 @@ def test_names(solver):
     # attempt name collision (via new)
     with pytest.raises(ValueError):
         node3 = Input(model, name='C')
-    assert(len(model.node) == 2)  # node3 not added to graph
+    assert(len(model.nodes) == 2)  # node3 not added to graph
 
     # attempt to create a node without a name
     with pytest.raises(TypeError):

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -29,11 +29,11 @@ def test_simple_model_with_annual_licence(simple_linear_model):
     si = ScenarioIndex(0, np.array([0], dtype=np.int32))
 
     annual_total = 365
-    lic = AnnualLicense(m.node["Input"], annual_total)
+    lic = AnnualLicense(m.nodes["Input"], annual_total)
     # Apply licence to the model
-    m.node["Input"].max_flow = lic
-    m.node["Output"].max_flow = 10.0
-    m.node["Output"].cost = -10.0
+    m.nodes["Input"].max_flow = lic
+    m.nodes["Output"].max_flow = 10.0
+    m.nodes["Output"].cost = -10.0
     m.setup()
 
     # timestepper.current is the next time step (because model has not begun)
@@ -42,24 +42,24 @@ def test_simple_model_with_annual_licence(simple_linear_model):
 
     # Licence is a hard constraint of 1.0
     # timestepper.current is now end of the first day
-    assert_allclose(m.node["Output"].flow, 1.0)
+    assert_allclose(m.nodes["Output"].flow, 1.0)
     # Check the constraint for the next timestep.
     assert_allclose(lic.value(m.timestepper._next, si), 1.0)
 
     # Now constrain the demand so that licence is not fully used
-    m.node["Output"].max_flow = 0.5
+    m.nodes["Output"].max_flow = 0.5
     m.step()
 
-    assert_allclose(m.node["Output"].flow, 0.5)
+    assert_allclose(m.nodes["Output"].flow, 0.5)
     # Check the constraint for the next timestep. The available amount should now be larger
     # due to the reduced use
     remaining = (annual_total-1.5)
     assert_allclose(lic.value(m.timestepper._next, si), remaining / (365 - 2))
 
     # Unconstrain the demand
-    m.node["Output"].max_flow = 10.0
+    m.nodes["Output"].max_flow = 10.0
     m.step()
-    assert_allclose(m.node["Output"].flow, remaining / (365 - 2))
+    assert_allclose(m.nodes["Output"].flow, remaining / (365 - 2))
     # Licence should now be on track for an expected value of 1.0
     remaining -= remaining / (365 - 2)
     assert_allclose(lic.value(m.timestepper._next, si), remaining / (365 - 3))
@@ -77,17 +77,17 @@ def test_simple_model_with_annual_licence_multi_year(simple_linear_model):
     m.timestepper.delta = datetime.timedelta(30)
 
     annual_total = 365.0
-    lic = AnnualLicense(m.node["Input"], annual_total)
+    lic = AnnualLicense(m.nodes["Input"], annual_total)
     # Apply licence to the model
-    m.node["Input"].max_flow = lic
-    m.node["Output"].max_flow = 10.0
-    m.node["Output"].cost = -10.0
+    m.nodes["Input"].max_flow = lic
+    m.nodes["Output"].max_flow = 10.0
+    m.nodes["Output"].cost = -10.0
     m.setup()
 
     for i in range(len(m.timestepper)):
         m.step()
         days_in_year = 365 + int(calendar.isleap(m.timestepper.current.datetime.year))
-        assert_allclose(m.node["Output"].flow, annual_total/days_in_year)
+        assert_allclose(m.nodes["Output"].flow, annual_total/days_in_year)
 
 
 def test_simple_model_with_exponential_license(simple_linear_model):
@@ -96,11 +96,11 @@ def test_simple_model_with_exponential_license(simple_linear_model):
 
     annual_total = 365
     # Expoential licence with max_value of e should give a hard constraint of 1.0 when on track
-    lic = AnnualExponentialLicense(m.node["Input"], annual_total, np.e)
+    lic = AnnualExponentialLicense(m.nodes["Input"], annual_total, np.e)
     # Apply licence to the model
-    m.node["Input"].max_flow = lic
-    m.node["Output"].max_flow = 10.0
-    m.node["Output"].cost = -10.0
+    m.nodes["Input"].max_flow = lic
+    m.nodes["Output"].max_flow = 10.0
+    m.nodes["Output"].cost = -10.0
     m.setup()
 
     # timestepper.current is the next time step (because model has not begun)
@@ -109,24 +109,24 @@ def test_simple_model_with_exponential_license(simple_linear_model):
 
     # Licence is a hard constraint of 1.0
     # timestepper.current is now end of the first day
-    assert_allclose(m.node["Output"].flow, 1.0)
+    assert_allclose(m.nodes["Output"].flow, 1.0)
     # Check the constraint for the next timestep.
     assert_allclose(lic.value(m.timestepper._next, si), 1.0)
 
     # Now constrain the demand so that licence is not fully used
-    m.node["Output"].max_flow = 0.5
+    m.nodes["Output"].max_flow = 0.5
     m.step()
 
-    assert_allclose(m.node["Output"].flow, 0.5)
+    assert_allclose(m.nodes["Output"].flow, 0.5)
     # Check the constraint for the next timestep. The available amount should now be larger
     # due to the reduced use
     remaining = (annual_total-1.5)
     assert_allclose(lic.value(m.timestepper._next, si), np.exp(-remaining / (365 - 2) + 1))
 
     # Unconstrain the demand
-    m.node["Output"].max_flow = 10.0
+    m.nodes["Output"].max_flow = 10.0
     m.step()
-    assert_allclose(m.node["Output"].flow, np.exp(-remaining / (365 - 2) + 1))
+    assert_allclose(m.nodes["Output"].flow, np.exp(-remaining / (365 - 2) + 1))
     # Licence should now be on track for an expected value of 1.0
     remaining -= np.exp(-remaining / (365 - 2) + 1)
     assert_allclose(lic.value(m.timestepper._next, si), np.exp(-remaining / (365 - 3) + 1))
@@ -138,11 +138,11 @@ def test_simple_model_with_hyperbola_license(simple_linear_model):
 
     annual_total = 365
     # Expoential licence with max_value of e should give a hard constraint of 1.0 when on track
-    lic = AnnualHyperbolaLicense(m.node["Input"], annual_total, 1.0)
+    lic = AnnualHyperbolaLicense(m.nodes["Input"], annual_total, 1.0)
     # Apply licence to the model
-    m.node["Input"].max_flow = lic
-    m.node["Output"].max_flow = 10.0
-    m.node["Output"].cost = -10.0
+    m.nodes["Input"].max_flow = lic
+    m.nodes["Output"].max_flow = 10.0
+    m.nodes["Output"].cost = -10.0
     m.setup()
 
     # timestepper.current is the next time step (because model has not begun)
@@ -151,24 +151,24 @@ def test_simple_model_with_hyperbola_license(simple_linear_model):
 
     # Licence is a hard constraint of 1.0
     # timestepper.current is now end of the first day
-    assert_allclose(m.node["Output"].flow, 1.0)
+    assert_allclose(m.nodes["Output"].flow, 1.0)
     # Check the constraint for the next timestep.
     assert_allclose(lic.value(m.timestepper._next, si), 1.0)
 
     # Now constrain the demand so that licence is not fully used
-    m.node["Output"].max_flow = 0.5
+    m.nodes["Output"].max_flow = 0.5
     m.step()
 
-    assert_allclose(m.node["Output"].flow, 0.5)
+    assert_allclose(m.nodes["Output"].flow, 0.5)
     # Check the constraint for the next timestep. The available amount should now be larger
     # due to the reduced use
     remaining = (annual_total-1.5)
     assert_allclose(lic.value(m.timestepper._next, si), (365 - 2) / remaining)
 
     # Unconstrain the demand
-    m.node["Output"].max_flow = 10.0
+    m.nodes["Output"].max_flow = 10.0
     m.step()
-    assert_allclose(m.node["Output"].flow, (365 - 2) / remaining)
+    assert_allclose(m.nodes["Output"].flow, (365 - 2) / remaining)
     # Licence should now be on track for an expected value of 1.0
     remaining -= (365 - 2) / remaining
     assert_allclose(lic.value(m.timestepper._next, si), (365 - 3) / remaining)

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -294,6 +294,40 @@ class TestTablesRecorder:
                 else:
                     np.testing.assert_allclose(ca, 10.0)
 
+    def test_nodes_with_str(self, simple_linear_model, tmpdir):
+        """
+        Test the TablesRecorder
+
+        """
+        from pywr.parameters import ConstantParameter
+
+        model = simple_linear_model
+        otpt = model.node['Output']
+        inpt = model.node['Input']
+        agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
+        p = ConstantParameter(10.0, name='max_flow')
+        inpt.max_flow = p
+
+        otpt.cost = -2.0
+
+        h5file = tmpdir.join('output.h5')
+        import tables
+        with tables.open_file(str(h5file), 'w') as h5f:
+            rec = TablesRecorder(model, h5f.root, nodes=['Output', 'Input', 'Sum'],
+                                 parameters=[p, ])
+
+            model.run()
+
+            for node_name in ['Output', 'Input', 'Sum', 'max_flow']:
+                ca = h5f.get_node('/', node_name)
+                assert ca.shape == (365, 1)
+                if node_name == 'Sum':
+                    np.testing.assert_allclose(ca, 20.0)
+                else:
+                    np.testing.assert_allclose(ca, 10.0)
+
+
+
 
 def test_total_deficit_node_recorder(simple_linear_model):
     """

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -230,33 +230,37 @@ def test_csv_recorder(simple_linear_model, tmpdir):
             assert expected == actual
 
 
-def test_hdf5_recorder(simple_linear_model, tmpdir):
-    """
-    Test the TablesRecorder
+class TestTablesRecorder:
 
-    """
-    model = simple_linear_model
-    otpt = model.node['Output']
-    inpt = model.node['Input']
-    agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
+    def test_nodes(self, simple_linear_model, tmpdir):
+        """
+        Test the TablesRecorder
 
-    inpt.max_flow = 10.0
-    otpt.cost = -2.0
+        """
+        model = simple_linear_model
+        otpt = model.node['Output']
+        inpt = model.node['Input']
+        agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
 
-    h5file = tmpdir.join('output.h5')
-    import tables
-    with tables.open_file(str(h5file), 'w') as h5f:
-        rec = TablesRecorder(model, h5f.root)
+        inpt.max_flow = 10.0
+        otpt.cost = -2.0
 
-        model.run()
+        h5file = tmpdir.join('output.h5')
+        import tables
+        with tables.open_file(str(h5file), 'w') as h5f:
+            rec = TablesRecorder(model, h5f.root)
 
-        for node_name in model.node.keys():
-            ca = h5f.get_node('/', node_name)
-            assert ca.shape == (365, 1)
-            if node_name == 'Sum':
-                np.testing.assert_allclose(ca, 20.0)
-            else:
-                np.testing.assert_allclose(ca, 10.0)
+            model.run()
+
+            for node_name in model.node.keys():
+                ca = h5f.get_node('/', node_name)
+                assert ca.shape == (365, 1)
+                if node_name == 'Sum':
+                    np.testing.assert_allclose(ca, 20.0)
+                else:
+                    np.testing.assert_allclose(ca, 10.0)
+
+
 
 
 def test_total_deficit_node_recorder(simple_linear_model):

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -24,9 +24,9 @@ def test_numpy_recorder(simple_linear_model):
     Test the NumpyArrayNodeRecorder
     """
     model = simple_linear_model
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
 
-    model.node['Input'].max_flow = 10.0
+    model.nodes['Input'].max_flow = 10.0
     otpt.cost = -2.0
     rec = NumpyArrayNodeRecorder(model, otpt)
 
@@ -54,7 +54,7 @@ def test_numpy_storage_recorder(simple_storage_model):
     """
     model = simple_storage_model
 
-    res = model.node['Storage']
+    res = model.nodes['Storage']
 
     rec = NumpyArrayStorageRecorder(model, res)
 
@@ -79,13 +79,13 @@ def test_numpy_parameter_recorder(simple_linear_model):
     # using leap year simplifies tests
     model.timestepper.start = pandas.to_datetime("2016-01-01")
     model.timestepper.end = pandas.to_datetime("2016-12-31")
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
 
     p = DailyProfileParameter(np.arange(366, dtype=np.float64), )
     p.name = 'daily profile'
-    model.node['Input'].max_flow = p
+    model.nodes['Input'].max_flow = p
     otpt.cost = -2.0
-    rec = NumpyArrayParameterRecorder(model, model.node['Input'].max_flow)
+    rec = NumpyArrayParameterRecorder(model, model.nodes['Input'].max_flow)
 
     # test retrieval of recorder
     assert model.recorders['numpyarrayparameterrecorder.daily profile'] == rec
@@ -108,7 +108,7 @@ def test_numpy_index_parameter_recorder(simple_storage_model):
 
     model = simple_storage_model
 
-    res = model.node['Storage']
+    res = model.nodes['Storage']
 
     p = ControlCurveIndexParameter(res, [5.0/20.0, 2.5/20.0])
 
@@ -181,9 +181,9 @@ def test_concatenated_dataframes(simple_storage_model):
     scA = Scenario(model, 'A', size=2)
     scB = Scenario(model, 'B', size=3)
 
-    res = model.node['Storage']
+    res = model.nodes['Storage']
     rec1 = NumpyArrayStorageRecorder(model, res)
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
     rec2 = NumpyArrayNodeRecorder(model, otpt)
     # The following can't return a DataFrame; is included to check
     # it doesn't cause any issues
@@ -202,8 +202,8 @@ def test_csv_recorder(simple_linear_model, tmpdir):
 
     """
     model = simple_linear_model
-    otpt = model.node['Output']
-    model.node['Input'].max_flow = 10.0
+    otpt = model.nodes['Output']
+    model.nodes['Input'].max_flow = 10.0
     otpt.cost = -2.0
 
     csvfile = tmpdir.join('output.csv')
@@ -238,8 +238,8 @@ class TestTablesRecorder:
 
         """
         model = simple_linear_model
-        otpt = model.node['Output']
-        inpt = model.node['Input']
+        otpt = model.nodes['Output']
+        inpt = model.nodes['Input']
         agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
 
         inpt.max_flow = 10.0
@@ -252,7 +252,7 @@ class TestTablesRecorder:
 
             model.run()
 
-            for node_name in model.node.keys():
+            for node_name in model.nodes.keys():
                 ca = h5f.get_node('/', node_name)
                 assert ca.shape == (365, 1)
                 if node_name == 'Sum':
@@ -268,8 +268,8 @@ class TestTablesRecorder:
         from pywr.parameters import ConstantParameter
 
         model = simple_linear_model
-        otpt = model.node['Output']
-        inpt = model.node['Input']
+        otpt = model.nodes['Output']
+        inpt = model.nodes['Input']
 
         p = ConstantParameter(10.0, name='max_flow')
         inpt.max_flow = p
@@ -286,7 +286,7 @@ class TestTablesRecorder:
 
             model.run()
 
-            for node_name in model.node.keys():
+            for node_name in model.nodes.keys():
                 ca = h5f.get_node('/', node_name)
                 assert ca.shape == (365, 1)
                 if node_name == 'Sum':
@@ -302,8 +302,8 @@ class TestTablesRecorder:
         from pywr.parameters import ConstantParameter
 
         model = simple_linear_model
-        otpt = model.node['Output']
-        inpt = model.node['Input']
+        otpt = model.nodes['Output']
+        inpt = model.nodes['Input']
         agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
         p = ConstantParameter(10.0, name='max_flow')
         inpt.max_flow = p
@@ -428,9 +428,9 @@ def test_total_deficit_node_recorder(simple_linear_model):
     Test TotalDeficitNodeRecorder
     """
     model = simple_linear_model
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
     otpt.max_flow = 30.0
-    model.node['Input'].max_flow = 10.0
+    model.nodes['Input'].max_flow = 10.0
     otpt.cost = -2.0
     rec = TotalDeficitNodeRecorder(model, otpt)
 
@@ -446,9 +446,9 @@ def test_total_flow_node_recorder(simple_linear_model):
     Test TotalDeficitNodeRecorder
     """
     model = simple_linear_model
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
     otpt.max_flow = 30.0
-    model.node['Input'].max_flow = 10.0
+    model.nodes['Input'].max_flow = 10.0
     otpt.cost = -2.0
     rec = TotalFlowNodeRecorder(model, otpt)
 
@@ -461,9 +461,9 @@ def test_total_flow_node_recorder(simple_linear_model):
 
 def test_aggregated_recorder(simple_linear_model):
     model = simple_linear_model
-    otpt = model.node['Output']
+    otpt = model.nodes['Output']
     otpt.max_flow = 30.0
-    model.node['Input'].max_flow = 10.0
+    model.nodes['Input'].max_flow = 10.0
     otpt.cost = -2.0
     rec1 = TotalFlowNodeRecorder(model, otpt)
     rec2 = TotalDeficitNodeRecorder(model, otpt)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -30,7 +30,7 @@ def test_run_simple1(solver):
     model.step()
 
     # check results
-    demand1 = model.node['demand1']
+    demand1 = model.nodes['demand1']
     assert_allclose(demand1.flow, 10.0, atol=1e-7)
     # initially the timestepper returns the first time-step, so timestepper.current
     # does not change after the first 'step'.
@@ -46,8 +46,8 @@ def test_run_reservoir1(solver):
     Without an additional supply the reservoir should empty and cause a failure.
     '''
     model = load_model('reservoir1.json', solver=solver)
-    demand1 = model.node['demand1']
-    supply1 = model.node['supply1']
+    demand1 = model.nodes['demand1']
+    supply1 = model.nodes['supply1']
     for demand, stored in [(10.0, 25.0), (10.0, 15.0), (10.0, 5.0), (5.0, 0.0), (0.0, 0.0)]:
         result = model.step()
         assert_allclose(demand1.flow, demand, atol=1e-7)
@@ -62,9 +62,9 @@ def test_run_reservoir2(solver):
     '''
     model = load_model('reservoir2.json', solver=solver)
 
-    demand1 = model.node['demand1']
-    supply1 = model.node['supply1']
-    catchment = model.node['catchment1']
+    demand1 = model.nodes['demand1']
+    supply1 = model.nodes['supply1']
+    catchment = model.nodes['catchment1']
     assert(catchment.min_flow == 5)
     for demand, stored in [(15.0, 25.0), (15.0, 15.0), (15.0, 5.0), (10.0, 0.0), (5.0, 0.0)]:
         result = model.step()
@@ -87,7 +87,7 @@ def test_run_river1(solver):
     model = load_model('river1.json', solver=solver)
 
     result = model.step()
-    demand1 = model.node['demand1']
+    demand1 = model.nodes['demand1']
     assert_allclose(demand1.flow, 5.0, atol=1e-7)
 
 
@@ -97,9 +97,9 @@ def test_run_river2(solver):
 
     model.step()
 
-    demand1 = model.node['demand1']
+    demand1 = model.nodes['demand1']
     assert_allclose(demand1.flow, 7.25, atol=1e-7)
-    demand2 = model.node['demand2']
+    demand2 = model.nodes['demand2']
     assert_allclose(demand2.flow, 2.0, atol=1e-7)
 
 
@@ -111,8 +111,8 @@ def test_run_timeseries1(solver):
     assert(model.timestepper.start == datetime.datetime(2015, 1, 1))
 
     # check results
-    demand1 = model.node['demand1']
-    catchment1 = model.node['catchment1']
+    demand1 = model.nodes['demand1']
+    catchment1 = model.nodes['catchment1']
     for expected in (23.92, 22.14, 22.57, 24.97, 27.59):
         result = model.step()
         assert_allclose(catchment1.flow, expected, atol=1e-7)
@@ -121,9 +121,9 @@ def test_run_timeseries1(solver):
 def test_run_cost1(solver):
     model = load_model('cost1.json', solver=solver)
 
-    supply1 = model.node['supply1']
-    supply2 = model.node['supply2']
-    demand1 = model.node['demand1']
+    supply1 = model.nodes['supply1']
+    supply2 = model.nodes['supply2']
+    demand1 = model.nodes['demand1']
 
     assert_allclose(supply1.get_cost(None, None), 1)
     assert_allclose(supply2.get_cost(None, None), 2)  # more expensive
@@ -157,7 +157,7 @@ def test_run_license1(solver):
     model.timestamp = datetime.datetime(2015, 1, 1)
 
     # add licenses to supply node
-    supply1 = model.node['supply1']
+    supply1 = model.nodes['supply1']
     daily_lic = pywr.licenses.DailyLicense(5)
     annual_lic = pywr.licenses.AnnualLicense(7)
     collection = pywr.licenses.LicenseCollection([daily_lic, annual_lic])
@@ -167,7 +167,7 @@ def test_run_license1(solver):
 
     # daily license is limit
     result = model.step()
-    d1 = model.node['demand1']
+    d1 = model.nodes['demand1']
     assert_allclose(d1.flow, 5.0, atol=1e-7)
 
     # resource state is getting worse
@@ -175,12 +175,12 @@ def test_run_license1(solver):
 
     # annual license is limit
     result = model.step()
-    d1 = model.node['demand1']
+    d1 = model.nodes['demand1']
     assert_allclose(d1.flow, 2.0, atol=1e-7)
 
     # annual license is exhausted
     result = model.step()
-    d1 = model.node['demand1']
+    d1 = model.nodes['demand1']
     assert_allclose(d1.flow, 0.0, atol=1e-7)
     assert_allclose(annual_lic.resource_state(model.timestep), 0.0, atol=1e-7)
 
@@ -192,13 +192,13 @@ def test_run_license2(solver):
 
     model.timestamp = datetime.datetime(2015, 1, 1)
 
-    supply1 = model.node['supply1']
+    supply1 = model.nodes['supply1']
 
     assert(len(supply1.licenses) == 2)
 
     # daily license limit
     result = model.step()
-    d1 = model.node['demand1']
+    d1 = model.nodes['demand1']
     assert_allclose(d1.flow, 5.0, atol=1e-7)
 
     # annual license limit
@@ -211,13 +211,13 @@ def test_run_license_group(solver):
     '''Test license groups'''
     model = load_model('groups1.xml', solver=solver)
 
-    supply1 = model.node['supply1']
-    supply2 = model.node['supply2']
+    supply1 = model.nodes['supply1']
+    supply2 = model.nodes['supply2']
 
     assert(len(model.group) == 2)
 
     result = model.step()
-    d1 = model.node['demand1']
+    d1 = model.nodes['demand1']
     assert_allclose(d1.flow, 6.0, atol=1e-7)
 
 
@@ -225,8 +225,8 @@ def test_run_bottleneck(solver):
     '''Test max flow constraint on intermediate nodes is upheld'''
     model = load_model('bottleneck.json', solver=solver)
     result = model.step()
-    d1 = model.node['demand1']
-    d2 = model.node['demand2']
+    d1 = model.nodes['demand1']
+    d2 = model.nodes['demand2']
     assert_allclose(d1.flow+d2.flow, 15.0, atol=1e-7)
 
 def test_run_discharge_upstream(solver):
@@ -237,8 +237,8 @@ def test_run_discharge_upstream(solver):
     '''
     model = load_model('river_discharge1.json', solver=solver)
     model.step()
-    demand = model.node['demand1']
-    term = model.node['term1']
+    demand = model.nodes['demand1']
+    term = model.nodes['term1']
     assert_allclose(demand.flow, 8.0, atol=1e-7)
     assert_allclose(term.flow, 0.0, atol=1e-7)
 
@@ -250,8 +250,8 @@ def test_run_discharge_downstream(solver):
     '''
     model = load_model('river_discharge2.json', solver=solver)
     model.step()
-    demand = model.node['demand1']
-    term = model.node['term1']
+    demand = model.nodes['demand1']
+    term = model.nodes['term1']
     assert_allclose(demand.flow, 5.0, atol=1e-7)
     assert_allclose(term.flow, 3.0, atol=1e-7)
 
@@ -261,10 +261,10 @@ def test_run_blender1(solver):
     '''Test blender constraint/component'''
     model = load_model('blender1.xml', solver=solver)
 
-    blender = model.node['blender1']
-    supply1 = model.node['supply1']
-    supply2 = model.node['supply2']
-    supply3 = model.node['supply3']
+    blender = model.nodes['blender1']
+    supply1 = model.nodes['supply1']
+    supply2 = model.nodes['supply2']
+    supply3 = model.nodes['supply3']
 
     # check blender ratio
     assert_allclose(blender.properties['ratio'].value(model.timestamp), 0.75, atol=1e-7)
@@ -284,9 +284,9 @@ def test_run_blender2(solver):
     '''Test blender constraint/component'''
     model = load_model('blender2.xml', solver=solver)
 
-    blender = model.node['blender1']
-    supply1 = model.node['supply1']
-    supply2 = model.node['supply2']
+    blender = model.nodes['blender1']
+    supply1 = model.nodes['supply1']
+    supply2 = model.nodes['supply2']
 
     # test model results
     result = model.step()
@@ -556,7 +556,7 @@ def test_reservoir_circle(solver):
 def test_reset(solver):
     """Test model reset"""
     model = load_model('license1.xml', solver=solver)
-    supply1 = model.node['supply1']
+    supply1 = model.nodes['supply1']
     license_collection = supply1.licenses
     license = [lic for lic in license_collection._licenses if isinstance(lic, pywr.licenses.AnnualLicense)][0]
     assert_allclose(license.available(None), 7.0, atol=1e-7)
@@ -593,7 +593,7 @@ def test_run_until_failure(solver):
 
     # run until failure
     model.timestamp = pandas.to_datetime('2015-12-01')
-    demand1 = model.node['demand1']
+    demand1 = model.nodes['demand1']
     def demand_func(node, timestamp):
         return timestamp.datetime.day
     demand1.min_flow = pywr.parameters.ParameterFunction(demand1, demand_func)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -49,10 +49,10 @@ def test_scenario(simple_linear_model, ):
     model = simple_linear_model  # Convenience renaming
 
     scenario = pywr.core.Scenario(model, 'Inflow', size=2)
-    model.node["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario, [5.0, 10.0])
+    model.nodes["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario, [5.0, 10.0])
 
-    model.node["Output"].max_flow = 5.0
-    model.node["Output"].cost = -2.0
+    model.nodes["Output"].max_flow = 5.0
+    model.nodes["Output"].cost = -2.0
 
     expected_node_results = {
         "Input": [5.0, 5.0],
@@ -68,15 +68,15 @@ def test_two_scenarios(simple_linear_model, ):
     model = simple_linear_model  # Convenience renaming
 
     scenario_input = pywr.core.Scenario(model, 'Inflow', size=2)
-    model.node["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [5.0, 10.0])
+    model.nodes["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [5.0, 10.0])
 
     scenario_outflow = pywr.core.Scenario(model, 'Outflow', size=2)
-    model.node["Output"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_outflow, [3.0, 8.0])
-    model.node["Output"].cost = -2.0
+    model.nodes["Output"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_outflow, [3.0, 8.0])
+    model.nodes["Output"].cost = -2.0
     
     # add numpy recorders to input and output nodes
-    NumpyArrayNodeRecorder(model, model.node["Input"], "input")
-    NumpyArrayNodeRecorder(model, model.node["Output"], "output")
+    NumpyArrayNodeRecorder(model, model.nodes["Input"], "input")
+    NumpyArrayNodeRecorder(model, model.nodes["Output"], "output")
 
     expected_node_results = {
         "Input": [3.0, 5.0, 3.0, 8.0],
@@ -102,10 +102,10 @@ def test_scenario_two_parameter(simple_linear_model, ):
     model = simple_linear_model  # Convenience renaming
 
     scenario_input = pywr.core.Scenario(model, 'Inflow', size=2)
-    model.node["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [5.0, 10.0])
+    model.nodes["Input"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [5.0, 10.0])
 
-    model.node["Output"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [8.0, 3.0])
-    model.node["Output"].cost = -2.0
+    model.nodes["Output"].max_flow = pywr.parameters.ConstantScenarioParameter(scenario_input, [8.0, 3.0])
+    model.nodes["Output"].cost = -2.0
 
     expected_node_results = {
         "Input": [5.0, 3.0],


### PR DESCRIPTION
Fixes #268

`TablesRecorder` is now a lot more general.

- It can record multiple `Nodes` and `Parameters`.
- User can specify the path within the h5 file they would like each array saving.
- It can be defined from JSON with filters and mode arguments.