### PR TITLE
Fixed #465. TablesRecorder sets Parameters as children.

### DIFF
--- a/pywr/recorders/recorders.py
+++ b/pywr/recorders/recorders.py
@@ -8,6 +8,10 @@ from .calibration import *
 from past.builtins import basestring
 from pywr.h5tools import H5Store
 from ..parameters import load_parameter
+import warnings
+
+class ParameterNameWarning(UserWarning):
+    pass
 
 def assert_rec(model, parameter, name=None):
     """Decorator for creating AssertionRecorder objects
@@ -222,7 +226,13 @@ class TablesRecorder(Recorder):
         if not param.name:
             raise ValueError("Can only record named Parameter objects")
         if where is None:
-            where = self.where + "/" + param.name
+            name = param.name.replace("/", "_")
+            if name != param.name:
+                warnings.warn(
+                    "Recorded parameter has \"/\" in name, replaced with \"_\" to avoid creation of subgroup: {}".format(param.name),
+                    ParameterNameWarning
+                )
+            where = self.where + "/" + name
         where = where.replace("//", "/")
         self.children.add(param)
         self.parameters.append((where, param))

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -185,7 +185,7 @@ def test_numpy_parameter_recorder(simple_linear_model):
 def test_numpy_index_parameter_recorder(simple_storage_model):
     """
     Test the NumpyArrayIndexParameterRecorder
-    
+
     Note the parameter is recorded at the start of the timestep, while the
     storage is recorded at the end of the timestep.
     """
@@ -442,6 +442,12 @@ class TestTablesRecorder:
         import tables
         with tables.open_file(str(h5file), 'w') as h5f:
             rec = TablesRecorder(model, h5f, parameters=[p, ])
+
+            # check parameters have been added to the component tree
+            # this is particularly important for parameters which update their
+            # values in `after`, e.g. DeficitParameter (see #465)
+            assert(not model.find_orphaned_parameters())
+            assert(p in rec.children)
 
             model.run()
 
@@ -993,4 +999,3 @@ class TestEventRecorder:
             assert_equal([3, ], [e.duration for e in evt_rec.events])
         else:
             assert len(evt_rec.events) == 0
-


### PR DESCRIPTION
Parameters added as children to TablesRecorder.

@jetuk It'd be good to have your eyes on this in case I've missed something.