### PR TITLE
Adds support for Parameter based min & max flow in AggregatedNode

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -65,7 +65,7 @@ cdef class Node(AbstractNode):
     cdef double _min_flow
     cdef double _max_flow
     cdef double _conversion_factor
-    cdef object _min_flow_param
+    cdef Parameter _min_flow_param
     cdef Parameter _max_flow_param
 
     cdef Parameter _conversion_factor_param
@@ -79,6 +79,11 @@ cdef class AggregatedNode(AbstractNode):
     cdef double[:] _factors
     cdef double _max_flow
     cdef double _min_flow
+    cdef Parameter _min_flow_param
+    cdef Parameter _max_flow_param
+
+    cpdef double get_min_flow(self, Timestep ts, ScenarioIndex scenario_index) except? -1
+    cpdef double get_max_flow(self, Timestep ts, ScenarioIndex scenario_index) except? -1
 
 cdef class BaseInput(Node):
     cdef object _licenses

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -107,6 +107,7 @@ def test_aggregated_node_max_flow(model):
     assert_allclose(B.flow, 10.0)
 
 
+@pytest.mark.skipif(pytest.config.getoption("--solver") != "glpk", reason="only valid for glpk")
 def test_aggregated_node_max_flow_parameter(model):
     """Nodes constrained by the max_flow of their AggregatedNode using a Parameter """
     A = Input(model, "A", max_flow=20.0, cost=1)
@@ -144,7 +145,9 @@ def test_aggregated_node_min_flow(model):
     assert_allclose(A.flow, 15.0)
     assert_allclose(B.flow, 0.0)
 
-def test_aggregated_node_min_flow(model):
+
+@pytest.mark.skipif(pytest.config.getoption("--solver") != "glpk", reason="only valid for glpk")
+def test_aggregated_node_min_flow_parameter(model):
     """Nodes constrained by the min_flow of their AggregatedNode"""
     A = Input(model, "A", max_flow=20.0, cost=1)
     B = Input(model, "B", max_flow=20.0, cost=100)

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -1,4 +1,5 @@
 from pywr.core import Model, Input, Output, Link, Storage, AggregatedNode, PiecewiseLink, MultiSplitLink
+from pywr.parameters import ConstantParameter
 
 import pytest
 from numpy.testing import assert_allclose
@@ -86,6 +87,7 @@ def test_aggregated_node_two_factors_time_varying(model):
     assert_allclose(A.flow, 20.0)
     assert_allclose(B.flow, 40.0)
 
+
 def test_aggregated_node_max_flow(model):
     """Nodes constrained by the max_flow of their AggregatedNode"""
     A = Input(model, "A", max_flow=20.0, cost=1)
@@ -104,6 +106,26 @@ def test_aggregated_node_max_flow(model):
     assert_allclose(A.flow, 20.0)
     assert_allclose(B.flow, 10.0)
 
+
+def test_aggregated_node_max_flow_parameter(model):
+    """Nodes constrained by the max_flow of their AggregatedNode using a Parameter """
+    A = Input(model, "A", max_flow=20.0, cost=1)
+    B = Input(model, "B", max_flow=20.0, cost=2)
+    Z = Output(model, "Z", max_flow=100, cost=-10)
+
+    A.connect(Z)
+    B.connect(Z)
+
+    agg = AggregatedNode(model, "agg", [A, B])
+    agg.max_flow = ConstantParameter(model, 30.0)
+
+    model.run()
+
+    assert_allclose(agg.flow, 30.0)
+    assert_allclose(A.flow, 20.0)
+    assert_allclose(B.flow, 10.0)
+
+
 def test_aggregated_node_min_flow(model):
     """Nodes constrained by the min_flow of their AggregatedNode"""
     A = Input(model, "A", max_flow=20.0, cost=1)
@@ -115,6 +137,24 @@ def test_aggregated_node_min_flow(model):
 
     agg = AggregatedNode(model, "agg", [A, B])
     agg.min_flow = 15.0
+
+    model.run()
+
+    assert_allclose(agg.flow, 15.0)
+    assert_allclose(A.flow, 15.0)
+    assert_allclose(B.flow, 0.0)
+
+def test_aggregated_node_min_flow(model):
+    """Nodes constrained by the min_flow of their AggregatedNode"""
+    A = Input(model, "A", max_flow=20.0, cost=1)
+    B = Input(model, "B", max_flow=20.0, cost=100)
+    Z = Output(model, "Z", max_flow=100, cost=0)
+
+    A.connect(Z)
+    B.connect(Z)
+
+    agg = AggregatedNode(model, "agg", [A, B])
+    agg.min_flow = ConstantParameter(model, 15.0)
 
     model.run()
 


### PR DESCRIPTION
- Implemented in GLPK solver only
- Small refactor of the aggregated nodes in the solver
- Found a small bug in the setting of `None` to min_flow & max_flow on Node

Fixes #461