### PR TITLE
Updates to storage max and initial volume

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -95,6 +95,7 @@ cdef class AbstractStorage(AbstractNode):
 cdef class Storage(AbstractStorage):
     cdef double _cost
     cdef double _initial_volume
+    cdef double _initial_volume_pc
     cdef double _min_volume
     cdef double _max_volume
     cdef double _level

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -854,12 +854,12 @@ cdef class Storage(AbstractStorage):
         cdef Parameter p
         # These are the supported aggregated style parameters that can be used for max_volume
         # They only work if all their children have no children themselves.
-        from .parameters import AggregatedParameter, AggregatedIndexParameter, ArrayIndexedParameter
+        from .parameters._parameters import AggregatedParameter, AggregatedIndexParameter, IndexedArrayParameter
 
         # TODO at some point remove this limitation
         # See issue #470 https://github.com/pywr/pywr/issues/470
         if self._max_volume_param is not None:
-            if isinstance(self._max_volume_param, (AggregatedParameter, AggregatedIndexParameter, ArrayIndexedParameter)):
+            if isinstance(self._max_volume_param, (AggregatedParameter, AggregatedIndexParameter, IndexedArrayParameter)):
                 # Some simple aggregated style parameters are accepted so long as they have simple children
                 for p in self._max_volume_param.children:
                     if len(p.children) > 0:

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -837,11 +837,22 @@ cdef class Storage(AbstractStorage):
         cdef int i
         cdef double mxv = self._max_volume
         cdef ScenarioIndex si
+        cdef Parameter p
+        # These are the supported aggregated style parameters that can be used for max_volume
+        # They only work if all their children have no children themselves.
+        from .parameters import AggregatedParameter, AggregatedIndexParameter, ArrayIndexedParameter
 
         # TODO at some point remove this limitation
         # See issue #470 https://github.com/pywr/pywr/issues/470
         if self._max_volume_param is not None:
-            if len(self._max_volume_param.children) > 0:
+            if isinstance(self._max_volume_param, (AggregatedParameter, AggregatedIndexParameter, ArrayIndexedParameter)):
+                # Some simple aggregated style parameters are accepted so long as they have simple children
+                for p in self._max_volume_param.children:
+                    if len(p.children) > 0:
+                        raise RuntimeError('Only children of agregated parameters with no dependencies are supported for max_volume.')
+                    p.calc_values(self._model.timestepper.current)
+
+            elif len(self._max_volume_param.children) > 0:
                 raise RuntimeError('Only parameters with no dependencies are supported for max_volume.')
             # We ensure that this is called in reset
             self._max_volume_param.calc_values(self._model.timestepper.current)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -395,6 +395,35 @@ def test_storage_max_volume_param(solver):
     np.testing.assert_allclose(storage.current_pc, 0.25)
 
 
+def test_storage_initial_volume_pc(solver):
+    """Test that setting initial volume as a percentage works as expected.
+    """
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime('2016-01-01'),
+        end=pandas.to_datetime('2016-01-01')
+    )
+
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    otpt = Output(model, 'output', max_flow=99999, cost=-99999)
+    storage.connect(otpt)
+
+    p = ConstantParameter(model, 20.0)
+    storage.max_volume = p
+    storage.initial_volume_pc = 0.5
+
+    model.setup()
+    np.testing.assert_allclose(storage.current_pc, 0.5)
+    np.testing.assert_allclose(storage.volume, 10.0)
+
+    model.run()
+
+    p.update(np.asarray([40.0, ]))
+    model.reset()
+    np.testing.assert_allclose(storage.current_pc, 0.5)
+    np.testing.assert_allclose(storage.volume, 20.0)
+
+
 def test_storage_max_volume_param_raises(solver):
     """Test a that an max_volume with a Parameter that has children.
     

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -396,8 +396,9 @@ def test_storage_max_volume_param(solver):
 
 
 def test_storage_max_volume_param_raises(solver):
-    """Test a that an max_volume with a Parameter that has children is an error
-
+    """Test a that an max_volume with a Parameter that has children.
+    
+    Only some aggregated style parameters should work here.
     """
 
     model = Model(
@@ -413,6 +414,31 @@ def test_storage_max_volume_param_raises(solver):
     p = AggregatedParameter(model, [ConstantParameter(model, 20.0), ConstantParameter(model, 20.0)], agg_func='sum')
 
     storage.max_volume = p
+    storage.initial_volume = 10.0
+
+    model.setup()
+    np.testing.assert_allclose(storage.current_pc, 0.25)
+
+
+def test_storage_max_volume_param_raises(solver):
+    """Test a that an max_volume with a Parameter that has children is an error
+
+    """
+
+    model = Model(
+        solver=solver,
+        start=pandas.to_datetime('2016-01-01'),
+        end=pandas.to_datetime('2016-01-01')
+    )
+
+    storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
+    otpt = Output(model, 'output', max_flow=99999, cost=-99999)
+    storage.connect(otpt)
+
+    p = AggregatedParameter(model, [ConstantParameter(model, 20.0), ConstantParameter(model, 20.0)], agg_func='sum')
+    p1 = AggregatedParameter(model, [p, ConstantParameter(model, 1.5)], agg_func="product")
+
+    storage.max_volume = p1
     storage.initial_volume = 10.0
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Two features

- Allow some simple aggregated style parameters to be used as max_volume.
- Added feature to set initial storage volume as a proportion of maximum volume. Fixes #453