### PR TITLE
Add filename to JSON exceptions for easier debugging

### DIFF
--- a/pywr/model.py
+++ b/pywr/model.py
@@ -131,7 +131,13 @@ class Model(object):
     @classmethod
     def loads(cls, data, model=None, path=None, solver=None):
         """Read JSON data from a string and parse it as a model document"""
-        data = json.loads(data)
+        try:
+            data = json.loads(data)
+        except json.decoder.JSONDecodeError as e:
+            message = e.args[0]
+            if path:
+                e.args = ("{} [{}]".format(e.args[0], os.path.basename(path)),)
+            raise(e)
         cls._load_includes(data, path)
         return cls.load(data, model, path, solver)
 
@@ -154,7 +160,13 @@ class Model(object):
                 if path is not None:
                     filename = os.path.join(os.path.dirname(path), filename)
                 with open(filename, "r") as f:
-                    include_data = json.loads(f.read())
+                    try:
+                        include_data = json.loads(f.read())
+                    except json.decoder.JSONDecodeError as e:
+                        message = e.args[0]
+                        if path:
+                            e.args = ("{} [{}]".format(e.args[0], os.path.basename(path)),)
+                        raise(e)
                 for key, value in include_data.items():
                     if isinstance(value, list):
                         try:

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -133,7 +133,7 @@ class Model(object):
         """Read JSON data from a string and parse it as a model document"""
         try:
             data = json.loads(data)
-        except json.decoder.JSONDecodeError as e:
+        except ValueError as e:
             message = e.args[0]
             if path:
                 e.args = ("{} [{}]".format(e.args[0], os.path.basename(path)),)
@@ -162,7 +162,7 @@ class Model(object):
                 with open(filename, "r") as f:
                     try:
                         include_data = json.loads(f.read())
-                    except json.decoder.JSONDecodeError as e:
+                    except ValueError as e:
                         message = e.args[0]
                         if path:
                             e.args = ("{} [{}]".format(e.args[0], os.path.basename(path)),)

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -165,7 +165,7 @@ class Model(object):
                     except ValueError as e:
                         message = e.args[0]
                         if path:
-                            e.args = ("{} [{}]".format(e.args[0], os.path.basename(path)),)
+                            e.args = ("{} [{}]".format(e.args[0], os.path.basename(filename)),)
                         raise(e)
                 for key, value in include_data.items():
                     if isinstance(value, list):

--- a/tests/models/invalid.json
+++ b/tests/models/invalid.json
@@ -1,0 +1,1 @@
+This is not a valid JSON file!!!

--- a/tests/models/invalid_include.json
+++ b/tests/models/invalid_include.json
@@ -1,0 +1,35 @@
+{
+    "metadata": {
+        "title": "Invalid include",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "includes": [
+        "invalid.json"
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -441,7 +441,7 @@ def test_json_invalid(solver):
 
 def test_json_invalid_include(solver):
     """JSON exceptions should report file name, even for includes"""
-    filename = os.path.join(TEST_FOLDER, "models", "invalid"+".json")
+    filename = os.path.join(TEST_FOLDER, "models", "invalid_include"+".json")
     with pytest.raises(ValueError) as excinfo:
         model = Model.load(filename, solver=solver)
     assert("invalid.json" in str(excinfo.value))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import pytest
+from json.decoder import JSONDecodeError
 from fixtures import *
 from helpers import *
 from pywr._core import Timestep, ScenarioIndex
@@ -431,3 +432,17 @@ def test_virtual_storage_cost(solver):
     node.cost = 5.0
     with pytest.raises(NotImplementedError):
         model.check()
+
+def test_json_invalid(solver):
+    """JSON exceptions should report file name"""
+    filename = os.path.join(TEST_FOLDER, "models", "invalid"+".json")
+    with pytest.raises(JSONDecodeError) as excinfo:
+        model = Model.load(filename, solver=solver)
+    assert("invalid.json" in str(excinfo.value))
+
+def test_json_invalid_include(solver):
+    """JSON exceptions should report file name, even for includes"""
+    filename = os.path.join(TEST_FOLDER, "models", "invalid_include"+".json")
+    with pytest.raises(JSONDecodeError) as excinfo:
+        model = Model.load(filename, solver=solver)
+    assert("invalid_include.json" in str(excinfo.value))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 
 import pytest
-from json.decoder import JSONDecodeError
 from fixtures import *
 from helpers import *
 from pywr._core import Timestep, ScenarioIndex
@@ -436,13 +435,13 @@ def test_virtual_storage_cost(solver):
 def test_json_invalid(solver):
     """JSON exceptions should report file name"""
     filename = os.path.join(TEST_FOLDER, "models", "invalid"+".json")
-    with pytest.raises(JSONDecodeError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         model = Model.load(filename, solver=solver)
     assert("invalid.json" in str(excinfo.value))
 
 def test_json_invalid_include(solver):
     """JSON exceptions should report file name, even for includes"""
     filename = os.path.join(TEST_FOLDER, "models", "invalid_include"+".json")
-    with pytest.raises(JSONDecodeError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         model = Model.load(filename, solver=solver)
     assert("invalid_include.json" in str(excinfo.value))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -441,7 +441,7 @@ def test_json_invalid(solver):
 
 def test_json_invalid_include(solver):
     """JSON exceptions should report file name, even for includes"""
-    filename = os.path.join(TEST_FOLDER, "models", "invalid_include"+".json")
+    filename = os.path.join(TEST_FOLDER, "models", "invalid"+".json")
     with pytest.raises(ValueError) as excinfo:
         model = Model.load(filename, solver=solver)
-    assert("invalid_include.json" in str(excinfo.value))
+    assert("invalid.json" in str(excinfo.value))


### PR DESCRIPTION
This PR adds the filename of JSON files to the exception message if an error occurs during parsing. This should help prevent a lot of head scratching!

Example:

```
>>> from pywr.model import Model
>>> model = Model.load("tests/models/invalid_include.json")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/snorf/Desktop/pywr/pywr/model.py", line 207, in load
    return cls.loads(data, model, path, solver)
  File "/Users/snorf/Desktop/pywr/pywr/model.py", line 141, in loads
    cls._load_includes(data, path)
  File "/Users/snorf/Desktop/pywr/pywr/model.py", line 169, in _load_includes
    raise(e)
  File "/Users/snorf/Desktop/pywr/pywr/model.py", line 164, in _load_includes
    include_data = json.loads(f.read())
  File "/Users/snorf/miniconda3/envs/pywr/lib/python3.5/json/__init__.py", line 319, in loads
    return _default_decoder.decode(s)
  File "/Users/snorf/miniconda3/envs/pywr/lib/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/snorf/miniconda3/envs/pywr/lib/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0) [invalid.json]
```

Closes #364.