### PR TITLE
Improved the mean flow recorders.

### DIFF
--- a/docs/source/api/pywr.recorders.rst
+++ b/docs/source/api/pywr.recorders.rst
@@ -59,8 +59,9 @@ Statistical recorders
 .. autosummary::
    :toctree: generated/
 
-   MeanFlowRecorder
+   MeanFlowNodeRecorder
    TotalFlowNodeRecorder
+   RollingMeanFlowNodeRecorder
    MinimumVolumeStorageRecorder
    MinimumThresholdVolumeStorageRecorder
    RollingWindowParameterRecorder

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -70,7 +70,7 @@ cdef class RollingWindowParameterRecorder(ParameterRecorder):
     cdef double[:, :] _memory
     cdef double[:, :] _data
 
-cdef class MeanFlowRecorder(NodeRecorder):
+cdef class RollingMeanFlowNodeRecorder(NodeRecorder):
     cdef int position
     cdef public int timesteps
     cdef public int days
@@ -84,6 +84,9 @@ cdef class TotalDeficitNodeRecorder(BaseConstantNodeRecorder):
     pass
 
 cdef class TotalFlowNodeRecorder(BaseConstantNodeRecorder):
+    cdef public double factor
+
+cdef class MeanFlowNodeRecorder(BaseConstantNodeRecorder):
     cdef public double factor
 
 cdef class DeficitFrequencyNodeRecorder(BaseConstantNodeRecorder):

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1035,7 +1035,6 @@ cdef class MeanFlowNodeRecorder(BaseConstantNodeRecorder):
     cpdef after(self):
         cdef ScenarioIndex scenario_index
         cdef int i
-        cdef int days = self.model.timestepper.current.days
         for scenario_index in self.model.scenarios.combinations:
             i = scenario_index.global_id
             self._values[i] += self._node._flow[i]*self.factor

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -885,7 +885,7 @@ cdef class RollingWindowParameterRecorder(ParameterRecorder):
 
 RollingWindowParameterRecorder.register()
 
-cdef class MeanFlowRecorder(NodeRecorder):
+cdef class RollingMeanFlowNodeRecorder(NodeRecorder):
     """Records the mean flow of a Node for the previous N timesteps
 
     Parameters
@@ -900,7 +900,7 @@ cdef class MeanFlowRecorder(NodeRecorder):
 
     """
     def __init__(self, model, node, timesteps=None, days=None, name=None, **kwargs):
-        super(MeanFlowRecorder, self).__init__(model, node, name=name, **kwargs)
+        super(RollingMeanFlowNodeRecorder, self).__init__(model, node, name=name, **kwargs)
         self.model = model
         if not timesteps and not days:
             raise ValueError("Either `timesteps` or `days` must be specified.")
@@ -915,7 +915,7 @@ cdef class MeanFlowRecorder(NodeRecorder):
         self._data = None
 
     cpdef setup(self):
-        super(MeanFlowRecorder, self).setup()
+        super(RollingMeanFlowNodeRecorder, self).setup()
         self.position = 0
         self._data = np.empty([len(self.model.timestepper), len(self.model.scenarios.combinations)])
         if self.days:
@@ -963,7 +963,7 @@ cdef class MeanFlowRecorder(NodeRecorder):
             days = None
         return cls(model, node, timesteps=timesteps, days=days, name=name)
 
