### PR TITLE
Glpk determinism

### DIFF
--- a/pywr/model.py
+++ b/pywr/model.py
@@ -614,6 +614,8 @@ class Model(object):
                 component.setup()
             component.reset()
 
+        self.solver.reset()
+
     def before(self):
         """ Perform initialisation work before solve on each timestep.
 

--- a/pywr/model.py
+++ b/pywr/model.py
@@ -56,7 +56,8 @@ class Model(object):
         self.graph = nx.DiGraph()
         self.metadata = {}
 
-        solver_name = kwargs.pop('solver', None)
+        solver_name = kwargs.pop("solver", None)
+        solver_args = kwargs.pop("solver_args", {})
 
         # time arguments
         start = kwargs.pop("start", "2015-01-01")
@@ -87,7 +88,7 @@ class Model(object):
         else:
             # use default solver
             solver = solver_registry[0]
-        self.solver = solver()
+        self.solver = solver(**solver_args)
         self.component_graph = nx.DiGraph()
         self.component_graph.add_node(ROOT_NODE)
         self.component_tree_flat = None
@@ -266,8 +267,10 @@ class Model(object):
             solver_data = data['solver']
         except KeyError:
             solver_name = solver
+            solver_args = {}
         else:
-            solver_name = data['solver']['name']
+            solver_name = data["solver"].pop("name")
+            solver_args = data["solver"]
 
         try:
             timestepper_data = data['timestepper']
@@ -282,6 +285,7 @@ class Model(object):
         if model is None:
             model = cls(
                 solver=solver_name,
+                solver_args=solver_args,
                 start=start,
                 end=end,
                 timestep=timestep,

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -2,8 +2,10 @@ import numpy as np
 cimport numpy as np
 from .parameters import parameter_registry, ConstantParameter
 from ._parameters import load_parameter, load_parameter_values, Parameter, IndexParameter
-from libc.math cimport isnan
 
+# http://stackoverflow.com/a/20031818/1300519
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
 
 cdef class BaseControlCurveParameter(Parameter):
     """ Base class for all Parameters that rely on a the attached Node containing a control_curve Parameter
@@ -102,7 +104,7 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     interpolated between 0 and 5. Between 50% and 30% the cost is interpolated
     between 5 and 10. Between 30% and 0% the cost is interpolated between 10
     and 20.
-    
+
     Volume:  100%            50%      30%       0%
              |...............|........|..........|
       Cost:  0.0             5.0      10.0    20.0
@@ -138,7 +140,7 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
         cdef double current_pc = node._current_pc[i]
         cdef double weight
 
-        if current_pc > 1.0 or isnan(current_pc):
+        if current_pc > 1.0 or npy_isnan(current_pc):
             return self._values[0]
 
         if current_pc < 0.0:

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -2,6 +2,7 @@ import numpy as np
 cimport numpy as np
 from .parameters import parameter_registry, ConstantParameter
 from ._parameters import load_parameter, load_parameter_values, Parameter, IndexParameter
+from libc.math cimport isnan
 
 
 cdef class BaseControlCurveParameter(Parameter):
@@ -137,7 +138,7 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
         cdef double current_pc = node._current_pc[i]
         cdef double weight
 
-        if current_pc > 1.0:
+        if current_pc > 1.0 or isnan(current_pc):
             return self._values[0]
 
         if current_pc < 0.0:

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -47,6 +47,9 @@ else:
         def solve(self, model):
             return self._cy_solver.solve(model)
 
+        def dump_mps(self, filename):
+            return self._cy_solver.dump_mps(filename)
+
         @property
         def stats(self):
             return self._cy_solver.stats

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -19,6 +19,8 @@ class Solver(object):
         raise NotImplementedError('Solver should be subclassed to provide setup()')
     def solve(self, model, timestep):
         raise NotImplementedError('Solver should be subclassed to provide solve()')
+    def reset(self):
+        raise NotImplementedError('Solver should be subclassed to provide reset()')
     @property
     def stats(self):
         return {}
@@ -46,6 +48,9 @@ else:
 
         def solve(self, model):
             return self._cy_solver.solve(model)
+
+        def reset(self):
+            return self._cy_solver.reset()
 
         def dump_mps(self, filename):
             return self._cy_solver.dump_mps(filename)
@@ -77,6 +82,9 @@ else:
 
         def solve(self, model):
             return self._cy_solver.solve(model)
+
+        def reset(self):
+            pass
 
         @property
         def stats(self):

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -15,6 +15,8 @@ solver_registry = []
 class Solver(object):
     """Solver base class from which all solvers should inherit"""
     name = 'default'
+    def __init__(self, *args, **kwargs):
+        pass
     def setup(self, model):
         raise NotImplementedError('Solver should be subclassed to provide setup()')
     def solve(self, model, timestep):
