### PR TITLE
Added DeficitParameter

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -1,6 +1,6 @@
 from pywr.recorders._recorders cimport Recorder
 from pywr._component cimport Component
-from .._core cimport Timestep, Scenario, ScenarioIndex, ScenarioCollection, AbstractNode
+from .._core cimport Timestep, Scenario, ScenarioIndex, ScenarioCollection, AbstractNode, Node
 
 cdef class Parameter(Component):
     cdef int _size
@@ -133,3 +133,5 @@ cdef class MinParameter(Parameter):
 cdef class NegativeMinParameter(MinParameter):
     pass
 
+cdef class DeficitParameter(Parameter):
+    cdef public Node node

--- a/tests/models/deficit.json
+++ b/tests/models/deficit.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Deficit",
+        "description": "Example of deficit parameter",
+        "minimum_version": "0.4dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-20",
+        "end": "2015-12-31",
+        "timestep": 31
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "monthlyprofile",
+                "values": [5, 6, 7, 8, 9, 10, 11, 12, 11, 10, 9, 8]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "yesterday_deficit",
+            "type": "input",
+            "max_flow": "deficit"
+        },
+        {
+            "name": "dummy_output",
+            "type": "output",
+            "max_flow": null,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["yesterday_deficit", "dummy_output"]
+    ],
+    "parameters": {
+        "deficit": {
+            "type": "deficit",
+            "node": "demand1"
+        }
+    },
+    "recorders": {
+        "deficit_recorder": {
+            "type": "numpyarrayparameterrecorder",
+            "parameter": "deficit"
+        },
+        "yesterday_recorder": {
+            "type": "numpyarraynoderecorder",
+            "node": "yesterday_deficit"
+        }
+    }
+}

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -125,7 +125,7 @@ def test_parameter_array_indexed_scenario_monthly_factors_json(model):
     model.path = os.path.join(TEST_DIR, "models")
     scA = Scenario(model, 'Scenario A', size=2)
     scB = Scenario(model, 'Scenario B', size=3)
-    
+
     p1 = ArrayIndexedScenarioMonthlyFactorsParameter.load(model, {
         "scenario": "Scenario A",
         "values": list(range(32)),
@@ -591,7 +591,7 @@ def test_simple_json_parameter_reference(solver):
 def test_threshold_parameter(simple_linear_model):
     model = simple_linear_model
     model.timestepper.delta = 150
-    
+
     scenario = Scenario(model, "Scenario", size=2)
 
     class DummyRecorder(Recorder):
@@ -608,7 +608,7 @@ def test_threshold_parameter(simple_linear_model):
 
     threshold = 10.0
     values = [50.0, 60.0]
-    
+
     rec1 = DummyRecorder(model, threshold-5, name="rec1")  # below
     rec2 = DummyRecorder(model, threshold, name="rec2")    # equal
     rec3 = DummyRecorder(model, threshold+5, name="rec3")  # above
@@ -620,7 +620,7 @@ def test_threshold_parameter(simple_linear_model):
         ("LE", (1, 1, 0)),
         ("GE", (0, 1, 1)),
     ]
-    
+
     for predicate, (value_lt, value_eq, value_gt) in expected:
         for rec in (rec1, rec2, rec3):
             param = RecorderThresholdParameter(model, rec, threshold, values=values, predicate=predicate)
@@ -629,7 +629,7 @@ def test_threshold_parameter(simple_linear_model):
             e[0, :] = values[1] # first timestep is always "on"
             r = AssertionRecorder(model, param, expected_data=e)
             r.name = "assert {} {} {}".format(rec.val, predicate, threshold)
-    
+
     model.run()
 
 
@@ -915,7 +915,7 @@ class TestMinMaxNegativeParameter:
         model = simple_linear_model
         model.timestepper.start = "2017-01-01"
         model.timestepper.end = "2017-01-15"
-        
+
         data = {
             "type": ptype,
             "parameter": {
@@ -925,18 +925,18 @@ class TestMinMaxNegativeParameter:
             }
         }
 
-        
+
         if ptype in ("max", "min"):
             data["threshold"] = 3
-        
+
         func = {"min": min, "max": max, "negative": lambda t,x: -x, "negativemax": lambda t,x: max(t, -x)}[ptype]
-        
+
         model.nodes["Input"].max_flow = parameter = load_parameter(model, data)
         model.nodes["Output"].max_flow = 9999
         model.nodes["Output"].cost = -100
-        
+
         daily_profile = model.parameters["raw"]
-        
+
         @assert_rec(model, parameter)
         def expected(timestep, scenario_index):
             value = daily_profile.get_value(scenario_index)
@@ -1052,3 +1052,25 @@ class TestThresholdParameters:
         # flow < 5
         assert p1.index(m.timestepper.current, si) == 0
 
+
+def test_deficit_parameter(solver):
+    """Test DeficitParameter
+
+    Here we test both uses of the DeficitParameter:
+      1) Recording the deficit for a node each timestep
+      2) Using yesterday's deficit to control today's flow
+    """
+    model = load_model("deficit.json", solver=solver)
+
+    model.run()
+
+    max_flow = np.array([5, 6, 7, 8, 9, 10, 11, 12, 11, 10, 9, 8])
+    demand = 10.0
+    supplied = np.minimum(max_flow, demand)
+    expected = demand - supplied
+    actual = model.recorders["deficit_recorder"].data
+    assert_allclose(expected, actual[:,0])
+
+    expected_yesterday = [0]+list(expected[0:-1])
+    actual_yesterday = model.recorders["yesterday_recorder"].data
+    assert_allclose(expected_yesterday, actual_yesterday[:,0])


### PR DESCRIPTION
This PR implements a *parameter* which tracks deficit. See notes in the class docstring about how this works. It's then easy to record the deficit using an numpy or tables recorder. The parameter can also be used by the solver evaluated as yesterday's deficit, which may be useful.