### PR TITLE
Add Polynomial parameters

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -122,6 +122,23 @@ cdef class AggregatedParameter(AggregatedParameterBase):
 cdef class AggregatedIndexParameter(AggregatedParameterBase):
     pass
 
+cdef class NegativeParameter(Parameter):
+    cdef public Parameter parameter
+
+cdef class MaxParameter(Parameter):
+    cdef public Parameter parameter
+    cdef public double threshold
+
+cdef class NegativeMaxParameter(MaxParameter):
+    pass
+
+cdef class MinParameter(Parameter):
+    cdef public Parameter parameter
+    cdef public double threshold
+
+cdef class NegativeMinParameter(MinParameter):
+    pass
+
 cdef class RecorderThresholdParameter(IndexParameter):
     cdef Recorder recorder
     cdef double threshold

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -906,6 +906,102 @@ cdef class AggregatedIndexParameter(AggregatedParameterBase):
 
 AggregatedIndexParameter.register()
 
+
+cdef class NegativeParameter(Parameter):
+    """ Parameter that takes negative of another `Parameter`
+
+    Parameters
+    ----------
+    parameter : `Parameter`
+        The parameter to to compare with the float.
+    """
+    def __init__(self, parameter, threshold=0.0, *args, **kwargs):
+        super(NegativeParameter, self).__init__(*args, **kwargs)
+        self.parameter = parameter
+        self.children.add(parameter)
+
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return -self.parameter.value(timestep, scenario_index)
+
+    @classmethod
+    def load(cls, model, data):
+        parameter = load_parameter(model, data.pop("parameter"))
+        return cls(parameter, **data)
+NegativeParameter.register()
+
+
+cdef class MaxParameter(Parameter):
+    """ Parameter that takes maximum of another `Parameter` and constant value (threshold)
+
+    This class is a more efficient version of `AggregatedParameter` where
+    a single `Parameter` is compared to constant value.
+
+    Parameters
+    ----------
+    parameter : `Parameter`
+        The parameter to to compare with the float.
+    threshold : float (default=0.0)
+        The threshold value to compare with the given parameter.
+    """
+    def __init__(self, parameter, threshold=0.0, *args, **kwargs):
+        super(MaxParameter, self).__init__(*args, **kwargs)
+        self.parameter = parameter
+        self.children.add(parameter)
+        self.threshold = threshold
+
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return max(self.parameter.value(timestep, scenario_index), self.threshold)
+
+    @classmethod
+    def load(cls, model, data):
+        parameter = load_parameter(model, data.pop("parameter"))
+        return cls(parameter, **data)
+MaxParameter.register()
+
+
+cdef class NegativeMaxParameter(MaxParameter):
+    """ Parameter that takes maximum of the negative of a `Parameter` and constant value (threshold) """
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return max(-self.parameter.value(timestep, scenario_index), self.threshold)
+NegativeMaxParameter.register()
+
+
+cdef class MinParameter(Parameter):
+    """ Parameter that takes minimum of another `Parameter` and constant value (threshold)
+
+    This class is a more efficient version of `AggregatedParameter` where
+    a single `Parameter` is compared to constant value.
+
+    Parameters
+    ----------
+    parameter : `Parameter`
+        The parameter to to compare with the float.
+    threshold : float (default=0.0)
+        The threshold value to compare with the given parameter.
+    """
+    def __init__(self, parameter, threshold=0.0, *args, **kwargs):
+        super(MinParameter, self).__init__(*args, **kwargs)
+        self.parameter = parameter
+        self.children.add(parameter)
+        self.threshold = threshold
+
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return min(self.parameter.value(timestep, scenario_index), self.threshold)
+
+    @classmethod
+    def load(cls, model, data):
+        parameter = load_parameter(model, data.pop("parameter"))
+        return cls(parameter, **data)
+MinParameter.register()
+
+
+cdef class NegativeMinParameter(MinParameter):
+    """ Parameter that takes minimum of the negative of a `Parameter` and constant value (threshold) """
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return min(-self.parameter.value(timestep, scenario_index), self.threshold)
+NegativeMinParameter.register()
+
+
 cdef class RecorderThresholdParameter(IndexParameter):
     """Returns one of two values depending on a Recorder value and a threshold
 

--- a/pywr/parameters/_polynomial.pxd
+++ b/pywr/parameters/_polynomial.pxd
@@ -9,4 +9,9 @@ cdef class Polynomial1DParameter(Parameter):
     cdef public bint use_proportional_volume
     cdef Parameter _parameter
 
+cdef class Polynomial2DStorageParameter(Parameter):
+    cdef public double[:, :] coefficients
+    cdef AbstractStorage _storage_node
+    cdef public bint use_proportional_volume
+    cdef Parameter _parameter
 

--- a/pywr/parameters/_polynomial.pxd
+++ b/pywr/parameters/_polynomial.pxd
@@ -1,0 +1,12 @@
+from .._core cimport Timestep, Scenario, ScenarioIndex, AbstractNode, Storage, AbstractStorage
+from ._parameters cimport Parameter, IndexParameter
+
+
+cdef class Polynomial1DParameter(Parameter):
+    cdef public double[:] coefficients
+    cdef AbstractNode _other_node
+    cdef AbstractStorage _storage_node
+    cdef public bint use_proportional_volume
+    cdef Parameter _parameter
+
+

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -1,0 +1,84 @@
+""" Module contains Polynomial Parameters """
+from ._parameters import load_parameter
+import numpy as np
+cimport numpy as np
+
+
+cdef class Polynomial1DParameter(Parameter):
+    """ Parameter that returns the result of 1D polynomial evaluation
+
+    The input to the polynomial can be either:
+     - The previous flow of the attached node (default)
+     - The previous flow of another `AbstractNode`
+     - The current storage of an `AbstractStorage` node
+     - The current value of another `Parameter`
+
+    Parameters
+    ----------
+    node : `AbstractNode`
+        An optional `AbstractNode` the flow of which is used to evaluate the polynomial.
+    storage_node : `Storage`
+        An optional `Storage` node the volume of which is used to evaluate the polynomial.
+    parameter : iterable of Parameter objects or single Parameter
+        An optional `Parameter` the value of which is used to evaluate the polynomial.
+    use_proportional_volume : bool
+        An optional boolean only used with a `Storage` node to switch between using absolute
+         or proportional volume when evaluating the polynomial.
+    """
+    def __init__(self, coefficients, *args, **kwargs):
+        self.coefficients = np.array(coefficients, dtype=np.float64)
+        self._other_node = kwargs.pop('node', None)
+        self._storage_node = kwargs.pop('storage_node', None)
+        self._parameter = kwargs.pop('parameter', None)
+        self.use_proportional_volume = kwargs.pop('use_proportional_volume', False)
+        # Check only one of the above is given
+        arg_check = [
+            self._other_node is not None,
+            self._storage_node is not None,
+            self._parameter is not None,
+        ]
+        # Check we haven't been given an ambiguous number of objects
+        if arg_check.count(True) > 1:
+            raise ValueError('Only one of "node", "storage_node" or "parameter" keywords should be given.')
+        super(Polynomial1DParameter, self).__init__(*args, **kwargs)
+
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+        cdef int i
+        cdef double x, y
+
+        # Get the 'x' value to put in the polynomial
+        if self._parameter is not None:
+            x = self._parameter.value(ts, scenario_index)
+        elif self._storage_node is not None:
+            if self.use_proportional_volume:
+                x = self._storage_node.current_pc[scenario_index._global_id]
+            else:
+                x = self._storage_node.volume[scenario_index._global_id]
+        elif self._other_node is not None:
+            x = self._other_node.flow[scenario_index._global_id]
+        else:
+            x = self._node.flow[scenario_index._global_id]
+
+        y = 0.0
+        for i in range(self.coefficients.shape[0]):
+            y += self.coefficients[i]*x**i
+        return y
+
+    @classmethod
+    def load(cls, model, data):
+        node = None
+        if 'node' in data:
+            node = model._get_node_from_ref(model, data["node"])
+        storage_node = None
+        if 'storage_node' in data:
+            storage_node = model._get_node_from_ref(model, data["storage_node"])
+        parameter = None
+        if 'parameter' in data:
+            parameter = load_parameter(model, data["parameter"])
+
+        coefficients = data.pop("coefficients")
+        use_proportional_volume = data.pop("use_proportional_volume", False)
+        parameter = cls(coefficients, node=node, storage_node=storage_node, parameter=parameter,
+                        use_proportional_volume=use_proportional_volume)
+        return parameter
+Polynomial1DParameter.register()

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -42,6 +42,11 @@ cdef class Polynomial1DParameter(Parameter):
         # Check we haven't been given an ambiguous number of objects
         if arg_check.count(True) > 1:
             raise ValueError('Only one of "node", "storage_node" or "parameter" keywords should be given.')
+
+        # Finally register parent relationship if parameter is given
+        if self._parameter is not None:
+            self.children.add(self._parameter)
+
         super(Polynomial1DParameter, self).__init__(*args, **kwargs)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
@@ -108,6 +113,8 @@ cdef class Polynomial2DStorageParameter(Parameter):
         self.coefficients = np.array(coefficients, dtype=np.float64)
         self._storage_node = storage_node
         self._parameter = parameter
+        # Register parameter relationships
+        self.children.add(parameter)
         self.use_proportional_volume = kwargs.pop('use_proportional_volume', False)
         super(Polynomial2DStorageParameter, self).__init__(*args, **kwargs)
 

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -43,11 +43,13 @@ cdef class Polynomial1DParameter(Parameter):
         if arg_check.count(True) > 1:
             raise ValueError('Only one of "node", "storage_node" or "parameter" keywords should be given.')
 
+        super(Polynomial1DParameter, self).__init__(*args, **kwargs)
+
         # Finally register parent relationship if parameter is given
         if self._parameter is not None:
             self.children.add(self._parameter)
 
-        super(Polynomial1DParameter, self).__init__(*args, **kwargs)
+
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         cdef int i
@@ -113,10 +115,11 @@ cdef class Polynomial2DStorageParameter(Parameter):
         self.coefficients = np.array(coefficients, dtype=np.float64)
         self._storage_node = storage_node
         self._parameter = parameter
-        # Register parameter relationships
-        self.children.add(parameter)
         self.use_proportional_volume = kwargs.pop('use_proportional_volume', False)
         super(Polynomial2DStorageParameter, self).__init__(*args, **kwargs)
+
+        # Register parameter relationships
+        self.children.add(parameter)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         cdef int i, j

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -15,6 +15,8 @@ cdef class Polynomial1DParameter(Parameter):
 
     Parameters
     ----------
+    coefficients : array like
+        The 1 dimensional array of polynomial coefficients.
     node : `AbstractNode`
         An optional `AbstractNode` the flow of which is used to evaluate the polynomial.
     storage_node : `Storage`
@@ -82,3 +84,57 @@ cdef class Polynomial1DParameter(Parameter):
                         use_proportional_volume=use_proportional_volume)
         return parameter
 Polynomial1DParameter.register()
+
+
+cdef class Polynomial2DStorageParameter(Parameter):
+    """ Parameter that returns the result of 2D polynomial evaluation
+
+    The 2 dimensions of the polynomial are the volume of a `Storage` node and
+    the current value of a `Parameter` respectively. Both must be given to this parameter.
+
+    Parameters
+    ----------
+    coefficients : array like
+        The 2 dimensional array of polynomial coefficients.
+    storage_node : `Storage`
+        A `Storage` node the volume of which is used to evaluate the polynomial.
+    parameter : iterable of Parameter objects or single Parameter
+        An `Parameter` the value of which is used to evaluate the polynomial.
+    use_proportional_volume : bool
+        An optional boolean only used with a `Storage` node to switch between using absolute
+         or proportional volume when evaluating the polynomial.
+    """
+    def __init__(self, coefficients, storage_node, parameter, *args, **kwargs):
+        self.coefficients = np.array(coefficients, dtype=np.float64)
+        self._storage_node = storage_node
+        self._parameter = parameter
+        self.use_proportional_volume = kwargs.pop('use_proportional_volume', False)
+        super(Polynomial2DStorageParameter, self).__init__(*args, **kwargs)
+
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+        cdef int i, j
+        cdef double x, y, z
+
+        # Storage volume is 1st dimension
+        if self.use_proportional_volume:
+            x = self._storage_node.current_pc[scenario_index._global_id]
+        else:
+            x = self._storage_node.volume[scenario_index._global_id]
+        # Parameter value is 2nd dimension
+        y = self._parameter.value(ts, scenario_index)
+
+        z = 0.0
+        for i in range(self.coefficients.shape[0]):
+            for j in range(self.coefficients.shape[1]):
+                z += self.coefficients[i, j]*x**i*y**j
+        return z
+
+    @classmethod
+    def load(cls, model, data):
+        storage_node = model._get_node_from_ref(model, data["storage_node"])
+        parameter = load_parameter(model, data["parameter"])
+        coefficients = data.pop("coefficients")
+        use_proportional_volume = data.pop("use_proportional_volume", False)
+        parameter = cls(coefficients, storage_node, parameter, use_proportional_volume=use_proportional_volume)
+        return parameter
+Polynomial2DStorageParameter.register()

--- a/pywr/parameters/control_curves.py
+++ b/pywr/parameters/control_curves.py
@@ -70,6 +70,8 @@ class ControlCurveParameter(BaseControlCurveParameter):
                 raise ValueError('Length of parameters should be one more than the number of '
                                  'control curves ({}).'.format(nvalues))
             self.parameters = list(parameters)
+            for p in self.parameters:
+                p.parents.add(self)
         else:
             # No values or parameters given, default to sequence of integers
             self.values = np.arange(nvalues)

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -10,7 +10,7 @@ from ._parameters import (
     IndexParameter, CachedParameter, RecorderThresholdParameter,
     AggregatedParameter, AggregatedIndexParameter,
     load_parameter, load_parameter_values, load_dataframe)
-from ._polynomial import Polynomial1DParameter
+from ._polynomial import Polynomial1DParameter, Polynomial2DStorageParameter
 from past.builtins import basestring
 import numpy as np
 import pandas

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -10,6 +10,7 @@ from ._parameters import (
     IndexParameter, CachedParameter, RecorderThresholdParameter,
     AggregatedParameter, AggregatedIndexParameter,
     load_parameter, load_parameter_values, load_dataframe)
+from ._polynomial import Polynomial1DParameter
 from past.builtins import basestring
 import numpy as np
 import pandas

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ extensions = [
     Extension('pywr.parameters._control_curves', ['pywr/parameters/_control_curves.pyx'],
               include_dirs=[np.get_include()],
               define_macros=define_macros),
+    Extension('pywr.parameters._polynomial', ['pywr/parameters/_polynomial.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
 ]
 
 extensions_optional = []

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -7,9 +7,11 @@ from pywr.parameters import (Parameter, ArrayIndexedParameter, ConstantScenarioP
     ArrayIndexedScenarioMonthlyFactorsParameter, MonthlyProfileParameter, DailyProfileParameter,
     DataFrameParameter, AggregatedParameter, ConstantParameter, CachedParameter,
     IndexParameter, AggregatedIndexParameter, RecorderThresholdParameter, ScenarioMonthlyProfileParameter,
+    Polynomial1DParameter,
     FunctionParameter, AnnualHarmonicSeriesParameter, load_parameter)
-from pywr.recorders import Recorder
 
+from pywr.recorders import Recorder
+from fixtures import simple_linear_model, simple_storage_model
 from helpers import load_model
 
 import datetime
@@ -686,3 +688,60 @@ def test_invalid_parameter_values():
     data = {'name': 'my_parameter', 'type': 'AParameterThatShouldHaveValues'}
     with pytest.raises(ValueError):
         load_parameter_values(model, data)
+
+
+class TestPolynomialParameters:
+    """ Tests for `Polynomial1DParameter` """
+    def test_init(self, simple_storage_model):
+        """ Test initialisation raises error with too many keywords """
+        stg = simple_storage_model.nodes['Storage']
+
+        with pytest.raises(ValueError):
+            # Passing both "parameter" and "storage_node" is invalid
+            Polynomial1DParameter([0.5, np.pi], parameter=ConstantParameter(2.0), storage_node=stg)
+
+    def test_1st_order_with_parameter(self, model):
+        """ Test 1st order with a `Parameter` """
+        p1 = Polynomial1DParameter([0.5, np.pi], parameter=ConstantParameter(2.0))
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        ts = model.timestepper.current
+        np.testing.assert_allclose(p1.value(ts, si), 0.5 + np.pi*2.0)
+
+    def test_2nd_order_with_parameter(self, model):
+        """ Test 2nd order with a `Parameter` """
+        p1 = ConstantParameter(2.0)
+        p1 = Polynomial1DParameter([0.5, np.pi, 3.0], parameter=p1)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        ts = model.timestepper.current
+        np.testing.assert_allclose(p1.value(ts, si), 0.5 + np.pi*2.0 + 3.0*2.0**2)
+
+    def test_1st_order_with_storage(self, simple_storage_model):
+        """ Test with a `Storage` node """
+        model = simple_storage_model
+        stg = model.nodes['Storage']
+
+        p1 = Polynomial1DParameter([0.5, np.pi], storage_node=stg)
+        p2 = Polynomial1DParameter([0.5, np.pi], storage_node=stg, use_proportional_volume=True)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+
+        model.setup()
+
+        ts = model.timestepper.current
+        np.testing.assert_allclose(p1.value(ts, si), 0.5 + np.pi*10)
+        np.testing.assert_allclose(p2.value(ts, si), 0.5 + np.pi * 0.5)
+
+    def test_load(self, model):
+
+        data = {
+            "type": "polynomial1d",
+            "coefficients": [0.5, 2.5],
+            "parameter": {
+                "type": "constant",
+                "value": 1.5
+            }
+        }
+
+        p1 = load_parameter(model, data)
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+        for ts in model.timestepper:
+            np.testing.assert_allclose(p1.value(ts, si), 0.5 + 2.5*1.5)


### PR DESCRIPTION
Two generic polynomial parameters.

The 1D parameter can be related to either a node (for flow), storage (for volume) or another parameter. The 2D parameter is a bit more specialised and uses a storage and parameter for the 2 dimensions. I couldn't think of a clean way to make the choice of the dimensions general while also being efficient.

Fixes #334