### PR TITLE
Added component_attrs to AggregatedNode

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -568,6 +568,8 @@ cdef class AggregatedNode(AbstractNode):
         self._min_flow_param = None
         self._max_flow_param = None
 
+    component_attrs = ["min_flow", "max_flow"]
+
     property nodes:
         def __get__(self):
             return self._nodes


### PR DESCRIPTION
Fixes a bug incorrectly identifying orphaned parameters if a parameter is set to AggregatedNode min_flow or max_flow