### PR TITLE
Upgraded Python 3.5 -> 3.6 in Travis and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     matrix:
         - CONDA_NPY=111  CONDA_PY=27
         - CONDA_NPY=111  CONDA_PY=34
-        - CONDA_NPY=111  CONDA_PY=35
+        - CONDA_NPY=111  CONDA_PY=36
 
 install:
     - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
       CONDA_NPY: 111
 
     - TARGET_ARCH: x64
-      CONDA_PY: 35
+      CONDA_PY: 36
       CONDA_NPY: 111
 
 # We always use a 64-bit machine, but can build x86 distributions


### PR DESCRIPTION
I think we should continue to support Python 2.7 and Python 3.4 as minimum versions, but have changed the 3.5 tests to 3.6.