### PR TITLE
Removed AggregatedBaseParameter

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -101,7 +101,15 @@ cdef class CachedParameter(IndexParameter):
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
 
-cdef class AggregatedParameterBase(IndexParameter):
+cdef class AggregatedParameter(Parameter):
+    cdef public set parameters
+    cdef object _agg_user_func
+    cdef int _agg_func
+    cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
+    cpdef add(self, Parameter parameter)
+    cpdef remove(self, Parameter parameter)
+
+cdef class AggregatedIndexParameter(IndexParameter):
     cdef public set parameters
     cdef object _agg_user_func
     cdef int _agg_func
@@ -109,12 +117,6 @@ cdef class AggregatedParameterBase(IndexParameter):
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cpdef add(self, Parameter parameter)
     cpdef remove(self, Parameter parameter)
-
-cdef class AggregatedParameter(AggregatedParameterBase):
-    pass
-
-cdef class AggregatedIndexParameter(AggregatedParameterBase):
-    pass
 
 cdef class NegativeParameter(Parameter):
     cdef public Parameter parameter

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -7,7 +7,6 @@ from ._parameters import (
     ArrayIndexedScenarioMonthlyFactorsParameter, TablesArrayParameter,
     DailyProfileParameter, MonthlyProfileParameter,
     ArrayIndexedScenarioParameter, ScenarioMonthlyProfileParameter,
-    AggregatedParameter, AggregatedIndexParameter,
     align_and_resample_dataframe, DataFrameParameter,
     IndexParameter, AggregatedParameter, AggregatedIndexParameter,
     load_parameter, load_parameter_values, load_dataframe)


### PR DESCRIPTION
- Sharing the code between AggregatedParameter and AggregatedIndexParameter is nice.
- However it causes unexpected behaviour on AggregatedParameter due it being a subclass of IndexParameter.