### PR TITLE
Check model isn't empty in solver setup.

### DIFF
--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -77,6 +77,8 @@ cdef class CythonGLPKSolver:
         cdef int n, num
 
         self.all_nodes = list(model.graph.nodes())
+        if not self.all_nodes:
+            raise ModelStructureError("Model is empty")
         self.nodes_with_cost = []
 
         n = 0

--- a/pywr/solvers/cython_lpsolve.pyx
+++ b/pywr/solvers/cython_lpsolve.pyx
@@ -154,6 +154,9 @@ cdef class CythonLPSolveSolver:
         cdef MYBOOL ret
         cdef REAL *ptr_var
 
+        if not model.graph.nodes():
+            raise ModelStructureError("Model is empty")
+
         routes = model.find_all_routes(BaseInput, BaseOutput, valid=(BaseLink, BaseInput, BaseOutput))
         # Find cross-domain routes
         cross_domain_routes = model.find_all_routes(BaseOutput, BaseInput, max_length=2, domain_match='different')

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,7 +10,8 @@ import pandas
 from numpy.testing import assert_allclose
 
 import pywr.core
-from pywr.core import Model, Storage, Input, Output, Link
+from pywr.model import Model, ModelStructureError
+from pywr.nodes import Storage, Input, Output, Link
 import pywr.solvers
 import pywr.parameters.licenses
 import pywr.domains.river
@@ -583,6 +584,13 @@ def test_reset(solver):
     assert_allclose(license.available(None), 2.0, atol=1e-7)
     model.reset()
     assert_allclose(license.available(None), 7.0, atol=1e-7)
+
+
+def test_run_empty(solver):
+    # empty model should raise an exception if run
+    model = Model(solver=solver)
+    with pytest.raises(ModelStructureError):
+        model.run()
 
 
 def test_run(solver):


### PR DESCRIPTION
Specifically check the model isn't empty when calling the solver's `setup` method and raise an exception if it is.