### PR TITLE
 Add parameter statistic tracking to EventRecorder

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -361,6 +361,8 @@ cdef class TablesArrayParameter(IndexParameter):
             # negative values are often erroneous
             if np.min(self._values_dbl) < 0.0:
                 warnings.warn('Negative values in input file "{}" from node: {}'.format(self.h5file, self.node))
+            if not np.all(np.isfinite(self._values_dbl)):
+                raise ValueError('Non-finite values in input file "{}" from node: {}'.format(self.h5file, self.node))
         else:
             if self._values_int is None:
                 self._values_int = node.read().astype(np.int32)

--- a/pywr/recorders/events.py
+++ b/pywr/recorders/events.py
@@ -32,11 +32,21 @@ class EventRecorder(Recorder):
     ----------
     threshold - IndexParameter, Parameter or Recorder
        The object that defines the start and end of an event.
-    minimum_event_lenght - int (default=1)
+    minimum_event_length - int (default=1)
         The minimum number of time-steps that an event must last for
         to be recorded. This is useful to not record events that are
         caused by model hysteresis. The default will cause all events
         to be recorded.
+    agg_func - string, callable
+        Function used for aggregating across the recorders. Numpy style functions that
+        support an axis argument are supported.
+    event_agg_func - string, callable
+        Optional different function for aggregating the `tracked_parameter` across events.
+        If given this aggregation will be added as a `value` column in the `to_dataframe` method.
+    tracked_parameter - `Parameter`
+        The parameter to track across each event. The values from this parameter are appended each
+        time-step to each event. These can then be used with other event recorders for statistical
+        aggregation, or with `event_agg_func`.
 
      See also
      --------
@@ -138,7 +148,13 @@ class EventRecorder(Recorder):
                 self._current_events[si.global_id] = None
 
     def to_dataframe(self):
-        """ Returns a DataFrame containing all of the events. """
+        """ Returns a `pandas.DataFrame` containing all of the events.
+
+        If `event_agg_func` is a valid aggregation function and `tracked_parameter`
+         is given then a "value" column is added to the dataframe containing the
+         result of the aggregation.
+
+        """
         # Return empty dataframe if no events are found.
         if len(self.events) == 0:
             return pandas.DataFrame(columns=['scenario_id', 'start', 'end'])
@@ -175,6 +191,12 @@ class EventDurationRecorder(Recorder):
     ----------
     event_recorder : EventRecorder
         EventRecorder instance to calculate the events.
+    agg_func - string, callable
+        Function used for aggregating across the recorders. Numpy style functions that
+        support an axis argument are supported.
+    recorder_agg_func - string, callable
+        Optional aggregating function for all events in each scenario. The function
+        must be supported by the `DataFrame.group_by` method.
 
     """
     def __init__(self, model, event_recorder, **kwargs):
@@ -233,7 +255,15 @@ class EventStatisticRecorder(Recorder):
     model : pywr.model.Model
     event_recorder : EventRecorder
         EventRecorder instance to calculate the events.
-
+    agg_func - string, callable
+        Function used for aggregating across the recorders. Numpy style functions that
+        support an axis argument are supported.
+    recorder_agg_func - string, callable
+        Optional aggregating function for all events in each scenario. The function
+        must be supported by the `DataFrame.group_by` method.
+    event_agg_func - string, callable
+        Optional different function for aggregating the `tracked_parameter` across events.
+        If given this aggregation will be added as a `value` column in the `to_dataframe` method.
     """
     def __init__(self, model, event_recorder, **kwargs):
         # Optional different method for aggregating across self.recorders scenarios

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -19,7 +19,7 @@ from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
     NumpyArrayIndexParameterRecorder, RollingWindowParameterRecorder, AnnualCountIndexParameterRecorder,
     RootMeanSquaredErrorNodeRecorder, MeanAbsoluteErrorNodeRecorder, MeanSquareErrorNodeRecorder,
     PercentBiasNodeRecorder, RMSEStandardDeviationRatioNodeRecorder, NashSutcliffeEfficiencyNodeRecorder,
-    EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder,
+    EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder, EventStatisticRecorder,
     FlowDurationCurveRecorder, FlowDurationCurveDeviationRecorder, StorageDurationCurveRecorder,
     SeasonalFlowDurationCurveRecorder, load_recorder, ParameterNameWarning)
 from pywr.recorders.progress import ProgressRecorder
@@ -1321,6 +1321,43 @@ class TestEventRecorder:
             assert_equal([3, ], [e.duration for e in evt_rec.events])
         else:
             assert len(evt_rec.events) == 0
+
+    @pytest.mark.parametrize("recorder_agg_func", ["min", "max", "mean", "median", "sum"])
+    def test_statistic_recorder(self, cyclical_storage_model, recorder_agg_func):
+        """ Test EventStatisticRecorder """
+        m = cyclical_storage_model
+
+        strg = m.nodes['Storage']
+        inpt = m.nodes['Input']
+        arry = NumpyArrayNodeRecorder(m, inpt)
+
+        # Create the trigger using a threhsold parameter
+        trigger = StorageThresholdRecorder(m, strg, 4.0, predicate='<=')
+        evt_rec = EventRecorder(m, trigger, tracked_parameter=inpt.max_flow)
+        evt_stat = EventStatisticRecorder(m, evt_rec, agg_func='max', event_agg_func='min', recorder_agg_func=recorder_agg_func)
+
+        m.run()
+
+        # Ensure there is at least one event
+        assert evt_rec.events
+
+        evt_values = {si.global_id:[] for si in m.scenarios.combinations}
+        for evt in evt_rec.events:
+            evt_values[evt.scenario_index.global_id].append(np.min(arry.data[evt.start.index:evt.end.index, evt.scenario_index.global_id]))
+
+        func = TestEventRecorder.funcs[recorder_agg_func]
+
+        agg_evt_values = []
+        for k, v in sorted(evt_values.items()):
+            if len(v) > 0:
+                agg_evt_values.append(func(v))
+            else:
+                agg_evt_values.append(np.nan)
+
+        # Test that the
+        assert_allclose(evt_stat.values(), agg_evt_values)
+        assert_allclose(evt_stat.aggregated_value(), np.max(agg_evt_values))
+
 
 def test_progress_recorder(simple_linear_model):
     model = simple_linear_model


### PR DESCRIPTION
 - Adds the ability for Event objects to hold a simple list of values from
   a Parameter for the duration of the event.
   - Currently only supports Parameters and not other components or nodes.
 - New EventStatisticRecorder to compute arbitrary aggregation of the
   tracked values and return via .values() and .aggregated_value()
   methods.
 - Test of the new object and functionality.

There's also another commit tacked on that adds a non-finite value sense check to TablesArrayParameter