### PR TITLE
Fix TotalDeficitNodeRecorder to multiply by time-step length.

### DIFF
--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -804,10 +804,11 @@ cdef class TotalDeficitNodeRecorder(BaseConstantNodeRecorder):
         cdef double max_flow
         cdef ScenarioIndex scenario_index
         cdef Timestep ts = self.model.timestepper.current
+        cdef int days = self.model.timestepper.delta.days
         cdef AbstractNode node = self._node
         for scenario_index in self.model.scenarios.combinations:
             max_flow = node.get_max_flow(ts, scenario_index)
-            self._values[scenario_index._global_id] += max_flow - node._flow[scenario_index._global_id]
+            self._values[scenario_index._global_id] += (max_flow - node._flow[scenario_index._global_id])*days
 
         return 0
 TotalDeficitNodeRecorder.register()

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -804,7 +804,7 @@ cdef class TotalDeficitNodeRecorder(BaseConstantNodeRecorder):
         cdef double max_flow
         cdef ScenarioIndex scenario_index
         cdef Timestep ts = self.model.timestepper.current
-        cdef int days = self.model.timestepper.delta.days
+        cdef int days = self.model.timestepper.current.days
         cdef AbstractNode node = self._node
         for scenario_index in self.model.scenarios.combinations:
             max_flow = node.get_max_flow(ts, scenario_index)
@@ -827,7 +827,7 @@ cdef class TotalFlowNodeRecorder(BaseConstantNodeRecorder):
     cpdef after(self):
         cdef ScenarioIndex scenario_index
         cdef int i
-        cdef int days = self.model.timestepper.delta.days
+        cdef int days = self.model.timestepper.current.days
         for scenario_index in self.model.scenarios.combinations:
             i = scenario_index._global_id
             self._values[i] += self._node._flow[i]*self.factor*days

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -596,6 +596,7 @@ def test_total_deficit_node_recorder(simple_linear_model):
     Test TotalDeficitNodeRecorder
     """
     model = simple_linear_model
+    model.timestepper.delta = 5
     otpt = model.nodes['Output']
     otpt.max_flow = 30.0
     model.nodes['Input'].max_flow = 10.0
@@ -603,10 +604,10 @@ def test_total_deficit_node_recorder(simple_linear_model):
     rec = TotalDeficitNodeRecorder(model, otpt)
 
     model.step()
-    assert_allclose(20.0, rec.aggregated_value(), atol=1e-7)
+    assert_allclose(20.0*5, rec.aggregated_value(), atol=1e-7)
 
     model.step()
-    assert_allclose(40.0, rec.aggregated_value(), atol=1e-7)
+    assert_allclose(40.0*5, rec.aggregated_value(), atol=1e-7)
 
 
 def test_total_flow_node_recorder(simple_linear_model):


### PR DESCRIPTION
Fixes #433