### PR TITLE
Some miscellaneous changes

### DIFF
--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -60,6 +60,9 @@ else:
         def dump_lp(self, filename):
             return self._cy_solver.dump_lp(filename)
 
+        def dump_glpk(self, filename):
+            return self._cy_solver.dump_glpk(filename)
+
         def retry_solve():
             def fget(self):
                 return self._cy_solver.retry_solve

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -650,6 +650,9 @@ cdef class CythonGLPKSolver:
     cpdef dump_lp(self, filename):
         glp_write_lp(self.prob, NULL, filename)
 
+    cpdef dump_glpk(self, filename):
+        glp_write_prob(self.prob, 0, filename)
+
 
 cdef int simplex(glp_prob *P, glp_smcp parm):
     return glp_simplex(P, &parm)

--- a/pywr/solvers/glpk.pxi
+++ b/pywr/solvers/glpk.pxi
@@ -156,9 +156,9 @@ cdef extern from "glpk.h":
     int glp_get_num_cols(glp_prob *P)
     int glp_get_num_nz(glp_prob *P)
 
-    int glp_write_mps(glp_prob *P, int fmt, const glp_mpscp *parm,
-      const char *fname)
-    int glp_write_lp(glp_prob *lp, const void *parm, const char *fname);
+    int glp_write_mps(glp_prob *P, int fmt, const glp_mpscp *parm, const char *fname)
+    int glp_write_lp(glp_prob *lp, const void *parm, const char *fname)
+    int glp_write_prob(glp_prob *P, int flags, const char *fname)
 
     int glp_get_row_stat(glp_prob *P, int i)
     int glp_get_col_stat(glp_prob *P, int i)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -483,14 +483,14 @@ def test_select_solver():
     """Test specifying the solver in JSON"""
     solver_names = [solver.name for solver in pywr.solvers.solver_registry]
     for solver_name in solver_names:
-        data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
+        data = '''{"metadata": {"minimum_version": "0.1"}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
         model = load_model(data=data)
         assert(model.solver.name.lower() == solver_name)
 
 def test_solver_unrecognised():
     '''Test specifying an unrecognised solver JSON'''
     solver_name = 'foobar'
-    data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
+    data = '''{"metadata": {"minimum_version": "0.1"}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s"}}''' % solver_name
     with pytest.raises(KeyError):
         model = load_model(data=data)
 
@@ -500,7 +500,7 @@ def test_select_glpk_presolve(use_presolve):
     """Test specifying the solver in JSON"""
     solver_names = ["glpk"]
     for solver_name in solver_names:
-        data = '''{"metadata": {}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s", "use_presolve": %s}}''' % (solver_name, use_presolve)
+        data = '''{"metadata": {"minimum_version": "0.1"}, "nodes": {}, "edges": {}, "timestepper": {"start": "1990-01-01","end": "1999-12-31","timestep": 1}, "solver": {"name": "%s", "use_presolve": %s}}''' % (solver_name, use_presolve)
         model = load_model(data=data)
         assert(model.solver.name.lower() == solver_name)
         assert(model.solver._cy_solver.use_presolve == (use_presolve == "true"))


### PR DESCRIPTION
- Added dumping linear programme to GLP file format from GLPK solver.
- Fixes #513 by testing for IPython import.
- Specified minimum_version in some tests to remove warnings.
- Asserted naming warnings are fired by TablesRecorder.

Should be enough for 0.4?