### PR TITLE
Revert "Request Cython<0.28 until upstream bug resolved."

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - numpy 1.8.*  # [not (win and (py35 or py36))]
     - numpy 1.9.*  # [win and py35]
     - numpy 1.11.*  # [win and py36]
-    - cython <0.28
+    - cython
     - glpk
     - lp_solve
     - future


### PR DESCRIPTION
This reverts commit e6e8fc6ca1d8084eb7d51cf9abed1dc0bc4d0a55.

Fixes #607 