### PR TITLE
Added support for slicing scenarios

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -5,11 +5,13 @@ cdef class Scenario:
     cdef basestring _name
     cdef int _size
     cdef public slice slice
+    cdef object _ensemble_names
 
 cdef class ScenarioCollection:
     cdef public object model
     cdef list _scenarios
-    cdef public list combinations
+    cdef readonly list combinations
+    cdef int[:, :] _user_combinations
     cpdef int get_scenario_index(self, Scenario sc) except? -1
     cpdef add_scenario(self, Scenario sc)
     cpdef int ravel_indices(self, int[:] scenario_indices) except? -1

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -4,6 +4,7 @@ from _recorders cimport Recorder
 cdef class Scenario:
     cdef basestring _name
     cdef int _size
+    cdef public slice slice
 
 cdef class ScenarioCollection:
     cdef public object model

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -57,7 +57,7 @@ cdef class ScenarioCollection:
         else:
             # product of all scenarios, taking into account Scenario.slice
             iter = itertools.product(*[range(scenario._size)[scenario.slice] if scenario.slice else range(scenario._size) for scenario in self._scenarios])
-            combinations = list([ScenarioIndex(i, np.array(x, dtype=np.int)) for i, x in enumerate(iter)])
+            combinations = list([ScenarioIndex(i, np.array(x, dtype=np.int32)) for i, x in enumerate(iter)])
         return combinations
 
     def setup(self):

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -6,19 +6,42 @@ import pandas as pd
 
 cdef double inf = float('inf')
 
-def product(sizes):
-    """ Wrapper for itertools.product to return a np.array """
-    cdef int s
-    for comb in itertools.product(*[range(s) for s in sizes]):
-        yield np.array(comb, dtype=np.int32)
-
 cdef class Scenario:
-    def __init__(self, model, name, int size=1, slice slice=None):
+    """ Represents a scenario in the model.
+
+    Typically a scenario will be used to run many similar models simultaneously. A small
+     number of `Parameter` objects in the model will be return different values depending
+     on the scenario, but many will not. Multiple scenarios can be defined such that
+     some `Parameter` values vary with one scenario, but not another. Scenarios are defined
+     with a size that represents the number of ensembles in within that scenario.
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+        The model instance to attach the scenario to.
+    name : str
+        The name of the scenario.
+    size : int, optional
+        The number of ensembles in the scenario. The default value is 1.
+    slice : slice, optional
+        If given this defines the subset of the ensembles that are actually run
+         in the model. This is useful if a large number of ensembles is defined, but
+         certain analysis (e.g. optimisation) can only be done on a small subset.
+    ensemble_names : iterable of str, optional
+        User defined names describing each ensemble.
+
+    See Also
+    --------
+    `ScenarioCollection`
+     """
+    def __init__(self, model, name, int size=1, slice slice=None, ensemble_names=None):
         self._name = name
         if size < 1:
             raise ValueError("Size must be greater than or equal to 1.")
         self._size = size
         self.slice = slice
+        self.ensemble_names = ensemble_names
+        # Do this last so only set on the model if no error is raised.
         model.scenarios.add_scenario(self)
 
     property size:
@@ -29,11 +52,41 @@ cdef class Scenario:
         def __get__(self):
             return self._name
 
+    property ensemble_names:
+        def __get__(self):
+            if self._ensemble_names is None:
+                return list(range(self._size))
+            return self._ensemble_names
+        def __set__(self, names):
+            if names is None:
+                self._ensemble_names = None
+                return
+            if len(names) != self._size:
+                raise ValueError("The length of ensemble_names ({}) must be equal to the size of the scenario ({})".format(len(names), self.size))
+            self._ensemble_names = names
+
 cdef class ScenarioCollection:
