### PR TITLE
Moved time table creation to reset() in TablesRecorder

### DIFF
--- a/pywr/recorders/recorders.py
+++ b/pywr/recorders/recorders.py
@@ -351,7 +351,7 @@ class TablesRecorder(Recorder):
             if group_name == "":
                 group_name = "/"
             description = {c: tables.Int64Col() for c in ('year', 'month', 'day', 'index')}
-            print(group_name, node_name)
+            
             try:
                 self.h5store.file.remove_node(group_name, node_name)
             except tables.NoSuchNodeError:

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -390,6 +390,12 @@ class TestTablesRecorder:
                 assert row['name'] == s.name
                 assert row['size'] == s.size
 
+            model.reset()
+            model.run()
+
+            time = h5f.get_node('/time')
+            assert len(time) == len(model.timestepper)
+
     def test_multiple_scenarios(self, simple_linear_model, tmpdir):
         """
         Test the TablesRecorder


### PR DESCRIPTION
This avoids a bug whereby resetting the model doesn't remove all the rows
in the time table. Subsequent appends then duplicate the entries. Time
table creation is now done in the reset method.