### PR TITLE
Performance improvement in calc_values.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -20,7 +20,7 @@ cdef class ScenarioCombinations:
     cdef ScenarioCollection _collection
 
 cdef class ScenarioIndex:
-    cdef int _global_id
+    cdef readonly int global_id
     cdef int[:] _indices
 
 cdef class Timestep:

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -196,19 +196,15 @@ cdef class ScenarioCollection:
 
 cdef class ScenarioIndex:
     def __init__(self, int global_id, int[:] indices):
-        self._global_id = global_id
+        self.global_id = global_id
         self._indices = indices
-
-    property global_id:
-        def __get__(self):
-            return self._global_id
 
     property indices:
         def __get__(self):
             return np.array(self._indices)
 
     def __repr__(self):
-        return "<ScenarioIndex gid={:d} indices={}>".format(self._global_id, tuple(np.asarray(self._indices)))
+        return "<ScenarioIndex gid={:d} indices={}>".format(self.global_id, tuple(np.asarray(self._indices)))
 
 
 cdef class Timestep:

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -128,7 +128,7 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
             self._values = np.array(values)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef int i = scenario_index._global_id
+        cdef int i = scenario_index.global_id
         cdef int j
         cdef Parameter cc_param
         cdef double cc, cc_prev
@@ -227,7 +227,7 @@ cdef class ControlCurveIndexParameter(IndexParameter):
         cdef double target_percentage
         cdef int index, j
         cdef Parameter control_curve
-        current_percentage = self.storage_node._current_pc[scenario_index._global_id]
+        current_percentage = self.storage_node._current_pc[scenario_index.global_id]
         index = len(self.control_curves)
         for j, control_curve in enumerate(self.control_curves):
             target_percentage = control_curve.get_value(scenario_index)

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -1,6 +1,6 @@
 from pywr.recorders._recorders cimport Recorder
 from pywr._component cimport Component
-from .._core cimport Timestep, Scenario, ScenarioIndex, AbstractNode
+from .._core cimport Timestep, Scenario, ScenarioIndex, ScenarioCollection, AbstractNode
 
 cdef class Parameter(Component):
     cdef int _size

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -569,7 +569,7 @@ cdef class IndexParameter(Parameter):
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         """Returns the current index as a float"""
         # return index as a float
-        return float(self.index(timestep, scenario_index))
+        return float(self.get_index(scenario_index))
 
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         """Returns the current index"""

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -41,10 +41,10 @@ cdef class Parameter(Component):
         cdef ScenarioIndex scenario_index
         cdef ScenarioCollection scenario_collection = self.model.scenarios
         for scenario_index in scenario_collection.combinations:
-            self.__values[<int>(scenario_index._global_id)] = self.value(timestep, scenario_index)
+            self.__values[<int>(scenario_index.global_id)] = self.value(timestep, scenario_index)
 
     cpdef double get_value(self, ScenarioIndex scenario_index):
-        return self.__values[<int>(scenario_index._global_id)]
+        return self.__values[<int>(scenario_index.global_id)]
 
     cpdef double[:] get_all_values(self):
         return self.__values
@@ -589,11 +589,11 @@ cdef class IndexParameter(Parameter):
         cdef ScenarioIndex scenario_index
         cdef ScenarioCollection scenario_collection = self.model.scenarios
         for scenario_index in scenario_collection.combinations:
-            self.__indices[<int>(scenario_index._global_id)] = self.index(timestep, scenario_index)
-            self.__values[<int>(scenario_index._global_id)] = self.value(timestep, scenario_index)
+            self.__indices[<int>(scenario_index.global_id)] = self.index(timestep, scenario_index)
+            self.__values[<int>(scenario_index.global_id)] = self.value(timestep, scenario_index)
 
     cpdef int get_index(self, ScenarioIndex scenario_index):
-        return self.__indices[<int>(scenario_index._global_id)]
+        return self.__indices[<int>(scenario_index.global_id)]
 
     cpdef int[:] get_all_indices(self):
         return self.__indices

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -39,11 +39,12 @@ cdef class Parameter(Component):
     cpdef calc_values(self, Timestep timestep):
         # default implementation calls Parameter.value in loop
         cdef ScenarioIndex scenario_index
