### PR TITLE
Use node._prev_flow in NodeThresholdParameter. Fixes #454

### DIFF
--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -112,7 +112,7 @@ StorageThresholdParameter.register()
 
 
 cdef class NodeThresholdParameter(AbstractThresholdParameter):
-    """ Returns one of two values depending on current flow in a node
+    """ Returns one of two values depending on previous flow in a node
 
     Parameters
     ----------
@@ -124,7 +124,14 @@ cdef class NodeThresholdParameter(AbstractThresholdParameter):
         self.node = node
 
     cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
-        return self.node._flow[scenario_index.global_id]
+        print("prev", self.node._prev_flow[scenario_index.global_id])
+        return self.node._prev_flow[scenario_index.global_id]
+
+    cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        if timestep.index == 0:
+            # previous flow on initial timestep is undefined
+            return 0
+        return AbstractThresholdParameter.index(self, timestep, scenario_index)
 
     @classmethod
     def load(cls, model, data):

--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -124,7 +124,6 @@ cdef class NodeThresholdParameter(AbstractThresholdParameter):
         self.node = node
 
     cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
-        print("prev", self.node._prev_flow[scenario_index.global_id])
         return self.node._prev_flow[scenario_index.global_id]
 
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:

--- a/pywr/recorders/recorders.py
+++ b/pywr/recorders/recorders.py
@@ -55,7 +55,10 @@ class AssertionRecorder(Recorder):
             elif self.expected_data is not None:
                 expected_value = self.expected_data[timestep.index, scenario_index.global_id]
             value = self.parameter.get_value(scenario_index)
-            np.testing.assert_allclose(value, expected_value)
+            try:
+                np.testing.assert_allclose(value, expected_value)
+            except AssertionError:
+                raise AssertionError("Expected {}, got {} from \"{}\" [timestep={}, scenario={}]".format(expected_value, value, self.parameter.name, timestep.index, scenario_index.global_id))
 
     def finish(self):
         super(AssertionRecorder, self).finish()


### PR DESCRIPTION
Fixes #454.

In the initial timestep the previous flow is undefined. Rather than returning a NaN, the parameter will always return 0 for it's index on the initial timestep.

AssertionRecorder doesn't let you check the index directly, so needed a workaround. See #467.