### PR TITLE
Add deterministic node ordering.

### DIFF
--- a/pywr/model.py
+++ b/pywr/model.py
@@ -371,7 +371,7 @@ class Model(object):
         destination with the same domain has the source.
         """
 
-        nodes = self.graph.nodes()
+        nodes = sorted(self.graph.nodes(), key=lambda n:n.name)
 
         if inspect.isclass(type1):
             # find all nodes of type1
@@ -429,6 +429,8 @@ class Model(object):
                     if is_valid:
                         all_routes.append(route)
 
+        # Now sort the routes to ensure determinism
+        all_routes = sorted(all_routes, key=lambda r: tuple(n.name for n in r))
         return all_routes
 
     def step(self):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -57,7 +57,7 @@ cdef class CythonGLPKSolver:
         # free the problem
         glp_delete_prob(self.prob)
 
-    cpdef object setup(self, model):
+    def setup(self, model):
         cdef Node supply
         cdef Node demand
         cdef Node node
@@ -76,7 +76,7 @@ cdef class CythonGLPKSolver:
         cdef cross_domain_row
         cdef int n, num
 
-        self.all_nodes = list(model.graph.nodes())
+        self.all_nodes = list(sorted(model.graph.nodes(), key=lambda n:n.name))
         if not self.all_nodes:
             raise ModelStructureError("Model is empty")
         self.nodes_with_cost = []


### PR DESCRIPTION
- `Model.find_all_routes` sorts the nodes by name.
- `setup` in GLPK solver also sorts nodes by name.

This should ensure the rows and columns in the LP are in a deterministic
order.