### PR TITLE
Only load required data in TablesArrayParameter

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -78,6 +78,7 @@ cdef class TablesArrayParameter(IndexParameter):
     cdef public object where
 
     cdef int _scenario_index
+    cdef int[:] _scenario_ids
 
 cdef class IndexedArrayParameter(Parameter):
     cdef public IndexParameter index_parameter

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -290,7 +290,7 @@ cdef class TablesArrayParameter(IndexParameter):
         self.where = where
         self.scenario = scenario
 
-        # Private attributes, initialised during reset()
+        # Private attributes, initialised during setup()
         self._values_dbl = None
         self._values_int = None
         self._scenario_index = -1
@@ -309,6 +309,10 @@ cdef class TablesArrayParameter(IndexParameter):
         self.h5store = H5Store(self.h5file, None, "r")
         node = self.h5store.file.get_node(self.where, self.node)
 
+        if not node.dtype in (np.float32, np.float64, np.int8, np.int16, np.int32):
+            raise TypeError("Unexpected dtype in array: {}".format(node.dtype))
+
+        # check the shape of the data is valid
         if self.scenario is not None:
             if node.shape[1] < self.scenario.size:
                 raise RuntimeError("The length of the second dimension of the tables Node should be the same as the size of the specified Scenario.")
@@ -318,30 +322,46 @@ cdef class TablesArrayParameter(IndexParameter):
             raise IndexError("The length of the first dimension of the tables Node should be equal to or greater than the number of timesteps.")
 
         # detect data type and read into memoryview
-        if node.dtype in (np.float32, np.float64):
-            if self.scenario and self.scenario.slice and not self.model.scenarios.user_combinations:
-                # only load the data required
-                self._values_dbl = node[:len(self.model.timestepper), self.scenario.slice]
+        self._values_dbl = None
+        self._values_int = None
+        if self.scenario:
+            # if possible, only load the data required
+            scenario_indices = None
+            if self.model.scenarios.user_combinations:
+                scenario_indices = set()
+                for user_combination in self.model.scenarios.user_combinations:
+                    scenario_indices.add(user_combination[self._scenario_index])
+                scenario_indices = sorted(list(scenario_indices))
                 self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
-                for n, i in enumerate(range(*self.scenario.slice.indices(self.scenario.slice.stop))):
+                for n, i in enumerate(scenario_indices):
                     self._scenario_ids[i] = n
-            else:
-                # load all of the data
+                if node.dtype in (np.float32, np.float64):
+                    self._values_dbl = node[:len(self.model.timestepper), scenario_indices]
+                else:
+                    self._values_int = node[:len(self.model.timestepper), scenario_indices]
+            elif self.scenario.slice:
+                self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
+                scenario_indices = range(*self.scenario.slice.indices(self.scenario.slice.stop))
+                for n, i in enumerate(scenario_indices):
+                    self._scenario_ids[i] = n
+                if node.dtype in (np.float32, np.float64):
+                    self._values_dbl = node[:len(self.model.timestepper), self.scenario.slice]
+                else:
+                    self._values_int = node[:len(self.model.timestepper), self.scenario.slice]
+            # else: scenario is defined, but all data required
+        if node.dtype in (np.float32, np.float64):
+            if self._values_dbl is None:
                 self._values_dbl = node.read().astype(np.float64)
+            # negative values are often erroneous
             if np.min(self._values_dbl) < 0.0:
                 warnings.warn('Negative values in input file "{}" from node: {}'.format(self.h5file, self.node))
-            self._values_int = None
-            shape = self._values_dbl.shape
-        elif node.dtype in (np.int8, np.int16, np.int32):
-            self._values_dbl = None
-            self._values_int = node.read().astype(np.int32)
-            shape = self._values_int.shape
         else:
-            raise TypeError("Unexpected dtype in array: {}".format(node.dtype))
+            if self._values_int is None:
+                self._values_int = node.read().astype(np.int32)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef int i = ts._index
-        cdef int j
+        cdef Py_ssize_t i = ts._index
+        cdef Py_ssize_t j
         if self._values_dbl is None:
             return float(self.get_index(scenario_index))
         # Support 1D and 2D indexing when scenario is or is not given.