-MeanFlowRecorder.register()
+RollingMeanFlowNodeRecorder.register()
 
 cdef class BaseConstantNodeRecorder(NodeRecorder):
     """
@@ -1020,6 +1020,33 @@ cdef class TotalFlowNodeRecorder(BaseConstantNodeRecorder):
             self._values[i] += self._node._flow[i]*self.factor*days
         return 0
 TotalFlowNodeRecorder.register()
+
+
+cdef class MeanFlowNodeRecorder(BaseConstantNodeRecorder):
+    """
+    Record the mean flow for a Node.
+
+    A factor can be provided to scale the total flow (e.g. for calculating operational costs).
+    """
+    def __init__(self, *args, **kwargs):
+        self.factor = kwargs.pop('factor', 1.0)
+        super(MeanFlowNodeRecorder, self).__init__(*args, **kwargs)
+
+    cpdef after(self):
+        cdef ScenarioIndex scenario_index
+        cdef int i
+        cdef int days = self.model.timestepper.current.days
+        for scenario_index in self.model.scenarios.combinations:
+            i = scenario_index.global_id
+            self._values[i] += self._node._flow[i]*self.factor
+        return 0
+
+    cpdef finish(self):
+        cdef int i
+        cdef int nt = self.model.timestepper.current.index
+        for i in range(self._values.shape[0]):
+            self._values[i] /= nt
+MeanFlowNodeRecorder.register()
 
 
 cdef class DeficitFrequencyNodeRecorder(BaseConstantNodeRecorder):

--- a/tests/models/mean_flow_recorder.json
+++ b/tests/models/mean_flow_recorder.json
@@ -53,7 +53,7 @@
         },
         "Mean Flow": {
             "comment": "Mean flow (last 3 days) from supply1",
-            "type": "MeanFlow",
+            "type": "rollingMeanFlownode",
             "node": "supply1",
             "timesteps": 3
         },

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -14,14 +14,14 @@ import json
 from numpy.testing import assert_allclose, assert_equal
 from fixtures import simple_linear_model, simple_storage_model
 from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
-    AggregatedRecorder, CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder,
-    TotalFlowNodeRecorder, MeanFlowRecorder, NumpyArrayParameterRecorder,
-    NumpyArrayIndexParameterRecorder, RollingWindowParameterRecorder, AnnualCountIndexParameterRecorder,
-    RootMeanSquaredErrorNodeRecorder, MeanAbsoluteErrorNodeRecorder, MeanSquareErrorNodeRecorder,
-    PercentBiasNodeRecorder, RMSEStandardDeviationRatioNodeRecorder, NashSutcliffeEfficiencyNodeRecorder,
-    EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder, EventStatisticRecorder,
-    FlowDurationCurveRecorder, FlowDurationCurveDeviationRecorder, StorageDurationCurveRecorder,
-    SeasonalFlowDurationCurveRecorder, load_recorder, ParameterNameWarning)
+                            AggregatedRecorder, CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder,
+                            TotalFlowNodeRecorder, RollingMeanFlowNodeRecorder, MeanFlowNodeRecorder, NumpyArrayParameterRecorder,
+                            NumpyArrayIndexParameterRecorder, RollingWindowParameterRecorder, AnnualCountIndexParameterRecorder,
+                            RootMeanSquaredErrorNodeRecorder, MeanAbsoluteErrorNodeRecorder, MeanSquareErrorNodeRecorder,
+                            PercentBiasNodeRecorder, RMSEStandardDeviationRatioNodeRecorder, NashSutcliffeEfficiencyNodeRecorder,
+                            EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder, EventStatisticRecorder,
+                            FlowDurationCurveRecorder, FlowDurationCurveDeviationRecorder, StorageDurationCurveRecorder,
+                            SeasonalFlowDurationCurveRecorder, load_recorder, ParameterNameWarning)
 from pywr.recorders.progress import ProgressRecorder
 
 from pywr.parameters import DailyProfileParameter, FunctionParameter, ArrayIndexedParameter
@@ -986,6 +986,23 @@ def test_total_flow_node_recorder(simple_linear_model):
     assert_allclose(20.0, rec.aggregated_value(), atol=1e-7)
 
 
+def test_mean_flow_node_recorder(simple_linear_model):
+    """
+    Test MeanFlowNodeRecorder
+    """
+    model = simple_linear_model
+    nt = len(model.timestepper)
+
+    otpt = model.nodes['Output']
+    otpt.max_flow = 30.0
+    model.nodes['Input'].max_flow = 10.0
+    otpt.cost = -2.0
+    rec = MeanFlowNodeRecorder(model, otpt)
+
+    model.run()
+    assert_allclose(10.0, rec.aggregated_value(), atol=1e-7)
+
+
 class TestAggregatedRecorder:
     """Tests for AggregatedRecorder"""
     funcs = {"min": np.min, "max": np.max, "mean": np.mean, "sum": np.sum}
@@ -1043,7 +1060,7 @@ def test_mean_flow_recorder(solver):
     inpt.connect(otpt)
 
     rec_flow = NumpyArrayNodeRecorder(model, inpt)
-    rec_mean = MeanFlowRecorder(model, node=inpt, timesteps=3)
+    rec_mean = RollingMeanFlowNodeRecorder(model, node=inpt, timesteps=3)
 
     scenario = Scenario(model, "dummy", size=2)
 
@@ -1068,7 +1085,7 @@ def test_mean_flow_recorder_days(solver):
     otpt = Output(model, "output")
     inpt.connect(otpt)
 
-    rec_mean = MeanFlowRecorder(model, node=inpt, days=31)
+    rec_mean = RollingMeanFlowNodeRecorder(model, node=inpt, days=31)
 
     model.run()
     assert(rec_mean.timesteps == 4)


### PR DESCRIPTION
- Current MeanFlowRecorder renamed to RollingMeanFlowNodeRecorder
  - It is only a rolling mean recorder, and it is meant for nodes.
  - This is a better overall description.
- Added a MeanFlowNodeRecorder that is a simple mean of flow through an
  entire model run.
  - This doesn't give instantaneous mean flow part way through a run
    however.
- Added both to the docs.