### PR TITLE
Changed syntax for table recorder names

### DIFF
--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -2,7 +2,7 @@ import sys
 from pywr._recorders import *
 from past.builtins import basestring
 from .h5tools import H5Store
-
+import os
 
 class CSVRecorder(Recorder):
     """
@@ -153,7 +153,7 @@ class TablesRecorder(Recorder):
 
         # Default to all nodes if None given.
         if self.nodes is None:
-            nodes = [(self.where, n) for n in self.model.nodes.values()]
+            nodes = [((self.where + "/" + n.name).replace("//", "/"), n) for n in self.model.nodes.values()]
         else:
             nodes = []
             for n in self.nodes:
@@ -162,13 +162,14 @@ class TablesRecorder(Recorder):
                     where, node = n
                 except (TypeError, ValueError):
                     node = n
-                    where = self.where
+                    where = self.where + "/" + node
 
                 # Accept a str, and lookup node by name instead.
                 if isinstance(node, basestring):
                     node = self.model.nodes[node]
                 # Otherwise assume it is a node object anyway
 
+                where = where.replace("//", "/")
                 nodes.append((where, node))
 
         if self.parameters is not None:
@@ -178,7 +179,7 @@ class TablesRecorder(Recorder):
                     where, param = p
                 except (TypeError, ValueError):
                     param = p
-                    where = self.where
+                    where = None
 
                 if isinstance(param, basestring):
                     param = self.model.parameters[param]
@@ -187,6 +188,11 @@ class TablesRecorder(Recorder):
 
                 if param.name is None:
                     raise ValueError('Can only record named Parameter objects.')
+
+                if where is None:
+                    where = self.where + "/" + param.name
+
+                where = where.replace("//", "/")
                 nodes.append((where, param))
 
         self._nodes = nodes
@@ -196,7 +202,10 @@ class TablesRecorder(Recorder):
                 atom = tables.Int32Atom()
             else:
                 atom = tables.Float64Atom()
-            self.h5store.file.create_carray(where, node.name, atom, shape, createparents=True)
+            group_name, node_name = os.path.split(where)
+            if "group_name" == "/":
+                group_name = self.h5store.file.root
+            self.h5store.file.create_carray(group_name, node_name, atom, shape, createparents=True)
 
         self.h5store = None
 
@@ -205,7 +214,7 @@ class TablesRecorder(Recorder):
         self.h5store = H5Store(self.h5file, self.filter_kwds, mode)
         self._arrays = {}
         for where, node in self._nodes:
-            self._arrays[node] = self.h5store.file.get_node(where, node.name)
+            self._arrays[node] = self.h5store.file.get_node(where)
 
     def save(self):
         """

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -2,7 +2,6 @@ import sys
 from pywr._recorders import *
 from past.builtins import basestring
 from .h5tools import H5Store
-import os
 
 class CSVRecorder(Recorder):
     """
@@ -202,7 +201,7 @@ class TablesRecorder(Recorder):
                 atom = tables.Int32Atom()
             else:
                 atom = tables.Float64Atom()
-            group_name, node_name = os.path.split(where)
+            group_name, node_name = where.rsplit("/", 1)
             if "group_name" == "/":
                 group_name = self.h5store.file.root
             self.h5store.file.create_carray(group_name, node_name, atom, shape, createparents=True)

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -313,14 +313,15 @@ class TestTablesRecorder:
         h5file = tmpdir.join('output.h5')
         import tables
         with tables.open_file(str(h5file), 'w') as h5f:
-            where = '/agroup'
-            rec = TablesRecorder(model, h5f, nodes=['Output', 'Input', 'Sum'],
+            nodes = ['Output', 'Input', 'Sum']
+            where = "/agroup"
+            rec = TablesRecorder(model, h5f, nodes=nodes,
                                  parameters=[p, ], where=where)
 
             model.run()
 
             for node_name in ['Output', 'Input', 'Sum', 'max_flow']:
-                ca = h5f.get_node(where, node_name)
+                ca = h5f.get_node("/agroup/" + node_name)
                 assert ca.shape == (365, 1)
                 if node_name == 'Sum':
                     np.testing.assert_allclose(ca, 20.0)
@@ -407,8 +408,8 @@ class TestTablesRecorder:
         h5file = tmpdir.join('output.h5')
         with tables.open_file(str(h5file), 'r') as h5f:
             assert model.metadata['title'] == h5f.title
-            rec_demand = h5f.get_node('/outputs/demand', 'Demand').read()
-            rec_storage = h5f.get_node('/storage/reservoir', 'Reservoir').read()
+            rec_demand = h5f.get_node('/outputs/demand').read()
+            rec_storage = h5f.get_node('/storage/reservoir').read()
 
             # model starts with no demand saving
             demand_baseline = 50.0


### PR DESCRIPTION
Closes #278.

Need to document how this works.

If a list of nodes are passed the arrays are named: `/where/node_name`, where where is a constant.

If tuples of (where, node) are used the arrays are named: `/where`