### PR TITLE
Update Appveyor Miniconda version for 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,17 +30,20 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Update conda
+    - cmd: conda update --yes --quiet conda
+
     # Add our channels
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
 
-    # Update conda
-    # TODO Downgrading from 4.4 to 4.3 is broken. Disable this update.
-    #- cmd: conda update --yes --quiet conda
 
     # Configure the VM.
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
+    - cmd: run_conda_forge_build_setup
+
     - cmd: conda install -n root --quiet --yes obvious-ci
-    - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    - cmd: conda install -n root --quiet --yes anaconda-client jinja2 setuptools
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,13 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    # Update conda
-    - cmd: conda update --yes --quiet conda
-    
     # Add our channels
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --add channels defaults
+
+    # Update conda
+    - cmd: conda update --yes --quiet conda
 
     # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   matrix:
     - TARGET_ARCH: x64
       CONDA_PY: 27
@@ -41,9 +36,6 @@ install:
     # Configure the VM.
     - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
-
-    - cmd: conda install -n root --quiet --yes obvious-ci
-    - cmd: conda install -n root --quiet --yes anaconda-client jinja2 setuptools
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,12 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Update conda
+    - cmd: conda update --yes --quiet conda
+    
     # Add our channels
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
-
-    # Update conda
-    - cmd: conda update --yes --quiet conda
 
     # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,10 @@ install:
     # Add our channels
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
-    - cmd: conda config --add channels defaults
 
     # Update conda
-    - cmd: conda update --yes --quiet conda
+    # TODO Downgrading from 4.4 to 4.3 is broken. Disable this update.
+    #- cmd: conda update --yes --quiet conda
 
     # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - numpy 1.8.*  # [not (win and (py35 or py36))]
     - numpy 1.9.*  # [win and py35]
     - numpy 1.11.*  # [win and py36]
-    - cython
+    - cython <0.28
     - glpk
     - lp_solve
     - future


### PR DESCRIPTION
The current location (`C:\\Miniconda35-x64`) was out of date and an old version.

I fully expect this to fail in the same way the 2.7 ones fail in #603.