+    """ Represents a collection of `Scenario` objects.
+
+    This class is used by a `Model` instance to hold the defined scenarios and control
+     which combinations of ensembles are used during model execution. By default the
+     product of all scenario ensembles (i.e. all possible combinations of ensembles) is
+     executed. However user defined slices can be set on individual `Scenario` instances
+     to restriction the number of ensembles executed from that scenario. Alternatively
+     the user may provide an array of the specific ensemble combinations (indices) that
+     should be run. The latter approach takes precedent over the former per `Scenario`
+     slices.
+
+    See Also
+    --------
+    `Scenario`
+
+    """
     def __init__(self, model):
         self.model = model
         self._scenarios = []
         self.combinations = None
+        self.user_combinations = None
 
     property scenarios:
         def __get__(self):
@@ -55,13 +108,39 @@ cdef class ScenarioCollection:
             # model has no scenarios defined, implicitly has 1 scenario of size 1
             combinations = [ScenarioIndex(0, np.array([0], dtype=np.int32))]
         else:
-            # product of all scenarios, taking into account Scenario.slice
-            iter = itertools.product(*[range(scenario._size)[scenario.slice] if scenario.slice else range(scenario._size) for scenario in self._scenarios])
-            combinations = list([ScenarioIndex(i, np.array(x, dtype=np.int32)) for i, x in enumerate(iter)])
+            if self._user_combinations is not None:
+                # use combinations given by user
+                combinations = list([ScenarioIndex(i, self._user_combinations[i, :]) for i in range(self._user_combinations.shape[0])])
+            else:
+                # product of all scenarios, taking into account Scenario.slice
+                iter = itertools.product(*[range(scenario._size)[scenario.slice] if scenario.slice else range(scenario._size) for scenario in self._scenarios])
+                combinations = list([ScenarioIndex(i, np.array(x, dtype=np.int32)) for i, x in enumerate(iter)])
         return combinations
 
     def setup(self):
         self.combinations = self.get_combinations()
+
+    property user_combinations:
+        def __get__(self, ):
+            return self._user_combinations
+        def __set__(self, values):
+            if values is None:
+                self._user_combinations = None
+                return
+            cdef Scenario sc
+            values = np.asarray(values, dtype=np.int32)
+            if values.ndim != 2:
+                raise ValueError('A 2-dimensional array of scenario indices must be provided.')
+            if values.shape[1] != len(self._scenarios):
+                raise ValueError('User defined combinations must ')
+            # Check maximum values
+            for sc, v in zip(self._scenarios, values.max(axis=0)):
+                if v >= sc._size:
+                    raise ValueError('Given ensemble index for scenario "{}" out of range.'.format(sc.name))
+            if np.any(values.min(axis=0) < 0):
+                raise ValueError('Ensemble index less than zero is invalid.')
+
+            self._user_combinations = values
 
     cpdef int get_scenario_index(self, Scenario sc) except? -1:
         """Return the index of Scenario in this controller."""
@@ -100,7 +179,7 @@ cdef class ScenarioCollection:
             if len(self._scenarios) == 0:
                 return pd.MultiIndex.from_product([range(1),], names=[''])
             else:
-                ranges = [range(sc._size) for sc in self._scenarios]
+                ranges = [sc.ensemble_names for sc in self._scenarios]
                 names = [sc._name for sc in self._scenarios]
                 return pd.MultiIndex.from_product(ranges, names=names)
 

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -264,7 +264,17 @@ class Model(object):
             for scen_data in scenarios_data:
                 scen_name = scen_data["name"]
                 size = scen_data["size"]
-                Scenario(model, scen_name, size=size)
+                s_slice = scen_data.pop("slice", None)
+                if s_slice:
+                    s_slice = slice(*s_slice)
+                Scenario(model, scen_name, size=size, slice=s_slice)
+
+        try:
+            scenario_combinations = data["scenario_combinations"]
+        except KeyError:
+            pass
+        else:
+            model.scenarios.user_combinations = scenario_combinations
 
         # load table references
         try:

--- a/tests/models/scenario_with_slices.json
+++ b/tests/models/scenario_with_slices.json
@@ -1,0 +1,33 @@
+{
+    "metadata": {
+        "title": "Scenario with slices",
+        "description": "Example of scenario with slices",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10,
+            "slice": [0, null, 2]
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "slice": [0, 1, 1]
+        }
+    ],
+    "nodes": [
+
+    ],
+    "edges": [
+
+    ],
+    "recorders": {
+
+    }
+}

