### PR TITLE
Clean __pycache__ and related when running conda-build on Windows.

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -2,5 +2,10 @@ set LIB=%LIBRARY_LIB%;.\lib;%LIB%
 set LIBPATH=%LIBRARY_LIB%;.\lib;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
+# clean up before building
+# assumes all .c files were compiled from .pyx and should be removed
+rmdir /s /q build dist
+del /s __pycache__ *.pyc *.pyo *.pyd *.so *.c
+
 "%PYTHON%" setup.py build_ext -I"%LIBRARY_INC%" -L"%LIBRARY_LIB%" install --with-glpk --with-lpsolve --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,6 +1,7 @@
 py.test %SRC_DIR%\tests --solver=glpk
 py.test %SRC_DIR%\tests --solver=lpsolve
 
+if errorlevel 1 exit 1
 
 if %PY3K% == 1 (
     set PY_VER=3


### PR DESCRIPTION
Previously implemented this change for Linux.