### PR TITLE
Fix247 & Added "tables" section to JSON

### DIFF
--- a/pywr/core.py
+++ b/pywr/core.py
@@ -309,6 +309,7 @@ class Model(object):
 
         self.parameters = NamedIterator()
         self.recorders = NamedIterator()
+        self.tables = {}
         self.scenarios = ScenarioCollection()
 
         if kwargs:
@@ -476,6 +477,16 @@ class Model(object):
             for scen_name, scen_data in scenarios_data.items():
                 size = scen_data["size"]
                 Scenario(model, scen_name, size=size)
+
+        # load table references
+        try:
+            tables_data = data["tables"]
+        except KeyError:
+            # Default to no table entries
+            pass
+        else:
+            for table_name, table_data in tables_data.items():
+                model.tables[table_name] = load_dataframe(model, table_data)
 
         # collect nodes to load
         nodes_to_load = {}

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -866,7 +866,7 @@ def load_parameter(model, data, parameter_name=None):
     return parameter
 
 
-def load_parameter_values(model, data, values_key='values'):
+def load_parameter_values(model, data, values_key='values', url_key='url'):
     """ Function to load values from a data dictionary.
 
     This function tries to load values in to a `np.ndarray` if 'values_key' is
@@ -878,14 +878,21 @@ def load_parameter_values(model, data, values_key='values'):
     data - dict
     values_key - str
         Key in data to load values directly to a `np.ndarray`
-
+    url_key - str
+        Key in data to load values directly from an external file reference (using pandas)
     """
     if values_key in data:
         # values are given as an array
         values = np.array(data.pop(values_key), np.float64)
-    else:
+    elif url_key in data:
         df = load_dataframe(model, data)
         values = np.squeeze(df.values.astype(np.float64))
+    else:
+        # Try to get some useful information about the parameter for the error message
+        name = data.get('name', None)
+        ptype = data.get('type', None)
+        raise ValueError("Parameter ('{name}' of type '{ptype}' is missing a valid key to load its values. "
+                         "Please provide either a '{}' or '{}' entry.".format(values_key, url_key, name=name, ptype=ptype))
     return values
 
 

--- a/tests/models/simple_df_shared.json
+++ b/tests/models/simple_df_shared.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constant",
+                "table": "simple_data",
+                "column": "max_flow",
+                "index": "demand1"
+            },
+            "cost": {
+                "type": "constant",
+                "table": "simple_data",
+                "column": "cost",
+                "index": "demand1"
+            }
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "tables": {
+        "simple_data": {
+            "url": "simple_data.csv",
+            "index_col": "node"
+        }
+    }
+}

--- a/tests/models/simple_df_shared.json
+++ b/tests/models/simple_df_shared.json
@@ -1,8 +1,8 @@
 {
     "metadata": {
         "title": "Simple 1",
-        "description": "A very simple example.",
-        "minimum_version": "0.1"
+        "description": "A very simple example using an external data file shared between two parameters.",
+        "minimum_version": "0.2dev"
     },
     "timestepper": {
         "start": "2015-01-01",

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -592,6 +592,21 @@ def test_constant_from_df(solver):
     """
     model = load_model('simple_df.json', solver=solver)
 
+    assert isinstance(model.nodes['demand1'].max_flow, ConstantParameter)
+    assert isinstance(model.nodes['demand1'].cost, ConstantParameter)
+
+    ts = model.timestepper.next()
+    si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+
+    np.testing.assert_allclose(model.nodes['demand1'].max_flow.value(ts, si), 10.0)
+    np.testing.assert_allclose(model.nodes['demand1'].cost.value(ts, si), -10.0)
+
+
+def test_constant_from_shared_df(solver):
+    """
+    Test that a shared dataframe can be used to provide data to ConstantParameter (single values).
+    """
+    model = load_model('simple_df_shared.json', solver=solver)
 
     assert isinstance(model.nodes['demand1'].max_flow, ConstantParameter)
     assert isinstance(model.nodes['demand1'].cost, ConstantParameter)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -641,3 +641,21 @@ def test_parameter_registry_overwrite(model):
     # parameter is instance of new class, not old class
     assert(isinstance(parameter, NewParameter))
     assert(parameter.DATA == 43)
+
+
+def test_invalid_parameter_values():
+    """
+    Test that `load_parameter_values` returns a ValueError rather than KeyError.
+
+    This is useful to catch and give useful messages when no valid reference to
+    a data location is given.
+
+    Regression test for Issue #247 (https://github.com/pywr/pywr/issues/247)
+    """
+
+    from pywr.parameters._parameters import load_parameter_values
+
+    m = Model()
+    data = {'name': 'my_parameter', 'type': 'AParameterThatShouldHaveValues'}
+    with pytest.raises(ValueError):
+        load_parameter_values(model, data)


### PR DESCRIPTION
This allows `DataFrame` objects to be read once by providing them in a `"tables"` section of the JSON. Reference to these objects can be made in individual `Parameter` definitions by using a `"table"` key instead of the `"url"`. The `"index"` and `"column"` keys should stay with the `Parameter` definition but other keys passed as keywords to pandas read functions should be moved to the `"tables"` definition.