### PR TITLE
Workaround issue #470 ...

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -838,6 +838,14 @@ cdef class Storage(AbstractStorage):
         cdef double mxv = self._max_volume
         cdef ScenarioIndex si
 
+        # TODO at some point remove this limitation
+        # See issue #470 https://github.com/pywr/pywr/issues/470
+        if self._max_volume_param is not None:
+            if len(self._max_volume_param.children) > 0:
+                raise RuntimeError('Only parameters with no dependencies are supported for max_volume.')
+            # We ensure that this is called in reset
+            self._max_volume_param.calc_values(self._model.timestepper.current)
+
         for i, si in enumerate(self.model.scenarios.combinations):
             self._volume[i] = self._initial_volume
             # Ensure variable maximum volume is taken in to account

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,7 @@ from pywr._core import Timestep, ScenarioIndex
 
 from pywr.core import *
 from pywr.domains.river import *
-from pywr.parameters import Parameter, ConstantParameter, DataFrameParameter
+from pywr.parameters import Parameter, ConstantParameter, DataFrameParameter, AggregatedParameter
 from pywr.recorders import assert_rec, AssertionRecorder
 
 TEST_FOLDER = os.path.dirname(__file__)
@@ -364,6 +364,61 @@ def test_storage_max_volume_zero(solver):
 
     model.run()
     assert np.isnan(storage.current_pc)
+
+
+def test_storage_max_volume_param(solver):
+    """Test a that an max_volume with a Parameter results in the correct current_pc
+
+    """
+
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime('2016-01-01'),
+        end=pandas.to_datetime('2016-01-01')
+    )
+
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    otpt = Output(model, 'output', max_flow=99999, cost=-99999)
+    storage.connect(otpt)
+
+    p = ConstantParameter(model, 20.0)
+    storage.max_volume = p
+    storage.initial_volume = 10.0
+
+    model.setup()
+    np.testing.assert_allclose(storage.current_pc, 0.5)
+
+    model.run()
+
+    p.update(np.asarray([40.0, ]))
+    model.reset()
+    np.testing.assert_allclose(storage.current_pc, 0.25)
+
+
+def test_storage_max_volume_param_raises(solver):
+    """Test a that an max_volume with a Parameter that has children is an error
+
+    """
+
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime('2016-01-01'),
+        end=pandas.to_datetime('2016-01-01')
+    )
+
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    otpt = Output(model, 'output', max_flow=99999, cost=-99999)
+    storage.connect(otpt)
+
+    p = AggregatedParameter(model, [ConstantParameter(model, 20.0), ConstantParameter(model, 20.0)], agg_func='sum')
+
+    storage.max_volume = p
+    storage.initial_volume = 10.0
+
+    with pytest.raises(RuntimeError):
+        model.run()
+
+
 
 def test_json_include(solver):
     """Test include in JSON document"""


### PR DESCRIPTION
by restricting the type of Parameter that can be set to `max_volume`.

This provides a partial fix for #470. Simple parameters, with no children, are permitted
as `max_volume` and these are forced to calculate their value for the intiial time-step during
reset.