### PR TITLE
A few things in there

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -363,9 +363,19 @@ class Model(object):
                     recorders_to_load[key]["name"] = key
         model._recorders_to_load = recorders_to_load
 
+        # load the remaining nodes
+        for node_name in list(nodes_to_load.keys()):
+            node = cls._get_node_from_ref(model, node_name)
+
         # load parameters and recorders
-        for name, rdata in model._recorders_to_load.items():
-            load_recorder(model, rdata)
+        while True:
+            try:
+                name, rdata = model._recorders_to_load.popitem()
+            except KeyError:
+                break
+            recorder = load_recorder(model, rdata)
+
+
         while True:
             try:
                 name, pdata = model._parameters_to_load.popitem()
@@ -374,10 +384,6 @@ class Model(object):
             parameter = load_parameter(model, pdata, name)
             if not isinstance(parameter, BaseParameter):
                 raise TypeError("Named parameters cannot be literal values. Use type \"constant\" instead.")
-
-        # load the remaining nodes
-        for node_name in list(nodes_to_load.keys()):
-            node = cls._get_node_from_ref(model, node_name)
 
         del(model._recorders_to_load)
         del(model._parameters_to_load)

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1169,7 +1169,7 @@ def load_recorder(model, data):
             # we're still in the process of loading data from JSON and
             # the parameter requested hasn't been loaded yet - do it now
             try:
-                data = model._recorders_to_load[recorder_name]
+                data = model._recorders_to_load.pop(recorder_name)
             except KeyError:
                 raise KeyError("Unknown recorder: '{}'".format(data))
             recorder = load_recorder(model, data)

--- a/tests/models/reservoir_with_circular_cc.json
+++ b/tests/models/reservoir_with_circular_cc.json
@@ -1,0 +1,44 @@
+{
+    "metadata": {
+        "title": "A model with a circular reference on the storage node.",
+        "description": "This is a simple demonstration of a circular reference problem with group control curves. See github issue #380: https://github.com/pywr/pywr/issues/380",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0,
+            "cost": "reservoir1_cost"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 300,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir1_cost": {
+                "type": "ControlCurveInterpolated",
+                "control_curve": {
+                    "type": "dailyprofile",
+                    "url": "control_curve.csv",
+                    "parse_dates": false,
+                    "column": "Control Curve"
+                },
+                "storage_node": "reservoir1",
+                "values": [-8, -6, -4]
+            }
+    }
+}

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -333,8 +333,6 @@ def test_control_curve_interpolated_json(solver):
     model.run()
 
 
-@pytest.mark.xfail(reason="Circular dependency in the JSON definition. "
-                          "See GitHub issue #380: https://github.com/pywr/pywr/issues/380")
 def test_circular_control_curve_interpolated_json(solver):
     # this is a little hack-y, as the parameters don't provide access to their
     # data once they've been initalised

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -458,10 +458,12 @@ def test_breaklink_node(solver):
 
 
 def test_reservoir_surface_area(solver):
+    from pywr.parameters import InterpolatedVolumeParameter
     model = load_model('reservoir_evaporation.json', solver=solver)
     model.timestepper.start = "1920-01-01"
     model.timestepper.end = "1920-01-02"
     res = model.run()
+    assert isinstance(model.nodes["reservoir1"].area, InterpolatedVolumeParameter)
     assert_allclose(model.nodes["evaporation"].flow, 2.46875)
 
 


### PR DESCRIPTION
I *think* this solves the circular reference problems. I went down a rabbit hole fixing the `area` loading problem (which had an unrealised circular reference problem in the existing test). This has fixed a few things as follows,

- Load nodes before recorders and parameters from JSON
- Load all parameters after creating the instance when loading Storage
- `load_recorder` consumes JSON data from `_recorders_to_load`.
- Load the area parameter correctly in `Storage`.
- Includes a circular control curve test that now works.

Fixes #380.
Fixes #585.