### PR TITLE
Added JSON support for license parameters.

### DIFF
--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -10,6 +10,7 @@ from ._parameters import (
     align_and_resample_dataframe, DataFrameParameter,
     IndexParameter, AggregatedParameter, AggregatedIndexParameter,
     load_parameter, load_parameter_values, load_dataframe)
+from . import licenses
 from ._polynomial import Polynomial1DParameter, Polynomial2DStorageParameter
 from ._thresholds import StorageThresholdParameter, RecorderThresholdParameter
 from past.builtins import basestring

--- a/tests/models/annual_license.json
+++ b/tests/models/annual_license.json
@@ -25,7 +25,10 @@
         {
             "name": "demand1",
             "type": "Output",
-            "max_flow": 50,
+            "max_flow": {
+                "type": "arrayindexed",
+                "values": [50, 50, 0, 50, 50, 50, 50]
+            },
             "cost": -10
         }
     ],

--- a/tests/models/annual_license.json
+++ b/tests/models/annual_license.json
@@ -1,0 +1,36 @@
+{
+    "metadata": {
+        "title": "Annual license test",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "annuallicense",
+                "node": "supply1",
+                "amount": 200
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 50,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}


### PR DESCRIPTION
This PR adds support for license parameters (e.g. `pywr.parameters.licenses.AnnualLicense`) from JSON.