### PR TITLE
Enabled OSX builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ env:
 # Travis has limited OSX resources
 # Only do OSX on Python 3.6
 matrix:
-  - os: linux
-    env: CONDA_PY=27
-  - os: linux
-    env: CONDA_PY=34
-  - os: linux
-    env: CONDA_PY=36 BUILD_DOC=1
-  - os: osx
-    env: CONDA_PY=36
+    include:
+      - os: linux
+        env: CONDA_PY=27
+      - os: linux
+        env: CONDA_PY=34
+      - os: linux
+        env: CONDA_PY=36 BUILD_DOC=1
+      - os: osx
+        env: CONDA_PY=36
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,11 @@ install:
       if [ ! -f ${HOME}/miniconda3/bin/conda ] ; then
           echo "Fresh miniconda install..."
           MINICONDA_URL="https://repo.continuum.io/miniconda"
-          MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
+          if [ `uname` == "Darwin" ]; then
+              MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+          else
+              MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
+          fi
           wget ${MINICONDA_URL}/${MINICONDA_FILE}
           rm -rf ${HOME}/miniconda3
           bash ${MINICONDA_FILE} -b -p ${HOME}/miniconda3

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
         env: CONDA_PY=36 BUILD_DOC=1
       - os: osx
         env: CONDA_PY=36
+             MACOSX_DEPLOYMENT_TARGET=10.9
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
     directories:
         - ${HOME}/miniconda3
 
+os:
+  - linux
+  - osx
+
 env:
     global:
         - secure: "bF1Ljix0pDNBBjgewrOxxNHJDEvlWDT5v5KckSq/Wl0v9QMAG5Fiilj0hPHVQrWoGz7F3xPU5KeprjQcfTo2UB7qPGDOVsovafbUTZ+0o6kc2mVLApYsRvlhUPX8tsRCrq6Zo874buMzbDPyAo3nnl3lkkWQ2Dh+gA7b7er9xS0="
@@ -13,6 +17,15 @@ env:
         - CONDA_PY=27
         - CONDA_PY=34
         - CONDA_PY=36 BUILD_DOC=1
+
+# Travis has limited OSX resources
+# Only do OSX on Python 3.6
+matrix:
+  exclude:
+    - os: osx
+      env: CONDA_PY=27
+    - os: osx
+      env: CONDA_PY=34
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,26 +6,21 @@ cache:
     directories:
         - ${HOME}/miniconda3
 
-os:
-  - linux
-  - osx
-
 env:
     global:
         - secure: "bF1Ljix0pDNBBjgewrOxxNHJDEvlWDT5v5KckSq/Wl0v9QMAG5Fiilj0hPHVQrWoGz7F3xPU5KeprjQcfTo2UB7qPGDOVsovafbUTZ+0o6kc2mVLApYsRvlhUPX8tsRCrq6Zo874buMzbDPyAo3nnl3lkkWQ2Dh+gA7b7er9xS0="
-    matrix:
-        - CONDA_PY=27
-        - CONDA_PY=34
-        - CONDA_PY=36 BUILD_DOC=1
 
 # Travis has limited OSX resources
 # Only do OSX on Python 3.6
 matrix:
-  exclude:
-    - os: osx
-      env: CONDA_PY=27
-    - os: osx
-      env: CONDA_PY=34
+  - os: linux
+    env: CONDA_PY=27
+  - os: linux
+    env: CONDA_PY=34
+  - os: linux
+    env: CONDA_PY=36 BUILD_DOC=1
+  - os: osx
+    env: CONDA_PY=36
 
 install:
     - |


### PR DESCRIPTION
This PR modifies the `travis.yml` to enable building and testing on OSX. Travis now support OSX builds for open source projects. So this means we can do travis builds for conda. 

Fixes #588 

There's currently an issue with OSX jobs on travis so the builds are being slow. One of these commits has however sucessfully built on the OSX environment, see:

https://travis-ci.org/pywr/pywr/builds/330419345