@@ -354,8 +374,8 @@ cdef class TablesArrayParameter(IndexParameter):
             return self._values_dbl[i, j]
 
     cpdef int index(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef int i = ts._index
-        cdef int j
+        cdef Py_ssize_t i = ts._index
+        cdef Py_ssize_t j
         if self._values_int is None:
             return int(self.get_value(scenario_index))
         # Support 1D and 2D indexing when scenario is or is not given.
@@ -363,6 +383,8 @@ cdef class TablesArrayParameter(IndexParameter):
             return self._values_int[i, 0]
         else:
             j = scenario_index._indices[self._scenario_index]
+            if self._scenario_ids is not None:
+                j = self._scenario_ids[j]
             return self._values_int[i, j]
 
     cpdef finish(self):

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -291,10 +291,11 @@ cdef class TablesArrayParameter(IndexParameter):
         self.scenario = scenario
 
         # Private attributes, initialised during setup()
-        self._values_dbl = None
-        self._values_int = None
+        self._values_dbl = None  # Stores the loaded data if float
+        self._values_int = None  # Stores the loaded data if integer
+        # If a scenario is present this is the index in the model list of scenarios
         self._scenario_index = -1
-        self._scenario_ids = None
+        self._scenario_ids = None  # Lookup of scenario index to the loaded data index
 
     cpdef setup(self):
         cdef Py_ssize_t n, i
@@ -327,28 +328,31 @@ cdef class TablesArrayParameter(IndexParameter):
         if self.scenario:
             # if possible, only load the data required
             scenario_indices = None
+            # Default to index that is just out of bounds to cause IndexError if something goes wrong
+            self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32) * self.scenario.size
+
+            # Calculate the scenario indices to load dependning on how scenario combinations are defined.
             if self.model.scenarios.user_combinations:
                 scenario_indices = set()
                 for user_combination in self.model.scenarios.user_combinations:
                     scenario_indices.add(user_combination[self._scenario_index])
                 scenario_indices = sorted(list(scenario_indices))
-                self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
+            elif self.scenario.slice:
+                scenario_indices = range(*self.scenario.slice.indices(self.scenario.slice.stop))
+            else:
+                # scenario is defined, but all data required
+                self._scenario_ids = None
+
+            if scenario_indices is not None:
+                # Now load only the required data
                 for n, i in enumerate(scenario_indices):
                     self._scenario_ids[i] = n
+
                 if node.dtype in (np.float32, np.float64):
                     self._values_dbl = node[:len(self.model.timestepper), scenario_indices].astype(np.float64)
                 else:
                     self._values_int = node[:len(self.model.timestepper), scenario_indices].astype(np.int32)
-            elif self.scenario.slice:
-                self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
-                scenario_indices = range(*self.scenario.slice.indices(self.scenario.slice.stop))
-                for n, i in enumerate(scenario_indices):
-                    self._scenario_ids[i] = n
-                if node.dtype in (np.float32, np.float64):
-                    self._values_dbl = node[:len(self.model.timestepper), self.scenario.slice].astype(np.float64)
-                else:
-                    self._values_int = node[:len(self.model.timestepper), self.scenario.slice].astype(np.int32)
-            # else: scenario is defined, but all data required
+
         if node.dtype in (np.float32, np.float64):
             if self._values_dbl is None:
                 self._values_dbl = node.read().astype(np.float64)

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -297,7 +297,7 @@ cdef class TablesArrayParameter(IndexParameter):
         self._scenario_ids = None
 
     cpdef setup(self):
-        cdef int n, i
+        cdef Py_ssize_t n, i
 
         super(TablesArrayParameter, self).setup()
         self._scenario_index = -1
@@ -314,7 +314,7 @@ cdef class TablesArrayParameter(IndexParameter):
             if self.scenario and self.scenario.slice and not self.model.scenarios.user_combinations:
                 # only load the data required
                 self._values_dbl = node[:, self.scenario.slice]
-                self._scenario_ids = np.ones(self.scenario.size, dtype=np.int)
+                self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
                 for n, i in enumerate(range(*self.scenario.slice.indices(self.scenario.slice.stop))):
                     self._scenario_ids[i] = n
             else:

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -363,7 +363,7 @@ cdef class TablesArrayParameter(IndexParameter):
         cdef Py_ssize_t i = ts._index
         cdef Py_ssize_t j
         if self._values_dbl is None:
-            return float(self.get_index(scenario_index))
+            return float(self.index(ts, scenario_index))
         # Support 1D and 2D indexing when scenario is or is not given.
         if self._scenario_index == -1:
             return self._values_dbl[i, 0]
@@ -377,7 +377,7 @@ cdef class TablesArrayParameter(IndexParameter):
         cdef Py_ssize_t i = ts._index
         cdef Py_ssize_t j
         if self._values_int is None:
-            return int(self.get_value(scenario_index))
+            return int(self.value(ts, scenario_index))
         # Support 1D and 2D indexing when scenario is or is not given.
         if self._scenario_index == -1:
             return self._values_int[i, 0]

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -336,18 +336,18 @@ cdef class TablesArrayParameter(IndexParameter):
                 for n, i in enumerate(scenario_indices):
                     self._scenario_ids[i] = n
                 if node.dtype in (np.float32, np.float64):
-                    self._values_dbl = node[:len(self.model.timestepper), scenario_indices]
+                    self._values_dbl = node[:len(self.model.timestepper), scenario_indices].astype(np.float64)
                 else:
-                    self._values_int = node[:len(self.model.timestepper), scenario_indices]
+                    self._values_int = node[:len(self.model.timestepper), scenario_indices].astype(np.int32)
             elif self.scenario.slice:
                 self._scenario_ids = np.ones(self.scenario.size, dtype=np.int32)
                 scenario_indices = range(*self.scenario.slice.indices(self.scenario.slice.stop))
                 for n, i in enumerate(scenario_indices):
                     self._scenario_ids[i] = n
                 if node.dtype in (np.float32, np.float64):
-                    self._values_dbl = node[:len(self.model.timestepper), self.scenario.slice]
+                    self._values_dbl = node[:len(self.model.timestepper), self.scenario.slice].astype(np.float64)
                 else:
-                    self._values_int = node[:len(self.model.timestepper), self.scenario.slice]
+                    self._values_int = node[:len(self.model.timestepper), self.scenario.slice].astype(np.int32)
             # else: scenario is defined, but all data required
         if node.dtype in (np.float32, np.float64):
             if self._values_dbl is None:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -196,11 +196,11 @@ def test_timeseries_with_scenarios(solver):
     model.step()
     catchment1 = model.nodes['catchment1']
 
-    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71])
+    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71], dtype=np.float64)
     assert_allclose(catchment1.flow, step1)
 
     model.step()
-    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80])
+    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80], dtype=np.float64)
     # Low tolerance because test values were truncated to 2 decimal places.
     assert_allclose(catchment1.flow, step2)
 
@@ -218,12 +218,12 @@ def test_timeseries_with_scenarios_hdf(solver):
     catchment1 = model.nodes['catchment1']
 
     model.step()
-    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71])
+    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71], dtype=np.float64)
     # Low tolerance because test values were truncated to 2 decimal places.
     assert_allclose(catchment1.flow, step1, atol=1e-1)
 
     model.step()
-    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80])
+    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80], dtype=np.float64)
     # Low tolerance because test values were truncated to 2 decimal places.
     assert_allclose(catchment1.flow, step2, atol=1e-1)
 
@@ -237,11 +237,30 @@ def test_tablesarrayparameter_scenario_slice(solver):
     model.setup()
     model.reset()
     model.step()
-    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71])
+    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71], dtype=np.float64)
     assert_allclose(catchment1.flow, step1[::2], atol=1e-1)
     model.step()
-    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80])
+    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80], dtype=np.float64)
     assert_allclose(catchment1.flow, step2[::2], atol=1e-1)
+    model.finish()
+
+def test_tablesarrayparameter_scenario_user_combinations(solver):
+    """Test TablesArrayParameter with user defined combination of scenarios"""
+    model = load_model('timeseries2_hdf.json', solver=solver)
+    catchment1 = model.nodes['catchment1']
+    scenario = model.scenarios["scenario A"]
+    scenario2 = Scenario(model, "scenario B", size=2)
+    # combinations are intentially out of order and with duplicates
+    model.scenarios.user_combinations = [(0, 0), (2, 0), (6, 1), (2, 1)]
+    model.setup()
+    model.reset()
+    assert(len(model.scenarios.combinations) == 4)
+    model.step()
+    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71], dtype=np.float64)
+    assert_allclose(catchment1.flow, step1[[0, 2, 6, 2]], atol=1e-1)
+    model.step()
+    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80], dtype=np.float64)
+    assert_allclose(catchment1.flow, step2[[0, 2, 6, 2]], atol=1e-1)
     model.finish()
 
 def test_tables_array_index_error(solver):

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -229,6 +229,21 @@ def test_timeseries_with_scenarios_hdf(solver):
 
     model.finish()
 
+def test_tablesarrayparameter_scenario_slice(solver):
+    model = load_model('timeseries2_hdf.json', solver=solver)
+    catchment1 = model.nodes['catchment1']
+    scenario = model.scenarios["scenario A"]
+    scenario.slice = slice(0, 10, 2)
+    model.setup()
+    model.reset()
+    model.step()
+    step1 = np.array([21.64, 21.72, 23.97, 23.35, 21.79, 21.52, 21.21, 22.58, 26.19, 25.71])
+    assert_allclose(catchment1.flow, step1[::2], atol=1e-1)
+    model.step()
+    step2 = np.array([20.03, 20.10, 22.18, 21.62, 20.17, 19.92, 19.63, 20.90, 24.24, 23.80])
+    assert_allclose(catchment1.flow, step2[::2], atol=1e-1)
+    model.finish()
+
 def test_tables_array_index_error(solver):
     # check an exception is raised (before the model starts) if the length
     # of the data passed to a TablesArrayParameter is not long enough


### PR DESCRIPTION
This PR begins to address #489, by only loading data required for the sliced scenario in `TablesArrayParameter`.

TODO:

- [x] slice in time as well as scenario
- [x] support for user combinations of scenarios
- [x] apply slice to integer datasets