### PR TITLE
Add support for literals in AggregatedParameters. Closes #325.

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -667,6 +667,11 @@ _agg_func_lookup = {
     "all": AggFuncs.ALL,
 }
 
+def wrap_const(value):
+    if isinstance(value, (int, float)):
+        value = ConstantParameter(value)
+    return value
+
 cdef class AggregatedParameterBase(IndexParameter):
     """Base class for aggregated parameters
 
@@ -677,7 +682,8 @@ cdef class AggregatedParameterBase(IndexParameter):
         parameters_data = data.pop("parameters")
         parameters = set()
         for pdata in parameters_data:
-            parameters.add(load_parameter(model, pdata))
+            parameter = load_parameter(model, pdata)
+            parameters.add(wrap_const(parameter))
 
         agg_func = data.pop("agg_func", None)
         return cls(parameters=parameters, agg_func=agg_func, **data)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -250,10 +250,7 @@ class TestAggregatedParameter:
             "type": "aggregated",
             "agg_func": "product",
             "parameters": [
-                {
-                    "type": "constant",
-                    "value": 0.8
-                },
+                0.8,
                 {
                     "type": "monthlyprofile",
                     "values": list(range(12))


### PR DESCRIPTION
This PR adds support for writing a literal into the parameter list for AggregatedParameter. The current requirement is that this is wrapped in a {"type": "constant", "value": X} parameter.

No changes are made to initalisation from Python space. Although it would be possible to do the same thing (convert floats to ConstantParameter), there might be some oddities with the .add/.remove methods, e.g. how should this work:

```
p = AggregatedParameter()
p.add(3.0)
p.remove(3.0)
```

You might expect this to work, but if 3.0 has been converted to a ConstantParameter that is what you'd need to pass to .remove. Also, not just equivalent (e.g. another constant == 3.0) as the set remove function works on the id() of the object, which the user doesn't even have a reference to!

Thoughts @jetuk?