### PR TITLE
Added casting in TablesArrayParameter.reset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ install:
       conda config --add channels conda-forge
 
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-build-setup
-      source run_conda_forge_build_setup
+      conda install --yes --quiet conda-build
 
 script:
     - conda build conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,10 +45,10 @@ install:
     - cmd: conda config --add channels conda-forge
     - cmd: conda config --add channels snorfalorpagus
     - cmd: conda info
-    - cmd: conda install -n root --quiet --yes conda-build=2.0.2 anaconda-client jinja2 setuptools
+    - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build conda-recipe --quiet"
+    - "%CMD_IN_ENV% conda build conda-recipe --quiet --no-remove-work-dir"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -61,6 +61,8 @@ test:
   requires:
     - pytest
     - nbconvert
+  source_files:
+    - tests/*
 
 about:
   home: https://github.com/pywr/pywr

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -319,12 +319,12 @@ cdef class TablesArrayParameter(IndexParameter):
 
         # detect data type and read into memoryview
         if node.dtype in (np.float32, np.float64):
-            self._values_dbl = node.read()
+            self._values_dbl = node.read().astype(np.float64)
             self._values_int = None
             shape = self._values_dbl.shape
         elif node.dtype in (np.int8, np.int16, np.int32):
             self._values_dbl = None
-            self._values_int = node.read()
+            self._values_int = node.read().astype(np.int32)
             shape = self._values_int.shape
         else:
             raise TypeError("Unexpected dtype in array: {}".format(node.dtype))


### PR DESCRIPTION
Without the change in this commit you get a type error if you try to read an HDF5 table using the TablesArrayParameter with an 8 or 16 bit integer types or 32 bit float type.

I haven't added a test for this yet.

This is required to work with the DSL tables we've recently generated.