-        for scenario_index in self.model.scenarios.combinations:
-            self.__values[<int>(scenario_index.global_id)] = self.value(timestep, scenario_index)
+        cdef ScenarioCollection scenario_collection = self.model.scenarios
+        for scenario_index in scenario_collection.combinations:
+            self.__values[<int>(scenario_index._global_id)] = self.value(timestep, scenario_index)
 
     cpdef double get_value(self, ScenarioIndex scenario_index):
-        return self.__values[<int>(scenario_index.global_id)]
+        return self.__values[<int>(scenario_index._global_id)]
 
     cpdef double[:] get_all_values(self):
         return self.__values
@@ -586,12 +587,13 @@ cdef class IndexParameter(Parameter):
 
     cpdef calc_values(self, Timestep timestep):
         cdef ScenarioIndex scenario_index
-        for scenario_index in self.model.scenarios.combinations:
-            self.__indices[<int>(scenario_index.global_id)] = self.index(timestep, scenario_index)
-            self.__values[<int>(scenario_index.global_id)] = self.value(timestep, scenario_index)
+        cdef ScenarioCollection scenario_collection = self.model.scenarios
+        for scenario_index in scenario_collection.combinations:
+            self.__indices[<int>(scenario_index._global_id)] = self.index(timestep, scenario_index)
+            self.__values[<int>(scenario_index._global_id)] = self.value(timestep, scenario_index)
 
     cpdef int get_index(self, ScenarioIndex scenario_index):
-        return self.__indices[<int>(scenario_index.global_id)]
+        return self.__indices[<int>(scenario_index._global_id)]
 
     cpdef int[:] get_all_indices(self):
         return self.__indices

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -64,16 +64,16 @@ cdef class Polynomial1DParameter(Parameter):
 
         # Get the 'x' value to put in the polynomial
         if self._parameter is not None:
-            x = self._parameter.__values[scenario_index._global_id]
+            x = self._parameter.__values[scenario_index.global_id]
         elif self._storage_node is not None:
             if self.use_proportional_volume:
-                x = self._storage_node._current_pc[scenario_index._global_id]
+                x = self._storage_node._current_pc[scenario_index.global_id]
             else:
-                x = self._storage_node._volume[scenario_index._global_id]
+                x = self._storage_node._volume[scenario_index.global_id]
         elif self._other_node is not None:
-            x = self._other_node._flow[scenario_index._global_id]
+            x = self._other_node._flow[scenario_index.global_id]
         else:
-            x = self._node._flow[scenario_index._global_id]
+            x = self._node._flow[scenario_index.global_id]
 
         # Apply scaling and offset
         x = x*self.scale + self.offset
@@ -151,11 +151,11 @@ cdef class Polynomial2DStorageParameter(Parameter):
 
         # Storage volume is 1st dimension
         if self.use_proportional_volume:
-            x = self._storage_node._current_pc[scenario_index._global_id]
+            x = self._storage_node._current_pc[scenario_index.global_id]
         else:
-            x = self._storage_node._volume[scenario_index._global_id]
+            x = self._storage_node._volume[scenario_index.global_id]
         # Parameter value is 2nd dimension
-        y = self._parameter.__values[scenario_index._global_id]
+        y = self._parameter.__values[scenario_index.global_id]
 
         # Apply scaling and offset
         x = self.storage_scale*x + self.storage_offset

--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -60,7 +60,7 @@ cdef class AbstractThresholdParameter(IndexParameter):
 
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         """Returns a value from the values attribute, using the index"""
-        cdef int ind = self.index(timestep, scenario_index)
+        cdef int ind = self.get_index(scenario_index)
         cdef double v
         if self.values is not None:
             v = self.values[ind]

--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -99,7 +99,7 @@ cdef class StorageThresholdParameter(AbstractThresholdParameter):
         self.storage = storage
 
     cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
-        return self.storage._volume[scenario_index._global_id]
+        return self.storage._volume[scenario_index.global_id]
 
     @classmethod
     def load(cls, model, data):
@@ -124,7 +124,7 @@ cdef class NodeThresholdParameter(AbstractThresholdParameter):
         self.node = node
 
     cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
