### PR TITLE
Recursive deletion of child nodes when deleting compound nodes.

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -743,8 +743,15 @@ class NodeIterator(object):
         raise KeyError("'{}'".format(key))
 
     def __delitem__(self, key):
-        """Remove a node from the graph by it's name"""
-        node = self[key]
+        """Remove a node from the graph"""
+        if isinstance(key, basestring):
+            node = self[key]
+        else:
+            node = key
+        # recursive delete to remove all sub-nodes
+        for node2 in self.model.graph.nodes():
+            if node2.parent == node:
+                del(self[node2])
         self.model.graph.remove_node(node)
 
     def keys(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -483,6 +483,22 @@ def test_storage_initial_volume_table():
     np.testing.assert_allclose(model.nodes["supply2"].initial_volume, 35.0)
 
 
+def test_recursive_delete(solver):
+    """Test recursive deletion of child nodes for compound nodes"""
+    model = Model()
+    n1 = Input(model, "n1")
+    n2 = Output(model, "n2")
+    s = Storage(model, "s", num_outputs=2)
+    assert len(model.nodes) == 3
+    assert len(model.graph.nodes()) == 6
+    del(model.nodes["n1"])
+    assert len(model.nodes) == 2
+    assert len(model.graph.nodes()) == 5
+    del(model.nodes["s"])
+    assert len(model.nodes) == 1
+    assert len(model.graph.nodes()) == 1
+
+
 def test_json_include(solver):
     """Test include in JSON document"""
     filename = os.path.join(TEST_FOLDER, "models", "extra1.json")


### PR DESCRIPTION
This PR allows you to delete compound nodes from a model, including their hidden sub nodes (as suggested in #166).

e.g.

```
del(model.nodes["my reservoir"])
```

It also allows you to delete a node directly rather than by name, e.g. `del(model.nodes[my_reservoir])`. This was required, as the child nodes often don't have unique names (e.g. `[output0]`).