### PR TITLE
Add `AnnualCountIndexParameterRecorder`

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -25,7 +25,9 @@ cdef class Timestep:
     cdef int _index
     cdef double _days
     cdef readonly int dayofyear
+    cdef readonly int day
     cdef readonly int month
+    cdef readonly int year
 
 cdef class Domain:
     cdef object name

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -148,7 +148,9 @@ cdef class Timestep:
         self._days = days
         tt = self.datetime.timetuple()
         self.dayofyear = tt.tm_yday
+        self.day = tt.tm_mday
         self.month = tt.tm_mon
+        self.year = tt.tm_year
 
     property datetime:
         """Timestep representation as a `datetime.datetime` object"""

--- a/pywr/_recorders.pxd
+++ b/pywr/_recorders.pxd
@@ -83,3 +83,9 @@ cdef class MinimumVolumeStorageRecorder(BaseConstantStorageRecorder):
     
 cdef class MinimumThresholdVolumeStorageRecorder(BaseConstantStorageRecorder):
     cdef public double threshold
+
+cdef class AnnualCountIndexParameterRecorder(IndexParameterRecorder):
+    cdef public int threshold
+    cdef int[:] _count
+    cdef int _current_year
+    cdef int[:] _current_max

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -633,7 +633,7 @@ def test_annual_count_index_parameter_recorder(simple_storage_model):
     # Demand is roughly 2 Ml/d per year
     #  First ensemble balances the demand
     #  Second ensemble should fail during 3rd year
-    demand = 2 / 365
+    demand = 2.0 / 365
     model.nodes['Input'].max_flow = ConstantScenarioParameter(scenario, [demand, 0])
     model.nodes['Output'].max_flow = demand
 


### PR DESCRIPTION
Records number of failures of an `IndexParameter` at or above a threshold.

Also adds convience attributes to `Timestep` for year and day in the same way as month.