### PR TITLE
Added Model.find_orphaned_components method. Closes #444.

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -1,4 +1,5 @@
 from pywr._core cimport *
+from pywr._component cimport Component
 import itertools
 import numpy as np
 cimport numpy as np
@@ -264,6 +265,23 @@ cdef class AbstractNode:
         if kwargs:
             raise TypeError("__init__() got an unexpected keyword argument '{}'".format(list(kwargs.items())[0]))
 
+    component_attrs = [] # redefined by subclasses
+    property components:
+        """Generator that returns all of the Components attached to the Node
+
+        This is used by Model.find_orphaned_parameters and isn't performance
+        critical.
+        """
+        def __get__(self):
+            for attr in self.component_attrs:
+                try:
+                    component = getattr(self, attr)
+                except AttributeError:
+                    pass
+                else:
+                    if isinstance(component, Component):
+                        yield component
+
     property allow_isolated:
         """ A property to flag whether this Node can be unconnected in a network. """
         def __get__(self):
@@ -401,6 +419,8 @@ cdef class Node(AbstractNode):
         self._cost_param = None
         self._conversion_factor_param = None
         self._domain = None
+
+    component_attrs = ["min_flow", "max_flow", "cost", "conversion_factor"]
 
     property cost:
         """The cost per unit flow via the node
@@ -662,6 +682,8 @@ cdef class Storage(AbstractStorage):
         self._cost_param = None
         self._domain = None
         self._allow_isolated = True
+
+    component_attrs = ["cost", "initial_volume", "min_volume", "max_volume", "level"]
 
     property cost:
         """The cost per unit increased in volume stored

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -683,7 +683,7 @@ cdef class Storage(AbstractStorage):
         self._domain = None
         self._allow_isolated = True
 
-    component_attrs = ["cost", "initial_volume", "min_volume", "max_volume", "level"]
+    component_attrs = ["cost", "min_volume", "max_volume", "level"]
 
     property cost:
         """The cost per unit increased in volume stored

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -26,6 +26,9 @@ from pywr.parameters._parameters import load_dataframe
 from pywr.parameters._parameters import Parameter as BaseParameter
 from pywr.recorders import ParameterRecorder, IndexParameterRecorder, Recorder
 
+class OrphanedParameterWarning(Warning):
+    pass
+
 class ModelDocumentWarning(Warning): # TODO
     pass
 
@@ -130,6 +133,9 @@ class Model(object):
         for node in self.nodes:
             node.check()
         self.check_graph()
+        orphans = self.find_orphaned_parameters()
+        if orphans:
+            warnings.warn("Model has {} orphaned parameters".format(len(orphans)), OrphanedParameterWarning)
 
     def check_graph(self):
         """Check the connectivity of the graph is valid"""

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -686,9 +686,7 @@ class Model(object):
         for parameter in self.components:
             if parameter.parents:
                 visited.add(parameter)
-        # Find all parameters referenced by a node. This is a bit hackish;
-        # ideally Nodes would provide a method to access their children.
-        #attrs = ["max_flow", "min_flow", "cost", "max_volume", "min_volume", "initial_volume", "mrf", "mrf_cost"]
+        # find all parameters referenced by a node
         for node in self.graph.nodes():
             for component in node.components:
                 visited.add(component)

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -153,7 +153,7 @@ def align_and_resample_dataframe(df, datetime_index):
 
 cdef class DataFrameParameter(Parameter):
     """Timeseries parameter with automatic alignment and resampling
-    
+
     Parameters
     ----------
     model : pywr.model.Model

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1063,7 +1063,7 @@ def test_orphaned_components(simple_linear_model):
     with pytest.warns(None) as record:
         model.check()
     for w in record:
-        if isinstance(w, OperhanedParameterWarning):
+        if isinstance(w, OrphanedParameterWarning):
             pytest.fail("OrphanedParameterWarning raised unexpectedly!")
 
     # add some orphans


### PR DESCRIPTION
This commit adds a method helpful in searching for parameters in
the model that aren't used. AbstractNode now provides a components
property which yields all of the components it uses. This is done
using a class attribute, component_attrs, which lists all of the
properties on a class which may hold a component (e.g. max_flow).
This will allow nodes to define new properties in the future,
although most will be caught anyway as all nodes in the model
are queried, including the children of complex nodes.

Also something (I used git stash?) seemed to remove a bunch of blank lines. Hopefully that's not going to create merge issues... I'll sort if it does.