--- a/tests/models/scenario_with_user_combinations.json
+++ b/tests/models/scenario_with_user_combinations.json
@@ -1,0 +1,38 @@
+{
+    "metadata": {
+        "title": "Scenario with slices",
+        "description": "Example of scenario with slices",
+        "minimum_version": "0.2dev"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10,
+            "slice": [0, null, 2]
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "slice": [0, 1, 1]
+        }
+    ],
+    "scenario_combinations": [
+        [0, 0],
+        [0, 1],
+        [5, 1]
+    ],
+    "nodes": [
+
+    ],
+    "edges": [
+
+    ],
+    "recorders": {
+
+    }
+}

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -306,3 +306,19 @@ def test_scenario_user_combinations(simple_linear_model):
         model.scenarios.user_combinations = [[19, 3], [2, 2]]
     with pytest.raises(ValueError):
         model.scenarios.user_combinations = [[-1, 2], [2, 2]]
+
+def test_scenario_slices_json(solver):
+    model = load_model('scenario_with_slices.json', solver=solver)
+    scenarios = model.scenarios
+    assert(len(scenarios) == 2)
+    assert(scenarios["scenario A"].slice == slice(0, None, 2))
+    assert(scenarios["scenario B"].slice == slice(0, 1, 1))
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 5)
+
+def test_scenario_slices_json(solver):
+    model = load_model('scenario_with_user_combinations.json', solver=solver)
+    scenarios = model.scenarios
+    assert(len(scenarios) == 2)
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 3)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -297,10 +297,12 @@ def test_scenario_user_combinations(simple_linear_model):
     combinations = model.scenarios.get_combinations()
     assert(len(combinations) == 2)
 
+    # Test wrong number of dimensions
     with pytest.raises(ValueError):
-        # Test wrong number of dimensions
         model.scenarios.user_combinations = [0, 1, 1, 1]
-        # Test out of range index
-        model.scenarios.user_combinations = [[19, 3], [2, 2]]
-        model.scenarios.user_combinations = [[-1, 2], [2, 2]]
 
+    # Test out of range index
+    with pytest.raises(ValueError):
+        model.scenarios.user_combinations = [[19, 3], [2, 2]]
+    with pytest.raises(ValueError):
+        model.scenarios.user_combinations = [[-1, 2], [2, 2]]

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -244,3 +244,38 @@ def test_dirty_scenario(simple_linear_model):
     assert(not model.dirty)
     scenario = Scenario(model, "test", size=42)
     assert(model.dirty)
+
+def test_scenario_slices(simple_linear_model):
+    """Test slicing of scenarios"""
+    model = simple_linear_model
+
+    # create two scenarios
+    s1 = Scenario(model=model, name="A", size=20)
+    s2 = Scenario(model=model, name="B", size=3)
+
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 20 * 3)
+
+    s1.slice = slice(0, None, 2)
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 10 * 3)
+
+    s2.slice = slice(1, 3, 1)
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 10 * 2)
+
+    assert(combinations[0].global_id == 0)
+    assert(tuple(combinations[0].indices) == (0, 1))
+
+    assert(combinations[-1].global_id == 19)
+    assert(tuple(combinations[-1].indices) == (18, 2))
+
+    model.run()
+
+    node = model.nodes["Input"]
+    assert((len(combinations),) == node.flow.shape)
+
+    s1.slice = None
+    s2.slice = None
+    combinations = model.scenarios.get_combinations()
+    assert(len(combinations) == 20 * 3)


### PR DESCRIPTION
Added support for slicing scenarios, in order to run only a subset.

Example usage:

```
scenario_weather = Scenario(model, size=200)
scenario_demand = Scenario(model, size=3)
scenario_weather.slice = slice(0, 50, 1) # only the first 50 weather scenarios
scenario_demand.slice = slice(2, 3, 1) # only the last demand scenario
```

This partially addresses #385. Not implemented is JSON support (is this needed?) or support for arbitrary combinations.

I'd like to use this next week. We can add the other bits as needed.