### PR TITLE
Drop testing of Python 3.4 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x64
-      CONDA_PY: 34
-      CONDA_NPY: 111
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x64
       CONDA_PY: 36
       CONDA_NPY: 113
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64


### PR DESCRIPTION
conda-forge no longer produces binaries for 3.4 [vc10] which makes testing difficult.

Closes #546.