@@ -41,7 +43,7 @@ else:
 
         def __init__(self, *args, **kwargs):
             super(CythonGLPKSolver, self).__init__(*args, **kwargs)
-            self._cy_solver = cy_CythonGLPKSolver()
+            self._cy_solver = cy_CythonGLPKSolver(**kwargs)
 
         def setup(self, model):
             return self._cy_solver.setup(model)
@@ -75,7 +77,7 @@ else:
 
         def __init__(self, *args, **kwargs):
             super(CythonLPSolveSolver, self).__init__(*args, **kwargs)
-            self._cy_solver = cy_CythonLPSolveSolver()
+            self._cy_solver = cy_CythonLPSolveSolver(**kwargs)
 
         def setup(self, model):
             return self._cy_solver.setup(model)

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -466,7 +466,7 @@ cdef class CythonGLPKSolver:
             if status != GLP_OPT or simplex_ret != 0:
                 print("Simplex solve returned: {}".format(simplex_ret))
                 print("Simplex status: {}".format(status))
-                glp_write_mps(self.prob, GLP_MPS_FILE, NULL, 'pywr_glpk_debug.mps')
+                self.dump_mps('pywr_glpk_debug.mps')
                 raise RuntimeError(status_string[status])
         self.stats['lp_solve'] += time.clock() - t0
         t0 = time.clock()
@@ -500,6 +500,9 @@ cdef class CythonGLPKSolver:
         self.stats['result_update'] += time.clock() - t0
 
         return route_flows, change_in_storage
+
+    cpdef dump_mps(self, filename):
+        glp_write_mps(self.prob, GLP_MPS_FILE, NULL, filename)
 
 
 cdef int simplex(glp_prob *P, glp_smcp parm):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -453,6 +453,7 @@ cdef class CythonGLPKSolver:
 
         # attempt to solve the linear programme
         t0 = time.clock()
+        glp_std_basis(self.prob)
         simplex_ret = simplex(self.prob, self.smcp)
         status = glp_get_status(self.prob)
         if status != GLP_OPT or simplex_ret != 0:

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -63,6 +63,7 @@ cdef class CythonGLPKSolver:
 
     def __init__(self):
         self.stats = None
+        self.is_first_solve = True
 
     def __dealloc__(self):
         # free the problem
@@ -399,6 +400,10 @@ cdef class CythonGLPKSolver:
                 glp_set_row_stat(self.prob, i+1, self.row_stat[global_id, i])
             for i in range(ncols):
                 glp_set_col_stat(self.prob, i+1, self.col_stat[global_id, i])
+
+    def reset(self):
+        # Resetting this triggers a crashing of a new basis in each scenario
+        self.is_first_solve = True
 
     cpdef object solve(self, model):
         t0 = time.clock()

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -52,7 +52,7 @@ cdef class CythonGLPKSolver:
     cdef int[:, :] col_stat
     cdef bint is_first_solve
     cdef bint has_presolved
-    cdef bint use_presolve
+    cdef public bint use_presolve
 
     def __cinit__(self):
         # create a new problem
@@ -63,11 +63,11 @@ cdef class CythonGLPKSolver:
         self.smcp.tm_lim = 5000  # 5 second limit
         glp_term_out(GLP_OFF)  # Disable terminal output
 
-    def __init__(self):
+    def __init__(self, use_presolve=False):
         self.stats = None
         self.is_first_solve = True
         self.has_presolved = False
-        self.use_presolve = True
+        self.use_presolve = use_presolve
 
     def __dealloc__(self):
         # free the problem

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -370,7 +370,7 @@ cdef class CythonGLPKSolver:
         }
 
     cdef _init_basis_arrays(self, model):
-        """ Initialise the arrays use for storing the LP basis by scenario """
+        """ Initialise the arrays used for storing the LP basis by scenario """
         cdef int nscenarios = len(model.scenarios.combinations)
         cdef int nrows = glp_get_num_rows(self.prob)
         cdef int ncols = glp_get_num_cols(self.prob)

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -54,6 +54,7 @@ cdef class CythonGLPKSolver:
         glp_init_smcp(&self.smcp)
         self.smcp.msg_lev = GLP_MSG_ERR
         self.smcp.tm_lim = 5000  # 5 second limit
+        glp_term_out(GLP_OFF)  # Disable terminal output
 
     def __init__(self):
         self.stats = None
@@ -453,7 +454,8 @@ cdef class CythonGLPKSolver:
 
         # attempt to solve the linear programme
         t0 = time.clock()
