### PR TITLE
Make area property load correctly in Storage

### DIFF
--- a/tests/models/reservoir_evaporation_without_area_property.json
+++ b/tests/models/reservoir_evaporation_without_area_property.json
@@ -1,0 +1,59 @@
+{
+    "metadata": {
+        "title": "Reservoir Evaporation",
+        "description": "A model with a reservoir, with evaporation proportional to surface area",
+        "minimum_version": "0.5dev0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "evaporation",
+            "type": "Output",
+            "max_flow": "reservoir_evaporation",
+            "cost": -1000
+        }        
+    ],
+    "edges": [
+        ["reservoir1", "evaporation"],
+        ["reservoir1", "demand1"]
+    ],
+    "parameters": {
+        "reservoir_area": {
+            "type": "interpolatedvolume",
+            "node": "reservoir1",
+            "volumes": [0, 1000],
+            "values": [0, 500],
+            "kind": "linear"
+        },
+        "evaporation_mm": {
+            "type": "monthlyprofile",
+            "values": [5.0, 5.0, 5.0, 5.0, 5.0, 6.0, 6.0, 6.0, 5.0, 5.0, 5.0, 5.0]
+        },
+        "reservoir_evaporation": {
+            "type": "aggregated",
+            "agg_func": "product",
+            "parameters": [
+                "reservoir_area",
+                "evaporation_mm",
+                0.001
+            ]
+        }
+    }
+}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -457,6 +457,8 @@ def test_breaklink_node(solver):
     assert_allclose(transfer.storage.volume, 0)
 
 
+@pytest.mark.xfail(reason="Circular dependency in the JSON definition. "
+                          "See GitHub issue #380: https://github.com/pywr/pywr/issues/380")
 def test_reservoir_surface_area(solver):
     from pywr.parameters import InterpolatedVolumeParameter
     model = load_model('reservoir_evaporation.json', solver=solver)
@@ -464,6 +466,15 @@ def test_reservoir_surface_area(solver):
     model.timestepper.end = "1920-01-02"
     res = model.run()
     assert isinstance(model.nodes["reservoir1"].area, InterpolatedVolumeParameter)
+    assert_allclose(model.nodes["evaporation"].flow, 2.46875)
+
+
+def test_reservoir_surface_area_without_area_property(solver):
+    """ Temporary test while the above test is not working. """
+    model = load_model('reservoir_evaporation_without_area_property.json', solver=solver)
+    model.timestepper.start = "1920-01-01"
+    model.timestepper.end = "1920-01-02"
+    res = model.run()
     assert_allclose(model.nodes["evaporation"].flow, 2.46875)
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -458,10 +458,12 @@ def test_breaklink_node(solver):
 
 
 def test_reservoir_surface_area(solver):
+    from pywr.parameters import InterpolatedVolumeParameter
     model = load_model('reservoir_evaporation.json', solver=solver)
     model.timestepper.start = "1920-01-01"
     model.timestepper.end = "1920-01-02"
     res = model.run()
+    assert isinstance(model.nodes["reservoir1"].area, InterpolatedVolumeParameter)
     assert_allclose(model.nodes["evaporation"].flow, 2.46875)
 
 


### PR DESCRIPTION
While #586 is not ready this takes a couple of commits.

It fixes the issue with area not being loading on `Storage`. However that means the existing reservoir evaporation example doesn't work because of #380. While this is not fixed I've copied the example to make it work if you don't set the `area` property of `Storage` (which isn't required for the evaporation calculation).

Suggest we merge this and do the 0.5 release rather than wait for #586.