-        return self.node._flow[scenario_index._global_id]
+        return self.node._flow[scenario_index.global_id]
 
     @classmethod
     def load(cls, model, data):
@@ -179,7 +179,7 @@ cdef class RecorderThresholdParameter(AbstractThresholdParameter):
 
     cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         # TODO Make this a more general API on Recorder
-        return self.recorder.data[timestep._index - 1, scenario_index._global_id]
+        return self.recorder.data[timestep._index - 1, scenario_index.global_id]
 
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         """Returns 1 if the predicate evalutes True, else 0"""

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -839,7 +839,7 @@ cdef class TotalDeficitNodeRecorder(BaseConstantNodeRecorder):
         cdef AbstractNode node = self._node
         for scenario_index in self.model.scenarios.combinations:
             max_flow = node.get_max_flow(ts, scenario_index)
-            self._values[scenario_index._global_id] += (max_flow - node._flow[scenario_index._global_id])*days
+            self._values[scenario_index.global_id] += (max_flow - node._flow[scenario_index.global_id])*days
 
         return 0
 TotalDeficitNodeRecorder.register()
@@ -860,7 +860,7 @@ cdef class TotalFlowNodeRecorder(BaseConstantNodeRecorder):
         cdef int i
         cdef int days = self.model.timestepper.current.days
         for scenario_index in self.model.scenarios.combinations:
-            i = scenario_index._global_id
+            i = scenario_index.global_id
             self._values[i] += self._node._flow[i]*self.factor*days
         return 0
 TotalFlowNodeRecorder.register()
@@ -877,8 +877,8 @@ cdef class DeficitFrequencyNodeRecorder(BaseConstantNodeRecorder):
         cdef AbstractNode node = self._node
         for scenario_index in self.model.scenarios.combinations:
             max_flow = node.get_max_flow(ts, scenario_index)
-            if abs(node._flow[scenario_index._global_id] - max_flow) > 1e-6:
-                self._values[scenario_index._global_id] += 1.0
+            if abs(node._flow[scenario_index.global_id] - max_flow) > 1e-6:
+                self._values[scenario_index.global_id] += 1.0
 
     cpdef finish(self):
         cdef int i
@@ -975,8 +975,8 @@ cdef class AnnualCountIndexParameterRecorder(IndexParameterRecorder):
             value = self._param.get_index(scenario_index)
 
             # Update annual max if a new maximum is found
-            if value > self._current_max[scenario_index._global_id]:
-                self._current_max[scenario_index._global_id] = value
+            if value > self._current_max[scenario_index.global_id]:
+                self._current_max[scenario_index.global_id] = value
 
         return 0
 

--- a/pywr/recorders/_thresholds.pyx
+++ b/pywr/recorders/_thresholds.pyx
@@ -72,8 +72,8 @@ cdef class StorageThresholdRecorder(StorageRecorder):
         cdef double volume
         cdef ScenarioIndex scenario_index
         for scenario_index in self.model.scenarios.combinations:
-            volume = self._node._volume[scenario_index._global_id]
-            self._state[scenario_index._global_id] = compare(volume, self.threshold, self.predicate)
+            volume = self._node._volume[scenario_index.global_id]
+            self._state[scenario_index.global_id] = compare(volume, self.threshold, self.predicate)
         return 0
 
 
@@ -117,8 +117,8 @@ cdef class NodeThresholdRecorder(NodeRecorder):
         cdef double flow
         cdef ScenarioIndex scenario_index
         for scenario_index in self.model.scenarios.combinations:
-            flow = self._node._flow[scenario_index._global_id]
-            self._state[scenario_index._global_id] = compare(flow, self.threshold, self.predicate)
+            flow = self._node._flow[scenario_index.global_id]
+            self._state[scenario_index.global_id] = compare(flow, self.threshold, self.predicate)
         return 0
 
 

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -431,21 +431,21 @@ cdef class CythonGLPKSolver:
         # update storage node constraint
         for col, storage in enumerate(storages):
             max_volume = storage.get_max_volume(timestep, scenario_index)