-        glp_std_basis(self.prob)
+        #glp_std_basis(self.prob)
+        glp_adv_basis(self.prob, 0)
         simplex_ret = simplex(self.prob, self.smcp)
         status = glp_get_status(self.prob)
         if status != GLP_OPT or simplex_ret != 0:

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -469,7 +469,7 @@ cdef class CythonGLPKSolver:
             if status != GLP_OPT or simplex_ret != 0:
                 print("Simplex solve returned: {}".format(simplex_ret))
                 print("Simplex status: {}".format(status))
-                self.dump_mps('pywr_glpk_debug.mps')
+                self.dump_mps(b'pywr_glpk_debug.mps')
                 raise RuntimeError(status_string[status])
         self.stats['lp_solve'] += time.clock() - t0
         t0 = time.clock()

--- a/pywr/solvers/glpk.pxi
+++ b/pywr/solvers/glpk.pxi
@@ -85,6 +85,9 @@ cdef extern from "glpk.h":
     int GLP_MPS_DECK = 1 # fixed (ancient)
     int GLP_MPS_FILE = 2 # free (modern)
 
+    int GLP_ON = 1
+    int GLP_OFF = 0
+
     glp_prob* glp_create_prob()
     void glp_init_smcp(glp_smcp *parm)
     void glp_erase_prob(glp_prob *P)
@@ -105,9 +108,11 @@ cdef extern from "glpk.h":
     void glp_set_obj_dir(glp_prob *P, int dir);
 
     void glp_std_basis(glp_prob *P)
+    void glp_adv_basis(glp_prob *P, int flags)
     int glp_simplex(glp_prob *P, const glp_smcp *parm)
 
     int glp_get_status(glp_prob *P)
+    int glp_term_out(int flag)
     
     double glp_get_row_prim(glp_prob *P, int i)
     double glp_get_col_prim(glp_prob *P, int j)

--- a/pywr/solvers/glpk.pxi
+++ b/pywr/solvers/glpk.pxi
@@ -123,3 +123,8 @@ cdef extern from "glpk.h":
 
     int glp_write_mps(glp_prob *P, int fmt, const glp_mpscp *parm,
       const char *fname)
+
+    int glp_get_row_stat(glp_prob *P, int i)
+    int glp_get_col_stat(glp_prob *P, int i)
+    void glp_set_row_stat(glp_prob *P, int i, int state)
+    void glp_set_col_stat(glp_prob *P, int i, int state)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -644,7 +644,7 @@ def test_solver_unrecognised():
 @pytest.mark.parametrize("use_presolve", ["true", "false"])
 def test_select_glpk_presolve(use_presolve):
     """Test specifying the solver in JSON"""
-    solver_names = [solver.name for solver in pywr.solvers.solver_registry]
+    solver_names = ["glpk"]
     for solver_name in solver_names:
         data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s", "use_presolve": %s}}''' % (solver_name, use_presolve)
         model = load_model(data=data)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -626,17 +626,27 @@ def test_run(solver):
 
 
 def test_select_solver():
-    """Test specifying the solver in XML"""
+    """Test specifying the solver in JSON"""
     solver_names = [solver.name for solver in pywr.solvers.solver_registry]
     for solver_name in solver_names:
         data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
         model = load_model(data=data)
         assert(model.solver.name.lower() == solver_name)
 
-
 def test_solver_unrecognised():
-    '''Test specifying an unrecognised solver XML'''
+    '''Test specifying an unrecognised solver JSON'''
     solver_name = 'foobar'
     data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
     with pytest.raises(KeyError):
         model = load_model(data=data)
+
+@pytest.mark.skipif(pytest.config.getoption("--solver") != "glpk", reason="only valid for glpk")
+@pytest.mark.parametrize("use_presolve", ["true", "false"])
+def test_select_glpk_presolve(use_presolve):
+    """Test specifying the solver in JSON"""
+    solver_names = [solver.name for solver in pywr.solvers.solver_registry]
+    for solver_name in solver_names:
+        data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s", "use_presolve": %s}}''' % (solver_name, use_presolve)
+        model = load_model(data=data)
+        assert(model.solver.name.lower() == solver_name)
+        assert(model.solver._cy_solver.use_presolve == (use_presolve == "true"))


### PR DESCRIPTION
This now does a few things to the GLPK solver

- Added ability to dump MPS file for the last LP.
- Added reset API to solvers
- Tracks the basis (row and column status) for each scenario. This is an attempt to make the solver deterministic when the model is rerun or run with different scenarios. Previously the basis was only crashed once on the first solve and then retained for each solve. Now the basis is crashed on the first time-step of each run for each scenario. The basis is then saved and reapplied on a scenario basis. In theory this makes each scenario entirely deterministic in the behaviour of the basis regardless of whether it is run multiple times or with other scenarios.
- Enabled presolver

Also added a simple NaN check to `ControlCurveInterpolatedParameter`