### PR TITLE
MinimumThresholdVolumeStorageRecorder

### DIFF
--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -80,3 +80,6 @@ cdef class BaseConstantStorageRecorder(StorageRecorder):
 
 cdef class MinimumVolumeStorageRecorder(BaseConstantStorageRecorder):
     pass
+    
+cdef class MinimumThresholdVolumeStorageRecorder(BaseConstantStorageRecorder):
+    cdef public double threshold

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -709,6 +709,22 @@ cdef class MinimumVolumeStorageRecorder(BaseConstantStorageRecorder):
         return 0
 recorder_registry.add(MinimumVolumeStorageRecorder)
 
+cdef class MinimumThresholdVolumeStorageRecorder(BaseConstantStorageRecorder):
+
+    def __init__(self, model, node, threshold, *args, **kwargs):
+        self.threshold = threshold
+        super(MinimumThresholdVolumeStorageRecorder, self).__init__(model, node, *args, **kwargs)
+    
+    cpdef reset(self):
+        self._values[...] = 0.0
+
+    cpdef int save(self) except -1:
+        cdef int i
+        for i in range(self._values.shape[0]):
+            if self._node._volume[i] <= self.threshold:
+                self._values[i] = 1.0 
+        return 0
+recorder_registry.add(MinimumThresholdVolumeStorageRecorder)
 
 def load_recorder(model, data):
     recorder = None

--- a/pywr/_recorders.pyx
+++ b/pywr/_recorders.pyx
@@ -695,6 +695,7 @@ cdef class BaseConstantStorageRecorder(StorageRecorder):
 
     cpdef double[:] values(self):
         return self._values
+recorder_registry.add(BaseConstantStorageRecorder)
 
 cdef class MinimumVolumeStorageRecorder(BaseConstantStorageRecorder):
 
@@ -706,6 +707,7 @@ cdef class MinimumVolumeStorageRecorder(BaseConstantStorageRecorder):
         for i in range(self._values.shape[0]):
             self._values[i] = np.min([self._node._volume[i], self._values[i]])
         return 0
+recorder_registry.add(MinimumVolumeStorageRecorder)
 
 
 def load_recorder(model, data):


### PR DESCRIPTION
A recorder that tracks whether a storage falls below a specified threshold at any point during a model run.

Request also adds  BaseConstantStorageRecorder and MinimumVolumeStorageRecorder to the registry