### PR TITLE
Support scenario user_combinations in TablesRecorder

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -173,7 +173,8 @@ cdef class ScenarioCollection:
     property shape:
         def __get__(self):
             if self._user_combinations is not None:
-                raise ValueError("ScenarioCollection.shape is undefined if user_combinations is defined.")
+                #raise ValueError("ScenarioCollection.shape is undefined if user_combinations is defined.")
+                return (len(self._user_combinations), )
             if len(self._scenarios) == 0:
                 return (1, )
             return tuple(len(range(sc.size)[sc.slice]) if sc.slice is not None else sc.size for sc in self._scenarios)

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -452,9 +452,9 @@ class TestTablesRecorder:
                 d += timedelta(1)
 
             scenarios = h5f.get_node('/scenarios')
-            for s in model.scenarios.scenarios:
+            for i, s in enumerate(model.scenarios.scenarios):
                 row = scenarios[i]
-                assert row['name'] == s.name
+                assert row['name'] == s.name.encode('utf-8')
                 assert row['size'] == s.size
 
             model.reset()
@@ -491,6 +491,51 @@ class TestTablesRecorder:
                 ca = h5f.get_node('/', node_name)
                 assert ca.shape == (365, 4, 2)
                 np.testing.assert_allclose(ca[0, ...], [[10, 10], [20, 20], [20, 30], [20, 40]])
+
+            scenarios = h5f.get_node('/scenarios')
+            for i, s in enumerate(model.scenarios.scenarios):
+                row = scenarios[i]
+                assert row['name'] == s.name.encode('utf-8')
+                assert row['size'] == s.size
+
+    def test_user_scenarios(self, simple_linear_model, tmpdir):
+        """
+        Test the TablesRecorder with user defined scenario subset
+
+        """
+        from pywr.parameters import ConstantScenarioParameter
+        model = simple_linear_model
+        scA = Scenario(model, name='A', size=4)
+        scB = Scenario(model, name='B', size=2)
+
+        # Use first and last combinations
+        model.scenarios.user_combinations = [[0, 0], [3, 1]]
+
+        otpt = model.nodes['Output']
+        inpt = model.nodes['Input']
+
+        inpt.max_flow = ConstantScenarioParameter(model, scA, [10, 20, 30, 40])
+        otpt.max_flow = ConstantScenarioParameter(model, scB, [20, 40])
+        otpt.cost = -2.0
+
+        h5file = tmpdir.join('output.h5')
+        import tables
+        with tables.open_file(str(h5file), 'w') as h5f:
+            rec = TablesRecorder(model, h5f)
+
+            model.run()
+
+            for node_name in model.nodes.keys():
+                ca = h5f.get_node('/', node_name)
+                assert ca.shape == (365, 2)
+                np.testing.assert_allclose(ca[0, ...], [10, 40])
+
+            # check combinations table exists
+            combinations = h5f.get_node('/scenario_combinations')
+            for i, comb in enumerate(model.scenarios.user_combinations):
+                row = combinations[i]
+                assert row['A'] == comb[0]
+                assert row['B'] == comb[1]
 
     def test_parameters(self, simple_linear_model, tmpdir):
         """

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -342,10 +342,8 @@ def test_scenario_user_combinations(simple_linear_model):
     model.scenarios.user_combinations = [[0, 1], [1, 1]]
     combinations = model.scenarios.get_combinations()
     assert(len(combinations) == 2)
-
-    # ScenarioCollection.shape is undefined if user combinations are defined
-    with pytest.raises(ValueError):
-        model.scenarios.shape
+    # ScenarioCollection.shape is simply the number of combinations
+    assert model.scenarios.shape == (2, )
 
     # Test wrong number of dimensions
     with pytest.raises(ValueError):


### PR DESCRIPTION
- Requires supporting ScenarioCollection.shape when user_combinations is given.
- Stores data in a flattened formed.
- Addes a table of scenarios combinations stored.
- Tests added.