-            avail_volume = max(storage._volume[scenario_index._global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
+            avail_volume = max(storage._volume[scenario_index.global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
             # change in storage cannot be more than the current volume or
             # result in maximum volume being exceeded
             lb = -avail_volume/timestep._days
-            ub = (max_volume-storage._volume[scenario_index._global_id])/timestep._days
+            ub = (max_volume - storage._volume[scenario_index.global_id]) / timestep._days
             set_row_bnds(self.prob, self.idx_row_storages+col, constraint_type(lb, ub), lb, ub)
 
         # update virtual storage node constraint
         for col, storage in enumerate(virtual_storages):
             max_volume = storage.get_max_volume(timestep, scenario_index)
-            avail_volume = max(storage._volume[scenario_index._global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
+            avail_volume = max(storage._volume[scenario_index.global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
             # change in storage cannot be more than the current volume or
             # result in maximum volume being exceeded
             lb = -avail_volume/timestep._days
-            ub = (max_volume-storage._volume[scenario_index._global_id])/timestep._days
+            ub = (max_volume - storage._volume[scenario_index.global_id]) / timestep._days
             set_row_bnds(self.prob, self.idx_row_virtual_storages+col, constraint_type(lb, ub), lb, ub)
 
         self.stats['bounds_update_storage'] += time.clock() - t0
@@ -485,7 +485,7 @@ cdef class CythonGLPKSolver:
         # commit the total flows
         for n in range(0, self.num_nodes):
             _node = self.all_nodes[n]
-            _node.commit(scenario_index._global_id, node_flows[n])
+            _node.commit(scenario_index.global_id, node_flows[n])
 
         self.stats['result_update'] += time.clock() - t0
 

--- a/pywr/solvers/cython_lpsolve.pyx
+++ b/pywr/solvers/cython_lpsolve.pyx
@@ -498,21 +498,21 @@ cdef class CythonLPSolveSolver:
         # update storage node constraint
         for col, storage in enumerate(storages):
             max_volume = storage.get_max_volume(timestep, scenario_index)
-            avail_volume = max(storage._volume[scenario_index._global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
+            avail_volume = max(storage._volume[scenario_index.global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
             # change in storage cannot be more than the current volume or
             # result in maximum volume being exceeded
             lb = -avail_volume/timestep.days
-            ub = (max_volume-storage._volume[scenario_index._global_id])/timestep.days
+            ub = (max_volume - storage._volume[scenario_index.global_id]) / timestep.days
             set_row_bnds(self.prob, self.idx_row_storages+col, lb, ub)
 
         # update virtual storage node constraint
         for col, storage in enumerate(virtual_storages):
             max_volume = storage.get_max_volume(timestep, scenario_index)
-            avail_volume = max(storage._volume[scenario_index._global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
+            avail_volume = max(storage._volume[scenario_index.global_id] - storage.get_min_volume(timestep, scenario_index), 0.0)
             # change in storage cannot be more than the current volume or
             # result in maximum volume being exceeded
             lb = -avail_volume/timestep.days
-            ub = (max_volume-storage._volume[scenario_index._global_id])/timestep.days
+            ub = (max_volume - storage._volume[scenario_index.global_id]) / timestep.days
             set_row_bnds(self.prob, self.idx_row_virtual_storages+col, lb, ub)
 
         self.stats['bounds_update_storage'] += time.clock() - t0
@@ -539,11 +539,11 @@ cdef class CythonLPSolveSolver:
 
         for route, flow in zip(routes, route_flow):
             # TODO make this cleaner.
-            route[0].commit(scenario_index._global_id, flow)
-            route[-1].commit(scenario_index._global_id, flow)
+            route[0].commit(scenario_index.global_id, flow)
+            route[-1].commit(scenario_index.global_id, flow)
             for node in route[1:-1]:
                 if isinstance(node, BaseLink):
-                    node.commit(scenario_index._global_id, flow)
+                    node.commit(scenario_index.global_id, flow)
 
         self.stats['result_update'] += time.clock() - t0
 


### PR DESCRIPTION
 - Results from using ScenarioIndex._global_id rather than ScenarioIndex.global_id.
 - Also typed the ScenarioCollection so the loop knows .collections is a list.

There is a bunch of time still spent in `calc_values`, but I think most of this is overhead from it being called from Python. I.e. you would need to type the `Parameter` objects in model to make this faster.