### PR TITLE
Added .gitattributes for timeseries2.csv. Closes #536.

### DIFF
--- a/tests/models/.gitattributes
+++ b/tests/models/.gitattributes
@@ -1,0 +1,2 @@
+# we test the checksum of this file, so line endings must be preserved
+timeseries2.csv text eol=lf


### PR DESCRIPTION
This PR tells Git to always checkout `timeseris2.csv` using unix-style line endings, so the checksum still works on Windows.