### PR TITLE
Make TablesArrayParameter load it's data during setup

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -303,7 +303,6 @@ cdef class TablesArrayParameter(IndexParameter):
         if self.scenario is not None:
             self._scenario_index = self.model.scenarios.get_scenario_index(self.scenario)
 
-    cpdef reset(self):
         self.h5store = H5Store(self.h5file, None, "r")
         node = self.h5store.file.get_node(self.where, self.node)
 


### PR DESCRIPTION
Current behaviour means the `TablesArrayParameter` loads data during `reset`. This is inefficient in certain algorithms that reset a model and rerun. The current implementation of the parameter does not expect the data to change between `setup` and `reset`. This moves the loading to `setup` instead.