### PR TITLE
Performance improvements

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -51,11 +51,24 @@ cdef class ArrayIndexedScenarioMonthlyFactorsParameter(Parameter):
     cdef Scenario _scenario
     cdef int _scenario_index
 
+
+
 cdef class DailyProfileParameter(Parameter):
     cdef double[:] _values
 
 cdef class IndexParameter(Parameter):
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
+
+cdef class TablesArrayParameter(IndexParameter):
+    cdef double[:, :] _values
+    cdef public Scenario scenario
+    cdef public object h5file
+    cdef public object h5store
+    cdef public object node
+    cdef public object where
+    cdef public object model
+
+    cdef int _scenario_index
 
 cdef class IndexedArrayParameter(Parameter):
     cdef public Parameter index_parameter

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -60,7 +60,8 @@ cdef class IndexParameter(Parameter):
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
 
 cdef class TablesArrayParameter(IndexParameter):
-    cdef double[:, :] _values
+    cdef double[:, :] _values_dbl
+    cdef long[:, :] _values_int
     cdef public Scenario scenario
     cdef public object h5file
     cdef public object h5store

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -61,7 +61,7 @@ cdef class IndexParameter(Parameter):
 
 cdef class TablesArrayParameter(IndexParameter):
     cdef double[:, :] _values_dbl
-    cdef long[:, :] _values_int
+    cdef int[:, :] _values_int
     cdef public Scenario scenario
     cdef public object h5file
     cdef public object h5store

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -315,7 +315,7 @@ cdef class TablesArrayParameter(IndexParameter):
             shape = self._values_dbl.shape
         else:
             self._values_dbl = None
-            self._values_int = node.read().astype(np.int32)
+            self._values_int = node.read()
             shape = self._values_int.shape
 
         if self.scenario is not None:

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -309,14 +309,16 @@ cdef class TablesArrayParameter(IndexParameter):
         node = self.h5store.file.get_node(self.where, self.node)
 
         # detect data type and read into memoryview
-        if node.dtype == np.float32 or node.dtype == np.float64:
+        if node.dtype in (np.float32, np.float64):
             self._values_dbl = node.read()
             self._values_int = None
             shape = self._values_dbl.shape
-        else:
+        elif node.dtype in (np.int8, np.int16, np.int32):
             self._values_dbl = None
             self._values_int = node.read()
             shape = self._values_int.shape
+        else:
+            raise TypeError("Unexpected dtype in array: {}".format(node.dtype))
 
         if self.scenario is not None:
             if shape[1] != self.scenario.size:

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -315,7 +315,7 @@ cdef class TablesArrayParameter(IndexParameter):
             shape = self._values_dbl.shape
         else:
             self._values_dbl = None
-            self._values_int = node.read()
+            self._values_int = node.read().astype(np.int32)
             shape = self._values_int.shape
 
         if self.scenario is not None:

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -248,7 +248,7 @@ class TablesRecorder(Recorder):
             entry['day'] = dt.day
             entry['index'] = idx
             entry.append()
-            self._time_table.flush()
+            #self._time_table.flush()
 
         for node, ca in self._arrays.items():
             if isinstance(node, AbstractStorage):
@@ -256,15 +256,21 @@ class TablesRecorder(Recorder):
             elif isinstance(node, AbstractNode):
                 ca[idx, :] = node.flow
             elif isinstance(node, IndexParameter):
+                a = np.empty(len(self.model.scenarios.combinations), dtype=np.int)
                 for si in self.model.scenarios.combinations:
-                    ca[idx, si.global_id] = node.index(ts, si)
+                     a[si.global_id] = node.index(ts, si)
+                ca[idx, :] = a
             elif isinstance(node, BaseParameter):
+                a = np.empty(len(self.model.scenarios.combinations), dtype=np.float64)
                 for si in self.model.scenarios.combinations:
-                    ca[idx, si.global_id] = node.value(ts, si)
+                    a[si.global_id] = node.value(ts, si)
+                ca[idx, :] = a
             else:
                 raise ValueError("Unrecognised Node type '{}' for TablesRecorder".format(type(node)))
 
     def finish(self):
+        if self._time_table is not None:
+            self._time_table.flush()
         self.h5store = None
         self._arrays = {}
 

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -500,6 +500,6 @@ def test_demand_saving_with_indexed_array_from_hdf(solver):
     demand_saving = 0.5
     assert_allclose(rec_demand.data[12, 0], demand_baseline * demand_saving)
 
-    # second control c2urve breached
+    # second control curve breached
     demand_saving = 0.25
     assert_allclose(rec_demand.data[13, 0], demand_baseline * demand_saving)


### PR DESCRIPTION
Two performance improvements related to pytables.

- First is an easy win the `TablesRecorder`
- Second is cythoning the `TablesArrayParameter` this also reads the entire array on init. It's not ideal for indices due to have to type to `double` and cast back to `int`.