### PR TITLE
Fix295

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -204,11 +204,6 @@ class NodeIterator(object):
             return node
         raise StopIteration()
 
-    def __call__(self):
-        # support for old API
-        return self
-
-
 class NamedIterator(object):
     def __init__(self):
         self._objects = []
@@ -1067,11 +1062,7 @@ class Storage(with_metaclass(NodeMeta, Drawable, Connectable, _core.Storage)):
         if min_volume is None:
             min_volume = 0.0
         max_volume = pop_kwarg_parameter(kwargs, 'max_volume', 0.0)
-        if 'volume' in kwargs:
-            # support older API where volume kwarg was the initial volume
-            initial_volume = kwargs.pop('volume')
-        else:
-            initial_volume = kwargs.pop('initial_volume', 0.0)
+        initial_volume = kwargs.pop('initial_volume', 0.0)
         cost = pop_kwarg_parameter(kwargs, 'cost', 0.0)
 
         position = kwargs.pop("position", {})

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -218,7 +218,7 @@ class NamedIterator(object):
     def __delitem__(self, key):
         """Remove a node from the graph by it's name"""
         obj = self[key]
-        self._objects.remove(rec)
+        self._objects.remove(obj)
 
     def __setitem__(self, key, obj):
         # TODO: check for name collisions / duplication

--- a/pywr/core.py
+++ b/pywr/core.py
@@ -158,7 +158,7 @@ class NodeIterator(object):
         for node in self.model.graph.nodes():
             if hide_children is False or node.parent is None:  # don't return child nodes (e.g. StorageInput)
                 yield node
-        raise StopIteration()
+        return
 
     def __getitem__(self, key):
         """Get a node from the graph by it's name"""

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,7 +46,7 @@ def simple_storage_model(request, solver):
     )
 
     inpt = Input(model, name="Input", max_flow=5.0, cost=-1)
-    res = Storage(model, name="Storage", num_outputs=1, num_inputs=1, max_volume=20, volume=10)
+    res = Storage(model, name="Storage", num_outputs=1, num_inputs=1, max_volume=20, initial_volume=10)
     otpt = Output(model, name="Output", max_flow=8, cost=-999)
     
     inpt.connect(res)
@@ -80,7 +80,7 @@ def three_storage_model(request, solver):
 
     for num in range(3):
         inpt = Input(model, name="Input {}".format(num), max_flow=5.0*num, cost=-1)
-        res = Storage(model, name="Storage {}".format(num), num_outputs=1, num_inputs=1, max_volume=20, volume=10+num)
+        res = Storage(model, name="Storage {}".format(num), num_outputs=1, num_inputs=1, max_volume=20, initial_volume=10+num)
         otpt = Output(model, name="Output {}".format(num), max_flow=8+num, cost=-999)
 
         inpt.connect(res)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,7 +23,7 @@ def assert_model(model, expected_node_results):
     __tracebackhide__ = True
     model.step()
 
-    for node in model.nodes():
+    for node in model.nodes:
         if node.name in expected_node_results:
             if isinstance(node, pywr.core.BaseNode):
                 assert_allclose(expected_node_results[node.name], node.flow, atol=1e-7)

--- a/tests/notebook.ipynb
+++ b/tests/notebook.ipynb
@@ -14,7 +14,7 @@
     "model = Model.load(\"models/simple1.json\")\n",
     "\n",
     "print(model)\n",
-    "print(\"nodes:\", len(model.nodes()))\n",
+    "print(\"nodes:\", len(model.nodes))\n",
     "\n",
     "draw_graph(model)"
    ]

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -64,7 +64,7 @@ def linear_model_with_storage(request, solver):
     lnk.connect(otpt)
 
     strg = pywr.core.Storage(model, name="Storage", max_volume=max_volume, min_volume=min_volume,
-                             volume=current_volume, cost=-strg_benefit)
+                             initial_volume=current_volume, cost=-strg_benefit)
 
     strg.connect(otpt)
     lnk.connect(strg)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,7 @@ def test_names(solver):
     assert(model.nodes['A'] is node1)
     assert(model.nodes['B'] is node2)
 
-    nodes = sorted(model.nodes(), key=lambda node: node.name)
+    nodes = sorted(model.nodes, key=lambda node: node.name)
     assert(nodes == [node1, node2])
 
     # rename node
@@ -76,7 +76,7 @@ def test_unexpected_kwarg_node(solver):
         storage = Storage(model, 'test_storage', invalid=True)
     # none of the nodes should have been added to the model as they all
     # raised exceptions during __init__
-    assert(not model.nodes())
+    assert(not model.nodes)
 
 
 def test_unexpected_kwarg_model(solver):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -528,6 +528,13 @@ def test_simple_json_parameter_reference(solver):
 
     assert(len(model.parameters) == 3) # only 3 parameters are named
 
+
+def test_simple_json_parameter_deletion(solver):
+    # note that parameters in the "parameters" section cannot be literals
+    model = load_model("parameter_reference.json")
+    del model.parameters["supply_max_flow"]
+
+
 def test_with_a_better_name():
 
     data = {

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -157,7 +157,7 @@ def test_control_curve(solver):
     from pywr.parameters import ConstantParameter
     control_curve = ConstantParameter(0.8)
     reservoir = river.Reservoir(model, name="Reservoir", max_volume=10, cost=-20, above_curve_cost=0.0,
-                                control_curve=control_curve, volume=10)
+                                control_curve=control_curve, initial_volume=10)
     reservoir.inputs[0].max_flow = 2.0
     reservoir.outputs[0].max_flow = 2.0
     lnk.connect(reservoir)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -339,7 +339,7 @@ def test_new_storage(solver):
 
     supply1 = pywr.core.Input(model, 'supply1')
 
-    splitter = pywr.core.Storage(model, 'splitter', num_outputs=1, num_inputs=2, max_volume=10, volume=5)
+    splitter = pywr.core.Storage(model, 'splitter', num_outputs=1, num_inputs=2, max_volume=10, initial_volume=5)
 
     demand1 = pywr.core.Output(model, 'demand1')
     demand2 = pywr.core.Output(model, 'demand2')
@@ -448,7 +448,7 @@ def test_storage_spill_compensation(solver):
     model = pywr.core.Model(solver=solver)
 
     catchment = pywr.core.Input(model, name="Input", min_flow=10.0, max_flow=10.0, cost=1)
-    reservoir = pywr.core.Storage(model, name="Storage", max_volume=100, volume=100.0)
+    reservoir = pywr.core.Storage(model, name="Storage", max_volume=100, initial_volume=100.0)
     spill = pywr.core.Link(model, name="Spill", cost=1.0)
     compensation = pywr.core.Link(model, name="Compensation", max_flow=3.0, cost=-999)
     terminator = pywr.core.Output(model, name="Terminator", cost=-1.0)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -128,7 +128,7 @@ def test_scenario_storage(solver):
     model = Model(solver=solver)
 
     i = Input(model, 'input', max_flow=999)
-    s = Storage(model, 'storage', num_inputs=1, num_outputs=1, max_volume=1000, volume=500)
+    s = Storage(model, 'storage', num_inputs=1, num_outputs=1, max_volume=1000, initial_volume=500)
     o = Output(model, 'output', max_flow=999)
 
     scenario_input = pywr.core.Scenario(model, 'Inflow', size=2)


### PR DESCRIPTION

- Fixes #295
- Removes deprecation errors around use of `StopIteration`. See [PEP479](https://www.python.org/dev/peps/pep-0479/)
- Fixes a bug in `NamedIterator.__delitem__`