### PR TITLE
Added an option for H5Store and TablesRecorder to create directories

### DIFF
--- a/pywr/h5tools.py
+++ b/pywr/h5tools.py
@@ -1,9 +1,11 @@
 import tables
 import sys
 from past.builtins import basestring
+import os
+
 
 class H5Store(object):
-    def __init__(self, filename, filter_kwds=None, mode="r", title='', metadata=None):
+    def __init__(self, filename, filter_kwds=None, mode="r", title='', metadata=None, create_directories=False):
         filter_kwds = filter_kwds
         mode = mode
         self._opened = False
@@ -19,6 +21,16 @@ class H5Store(object):
                 filters = tables.Filters(**filter_kwds)
             else:
                 filters = None
+
+            # Create directories for the filename if required
+            if create_directories:
+                try:
+                    os.makedirs(os.path.dirname(filename))
+                except OSError as exception:
+                    import errno
+                    if exception.errno != errno.EEXIST:
+                        raise
+
             self.file = tables.open_file(filename, mode=mode, filters=filters, title=title)
             self._opened = True
         elif isinstance(filename, tables.File):

--- a/pywr/recorders.py
+++ b/pywr/recorders.py
@@ -113,10 +113,14 @@ class TablesRecorder(Recorder):
             Model argument to pass to tables.open_file. Defaults to 'w'
         metadata : dict
             Dict of user defined attributes to save on the root node (`root._v_attrs`)
+        create_directories : bool
+            If a file path is given and create_directories is True then attempt to make the intermediate
+            directories. This uses os.makedirs() underneath.
         """
         self.filter_kwds = kwargs.pop('filter_kwds', {})
         self.mode = kwargs.pop('mode', 'w')
         self.metadata = kwargs.pop('metadata', {})
+        self.create_directories = kwargs.pop('create_directories', False)
 
         title = kwargs.pop('title', None)
         if title is None:
@@ -159,7 +163,8 @@ class TablesRecorder(Recorder):
         scenario_shape = list(self.model.scenarios.shape)
         shape = [len(self.model.timestepper)] + scenario_shape
 
-        self.h5store = H5Store(self.h5file, self.filter_kwds, self.mode, title=self.title, metadata=self.metadata)
+        self.h5store = H5Store(self.h5file, self.filter_kwds, self.mode, title=self.title, metadata=self.metadata,
+                               create_directories=self.create_directories)
 
         # Create a CArray for each node
         self._arrays = {}

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -19,6 +19,7 @@ from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
 
 from pywr.parameters import DailyProfileParameter, FunctionParameter
 from helpers import load_model
+import os
 
 
 def test_numpy_recorder(simple_linear_model):
@@ -296,6 +297,22 @@ def test_csv_recorder(simple_linear_model, tmpdir):
 
 
 class TestTablesRecorder:
+
+    def test_create_directory(self, simple_linear_model, tmpdir):
+        """ Test TablesRecorder to create a new directory """
+
+        model = simple_linear_model
+        otpt = model.nodes['Output']
+        inpt = model.nodes['Input']
+        agg_node = AggregatedNode(model, 'Sum', [otpt, inpt])
+
+        inpt.max_flow = 10.0
+        otpt.cost = -2.0
+        # Make a path with a new directory
+        h5file = tmpdir.join('outputs', 'output.h5')
+        rec = TablesRecorder(model, str(h5file), create_directories=True)
+        model.run()
+        assert os.path.exists(str(h5file))
 
     def test_nodes(self, simple_linear_model, tmpdir):
         """


### PR DESCRIPTION
Default is the same as it was, but you can now pass `create_directories=True` and the reorder will make any missing directories for you.