### PR TITLE
More determinism in GLPK solver

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -304,6 +304,13 @@ cdef class AbstractNode:
             # apply new name
             self._name = name
 
+    property fully_qualified_name:
+        def __get__(self):
+            if self._parent is not None:
+                return '{}.{}'.format(self._parent.fully_qualified_name, self.name)
+            return self.name
+
+
     property recorders:
         """ Returns a list of `Recorder` objects attached to this node.
 

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -571,7 +571,7 @@ cdef class AggregatedNode(AbstractNode):
         self._allow_isolated = True
         self.virtual = True
         self._factors = None
-        self._min_flow = -inf
+        self._min_flow = 0.0
         self._max_flow = inf
         self._min_flow_param = None
         self._max_flow_param = None

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -490,7 +490,7 @@ class Model(object):
                         all_routes.append(route)
 
         # Now sort the routes to ensure determinism
-        all_routes = sorted(all_routes, key=lambda r: tuple(n.name for n in r))
+        all_routes = sorted(all_routes, key=lambda r: tuple(n.fully_qualified_name for n in r))
         return all_routes
 
     def step(self):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -506,12 +506,20 @@ cdef class CythonGLPKSolver:
         # update non-storage properties
         for col, node in enumerate(non_storages):
             min_flow = inf_to_dbl_max(node.get_min_flow(scenario_index))
+            if np.abs(min_flow) < 1e-8:
+                min_flow = 0.0
             max_flow = inf_to_dbl_max(node.get_max_flow(scenario_index))
+            if np.abs(max_flow) < 1e-8:
+                max_flow = 0.0
             set_row_bnds(self.prob, self.idx_row_non_storages+col, constraint_type(min_flow, max_flow), min_flow, max_flow)
 
         for col, agg_node in enumerate(aggregated):
             min_flow = inf_to_dbl_max(agg_node.get_min_flow(scenario_index))
+            if np.abs(min_flow) < 1e-8:
+                min_flow = 0.0
             max_flow = inf_to_dbl_max(agg_node.get_max_flow(scenario_index))
+            if np.abs(max_flow) < 1e-8:
+                max_flow = 0.0
             set_row_bnds(self.prob, self.idx_row_aggregated_min_max + col, constraint_type(min_flow, max_flow), min_flow, max_flow)
 
         self.stats['bounds_update_nonstorage'] += time.clock() - t0
@@ -530,6 +538,11 @@ cdef class CythonGLPKSolver:
                 # result in maximum volume being exceeded
                 lb = -avail_volume/timestep._days
                 ub = max(max_volume - storage._volume[scenario_index.global_id], 0.0) / timestep._days
+
+                if np.abs(lb) < 1e-8:
+                    lb = 0.0
+                if np.abs(ub) < 1e-8:
+                    ub = 0.0
                 set_row_bnds(self.prob, self.idx_row_storages+col, constraint_type(lb, ub), lb, ub)
 
         # update virtual storage node constraint
@@ -545,6 +558,11 @@ cdef class CythonGLPKSolver:
                 # result in maximum volume being exceeded
                 lb = -avail_volume/timestep._days
                 ub = max(max_volume - storage._volume[scenario_index.global_id], 0.0) / timestep._days
+
+                if np.abs(lb) < 1e-8:
+                    lb = 0.0
+                if np.abs(ub) < 1e-8:
+                    ub = 0.0
                 set_row_bnds(self.prob, self.idx_row_virtual_storages+col, constraint_type(lb, ub), lb, ub)
 
         self.stats['bounds_update_storage'] += time.clock() - t0

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -593,7 +593,9 @@ cdef class CythonGLPKSolver:
             print("Simplex solve returned: {} ({})".format(simplex_status_string[simplex_ret], simplex_ret))
             print("Simplex status: {} ({})".format(status_string[status], status))
             print("Scenario ID: {}".format(scenario_index.global_id))
+            print("Timestep index: {}".format(timestep._index))
             self.dump_mps(b'pywr_glpk_debug.mps')
+            self.dump_lp(b'pywr_glpk_debug.lp')
 
             self.smcp.msg_lev = GLP_MSG_DBG
             # Retry solve with debug messages
@@ -693,7 +695,6 @@ cdef set_mat_row(glp_prob *P, int i, int len, int* ind, double* val):
         cdef int j
         for j in range(len):
             assert np.isfinite(val[j+1])
-
             assert np.abs(val[j+1]) > 1e-6
             assert ind[j+1] > 0
 

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -335,7 +335,7 @@ cdef class CythonGLPKSolver:
             length = len(matrix)
             ind = <int*>malloc(1+length * sizeof(int))
             val = <double*>malloc(1+length * sizeof(double))
-            for i, col in enumerate(matrix):
+            for i, col in enumerate(sorted(matrix)):
                 ind[1+i] = 1+col
                 val[1+i] = 1.0
             set_mat_row(self.prob, row, length, ind, val)


### PR DESCRIPTION
Some changes here:

- Use a fully qualified node name for sorting the nodes & routes in the solver. This should ensure that the order of the columns & rows in the LP is deterministic. Previously this was not the case due to, for example, `Storage` sublinks having the same name.
- Add an absolute epsilon check against (1e-8) before passing row bounds and objective coefficients to GLPK. This was following some advice on the GLPK wiki: https://en.wikibooks.org/wiki/GLPK/Modeling_tips#Close-to-zero_values
- Sorted a `set` that's used for defining the min / max flow constraints on `AggregatedNode`