### PR TITLE
Allow specifying solver name via PYWR_SOLVER environment variable.

### DIFF
--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,5 +1,7 @@
-py.test -v %SRC_DIR%\tests --solver=glpk
-py.test -v %SRC_DIR%\tests --solver=lpsolve
+set PYWR_SOLVER=glpk
+py.test -v %SRC_DIR%\tests
+set PYWR_SOLVER=lpsolve
+py.test -v %SRC_DIR%\tests
 
 if errorlevel 1 exit 1
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -1,5 +1,5 @@
-py.test -v ${SRC_DIR}/tests --solver=glpk
-py.test -v ${SRC_DIR}/tests --solver=lpsolve
+PYWR_SOLVER=glpk py.test -v ${SRC_DIR}/tests
+PYWR_SOLVER=lpsolve py.test -v ${SRC_DIR}/tests
 
 if [ "${PY3K}" == "1" ]; then
     PY_VER=3

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -81,6 +81,11 @@ class Model(object):
         # Import this here once everything else is defined.
         # This avoids circular references in the solver classes
         from pywr.solvers import solver_registry
+
+        if solver_name is None:
+            # See if there is a environment variable defining the solver
+            solver_name = os.environ.get('PYWR_SOLVER', None)
+
         if solver_name is not None:
             # use specific solver
             solver = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,9 @@
+import os
+from pywr.model import Model
 
-import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--solver", action="store", default="glpk",
-        help="Solver to run the tests against.")
-
-@pytest.fixture
-def solver(request):
-    return request.config.getoption("--solver")
 
 def pytest_report_header(config):
     headers = []
-    solver_name = config.getoption("--solver")
+    solver_name = Model().solver.name
     headers.append('solver: {}'.format(solver_name))
     return '\n'.join(headers)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,19 +9,19 @@ import datetime
 import pytest
 
 @pytest.fixture()
-def model(request, solver):
-    model = Model(solver=solver)
+def model(request):
+    model = Model()
     return model
 
 @pytest.fixture()
-def simple_linear_model(request, solver):
+def simple_linear_model(request):
     """
     Make a simple model with a single Input and Output.
 
     Input -> Link -> Output
 
     """
-    model = Model(solver=solver)
+    model = Model()
     inpt = Input(model, name="Input")
     lnk = Link(model, name="Link", cost=1.0)
     inpt.connect(lnk)
@@ -31,7 +31,7 @@ def simple_linear_model(request, solver):
     return model
 
 @pytest.fixture()
-def simple_storage_model(request, solver):
+def simple_storage_model(request):
     """
     Make a simple model with a single Input, Storage and Output.
     
@@ -42,7 +42,6 @@ def simple_storage_model(request, solver):
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-05'),
         timestep=datetime.timedelta(1),
-        solver=solver
     )
 
     inpt = Input(model, name="Input", max_flow=5.0, cost=-1)
@@ -56,7 +55,7 @@ def simple_storage_model(request, solver):
 
 
 @pytest.fixture()
-def three_storage_model(request, solver):
+def three_storage_model(request):
     """
     Make a simple model with three input, storage and output nodes. Also adds
     an `AggregatedStorage` and `AggregatedNode`.
@@ -72,7 +71,6 @@ def three_storage_model(request, solver):
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-05'),
         timestep=datetime.timedelta(1),
-        solver=solver
     )
 
     all_res = []

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -9,8 +9,8 @@ from pandas import Timestamp
 from helpers import load_model
 
 @pytest.fixture
-def model(solver):
-    model = Model(solver=solver)
+def model():
+    model = Model()
     model.timestepper.start = Timestamp("2016-01-01")
     model.timestepper.end = Timestamp("2016-01-02")
     return model
@@ -132,7 +132,7 @@ def test_aggregated_node_max_flow_with_weights(model, flow_weights, expected_agg
     assert_allclose(B.flow, expected_B_flow)
 
 
-@pytest.mark.skipif(pytest.config.getoption("--solver") != "glpk", reason="only valid for glpk")
+@pytest.mark.skipif(Model().solver.name == "lpsolve", reason="Not supported in lpsolve.")
 def test_aggregated_node_max_flow_parameter(model):
     """Nodes constrained by the max_flow of their AggregatedNode using a Parameter """
     A = Input(model, "A", max_flow=20.0, cost=1)
@@ -171,7 +171,7 @@ def test_aggregated_node_min_flow(model):
     assert_allclose(B.flow, 0.0)
 
 
-@pytest.mark.skipif(pytest.config.getoption("--solver") != "glpk", reason="only valid for glpk")
+@pytest.mark.skipif(Model().solver.name == "lpsolve", reason="Not supported in lpsolve.")
 def test_aggregated_node_min_flow_parameter(model):
     """Nodes constrained by the min_flow of their AggregatedNode"""
     A = Input(model, "A", max_flow=20.0, cost=1)
@@ -209,8 +209,8 @@ def test_aggregated_node_max_flow_same_route(model):
     assert_allclose(agg.flow, 30.0)
     assert_allclose(A.flow + B.flow, 30.0)
 
-def test_aggregated_constraint_json(solver):
-    model = load_model("aggregated1.json", solver=solver)
+def test_aggregated_constraint_json():
+    model = load_model("aggregated1.json")
 
     agg = model.nodes["agg"]
     assert(agg.nodes == [model.nodes["A"], model.nodes["B"]])

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -43,7 +43,7 @@ def test_linear_model(simple_linear_model, in_flow, out_flow, benefit):
     (10.0, 5.0, 5.0, 0.0, 10.0, 2.0),
     (10.0, 5.0, 0.0, 5.0, 10.0, 2.0),
     ])
-def linear_model_with_storage(request, solver):
+def linear_model_with_storage(request):
     """
     Make a simple model with a single Input and Output and an offline Storage Node
 
@@ -56,7 +56,7 @@ def linear_model_with_storage(request, solver):
     max_strg_out = 10.0
     max_volume = 10.0
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     inpt = pywr.core.Input(model, name="Input", min_flow=in_flow, max_flow=in_flow)
     lnk = pywr.core.Link(model, name="Link", cost=0.1)
     inpt.connect(lnk)
@@ -86,7 +86,7 @@ def test_linear_model_with_storage(linear_model_with_storage):
     assert_model(*linear_model_with_storage)
 
 @pytest.fixture
-def two_domain_linear_model(request, solver):
+def two_domain_linear_model(request):
     """
     Make a simple model with two domains, each with a single Input and Output
 
@@ -104,7 +104,7 @@ def two_domain_linear_model(request, solver):
     river_domain = pywr.core.Domain('river')
     grid_domain = pywr.core.Domain('grid')
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     # Create river network
     river_inpt = pywr.core.Input(model, name="Catchment", max_flow=river_flow, domain=river_domain)
     river_lnk = pywr.core.Link(model, name="Reach", domain=river_domain)
@@ -142,7 +142,7 @@ def test_two_domain_linear_model(two_domain_linear_model):
 
 
 @pytest.fixture
-def two_cross_domain_output_single_input(request, solver):
+def two_cross_domain_output_single_input(request):
     """
     Make a simple model with two domains. Thre are two Output nodes
     both connect to an Input node in a different domain.
@@ -160,7 +160,7 @@ def two_cross_domain_output_single_input(request, solver):
     river_flow = 10.0
     expected_node_results = {}
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     # Create grid network
     grid_inpt = pywr.core.Input(model, name="Input", domain='grid',)
     grid_lnk = pywr.core.Link(model, name="Link", cost=1.0, domain='grid')
@@ -201,14 +201,14 @@ def test_two_cross_domain_output_single_input(two_cross_domain_output_single_inp
 
 
 @pytest.fixture()
-def simple_linear_inline_model(request, solver):
+def simple_linear_inline_model(request):
     """
     Make a simple model with a single Input and Output nodes inline of a route.
 
     Input 0 -> Input 1 -> Link -> Output 0 -> Output 1
 
     """
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     inpt0 = pywr.core.Input(model, name="Input 0")
     inpt1 = pywr.core.Input(model, name="Input 1")
     inpt0.connect(inpt1)
@@ -251,7 +251,7 @@ def test_simple_linear_inline_model(simple_linear_inline_model, in_flow_1, out_f
 
 
 @pytest.fixture()
-def bidirectional_model(request, solver):
+def bidirectional_model(request):
     """
     Make a simple model with a single Input and Output.
 
@@ -261,7 +261,7 @@ def bidirectional_model(request, solver):
     Input 1 -> Link 1 -> Output 1
 
     """
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     for i in range(2):
         inpt = pywr.core.Input(model, name="Input {}".format(i))
         lnk = pywr.core.Link(model, name="Link {}".format(i))
@@ -301,8 +301,7 @@ def test_bidirectional_model(bidirectional_model):
     assert_model(model, expected_node_results)
 
 
-def make_simple_model(supply_amplitude, demand, frequency,
-                      initial_volume, solver):
+def make_simple_model(supply_amplitude, demand, frequency, initial_volume):
     """
     Make a simlpe model,
         supply -> reservoir -> demand.
@@ -312,7 +311,7 @@ def make_simple_model(supply_amplitude, demand, frequency,
 
     """
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
 
     S = supply_amplitude
     w = frequency
@@ -337,7 +336,7 @@ def make_simple_model(supply_amplitude, demand, frequency,
 
     return model
 
-def pytest_run_analytical(solver):
+def pytest_run_analytical():
     """
     Run the test model though a year with analytical solution values to
     ensure reservoir just contains sufficient volume.
@@ -348,7 +347,7 @@ def pytest_run_analytical(solver):
     w = 2*np.pi/365 # frequency (annual)
     V0 = S/w  # initial reservoir level
 
-    model = make_simple_model(S, D, w, V0, solver)
+    model = make_simple_model(S, D, w, V0)
 
     model.timestamp = datetime.datetime(2015, 1, 1)
 

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -314,10 +314,10 @@ def test_control_curve_interpolated(model):
             model.run()
 
 
-def test_control_curve_interpolated_json(solver):
+def test_control_curve_interpolated_json():
     # this is a little hack-y, as the parameters don't provide access to their
     # data once they've been initalised
-    model = load_model("reservoir_with_cc.json", solver=solver)
+    model = load_model("reservoir_with_cc.json")
     reservoir1 = model.nodes["reservoir1"]
     model.setup()
     path = os.path.join(os.path.dirname(__file__), "models", "control_curve.csv")
@@ -335,10 +335,10 @@ def test_control_curve_interpolated_json(solver):
 
 @pytest.mark.xfail(reason="Circular dependency in the JSON definition. "
                           "See GitHub issue #380: https://github.com/pywr/pywr/issues/380")
-def test_circular_control_curve_interpolated_json(solver):
+def test_circular_control_curve_interpolated_json():
     # this is a little hack-y, as the parameters don't provide access to their
     # data once they've been initalised
-    model = load_model("reservoir_with_circular_cc.json", solver=solver)
+    model = load_model("reservoir_with_circular_cc.json")
     reservoir1 = model.nodes["reservoir1"]
     model.setup()
     path = os.path.join(os.path.dirname(__file__), "models", "control_curve.csv")
@@ -450,9 +450,9 @@ class TestMonthlyProfileControlCurveParameter:
         model.setup()
         self._assert_results(model, s, p, scale=1.5)
 
-    def test_json_load(self, solver):
+    def test_json_load(self):
 
-        model = load_model("demand_saving.json", solver=solver)
+        model = load_model("demand_saving.json")
 
         storage = model.nodes["supply1"]
         demand = model.nodes["demand1"]
@@ -516,7 +516,7 @@ def test_daily_profile_control_curve(simple_linear_model):
         model.run()
 
 
-def test_demand_saving_with_indexed_array(solver):
+def test_demand_saving_with_indexed_array():
     """Test demand saving based on reservoir control curves
 
     This is a relatively complex test to pass due to the large number of
@@ -525,7 +525,7 @@ def test_demand_saving_with_indexed_array(solver):
     on the state of a reservoir.
     """
 
-    model = load_model("demand_saving2.json", solver=solver)
+    model = load_model("demand_saving2.json")
 
     model.timestepper.end = pd.Timestamp("2016-01-31")
 
@@ -554,9 +554,9 @@ def test_demand_saving_with_indexed_array(solver):
     assert_allclose(rec_demand.data[12, 0], demand_baseline * demand_factor * demand_saving)
 
 
-def test_demand_saving_with_indexed_array_from_hdf(solver):
+def test_demand_saving_with_indexed_array_from_hdf():
     """Test demand saving based on a predefined demand saving level in a HDF file."""
-    model = load_model("demand_saving_hdf.json", solver=solver)
+    model = load_model("demand_saving_hdf.json")
 
     model.timestepper.end = pd.Timestamp("2016-01-31")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,9 +15,9 @@ from pywr.recorders import assert_rec, AssertionRecorder
 
 TEST_FOLDER = os.path.dirname(__file__)
 
-def test_names(solver):
+def test_names():
     '''Test node names'''
-    model = Model(solver=solver)
+    model = Model()
 
     node1 = Input(model, name='A')
     node2 = Output(model, name='B')
@@ -66,8 +66,8 @@ def test_model_nodes(model):
     assert(all_nodes == [])
 
 
-def test_unexpected_kwarg_node(solver):
-    model = Model(solver=solver)
+def test_unexpected_kwarg_node():
+    model = Model()
 
     with pytest.raises(TypeError):
         node = Node(model, 'test_node', invalid=True)
@@ -80,15 +80,15 @@ def test_unexpected_kwarg_node(solver):
     assert(not model.nodes)
 
 
-def test_unexpected_kwarg_model(solver):
+def test_unexpected_kwarg_model():
     with pytest.raises(TypeError):
-        model = Model(solver=solver, thisisgoingtofail=True)
-    model = Model(solver=solver)
+        model = Model(thisisgoingtofail=True)
+    model = Model()
 
-def test_slots_connect_disconnect(solver):
+def test_slots_connect_disconnect():
     """Test connection and disconnection to storage node slots
     """
-    model = Model(solver=solver)
+    model = Model()
 
     supply1 = Input(model, name='supply1')
     supply2 = Input(model, name='supply2')
@@ -137,8 +137,8 @@ def test_slots_connect_disconnect(solver):
         supply1.disconnect(storage)
 
 
-def test_node_position(solver):
-    model = Model(solver=solver)
+def test_node_position():
+    model = Model()
 
     # node position, from kwargs
 
@@ -214,10 +214,10 @@ def test_timeseries_excel(simple_linear_model, filename):
 
     model.run()
 
-def test_dirty_model(solver):
+def test_dirty_model():
     """Test that the LP is updated when the model structure is redefined"""
     # start dirty
-    model = Model(solver=solver)
+    model = Model()
     assert(model.dirty)
 
     # add some nodes, still dirty
@@ -249,13 +249,12 @@ def test_dirty_model(solver):
     supply2.disconnect()
     assert(model.dirty)
 
-def test_reset_initial_volume(solver):
+def test_reset_initial_volume():
     """
     If the model doesn't reset correctly changing the initial volume and
     re-running will cause an exception.
     """
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -272,9 +271,9 @@ def test_reset_initial_volume(solver):
         model.run()
         assert(otpt.flow == initial_volume)
 
-def test_shorthand_property(solver):
+def test_shorthand_property():
     # test shorthand assignment of constant properties
-    model = Model(solver=solver)
+    model = Model()
     node = Node(model, 'node')
     for attr in ('min_flow', 'max_flow', 'cost', 'conversion_factor'):
         # should except int, float or Paramter
@@ -290,9 +289,9 @@ def test_shorthand_property(solver):
             setattr(node, attr, None)
 
 
-def test_shorthand_property_storage(solver):
+def test_shorthand_property_storage():
     # test shorthand assignment of constant properties
-    model = Model(solver=solver)
+    model = Model()
     node = Storage(model, 'node')
     for attr in ('min_volume', 'max_volume', 'cost', 'level'):
         # should except int, float or Paramter
@@ -308,10 +307,10 @@ def test_shorthand_property_storage(solver):
             setattr(node, attr, None)
 
 
-def test_reset_before_run(solver):
+def test_reset_before_run():
     # See issue #82. Previously this would raise:
     #    AttributeError: Memoryview is not initialized
-    model = Model(solver=solver)
+    model = Model()
     node = Node(model, 'node')
     model.reset()
 
@@ -327,13 +326,13 @@ def test_check_isolated_nodes(simple_linear_model):
     with pytest.raises(ModelStructureError):
         model.check()
 
-def test_check_isolated_nodes_storage(solver):
+def test_check_isolated_nodes_storage():
     """Test model structure checker with Storage
 
     The Storage node itself doesn't have any connections, but it's child
     nodes do need to be connected.
     """
-    model = Model(solver=solver)
+    model = Model()
 
     # add a storage, but don't connect it's outflow to anything
     storage = Storage(model, 'storage', num_inputs=1, num_outputs=0)
@@ -345,13 +344,12 @@ def test_check_isolated_nodes_storage(solver):
     storage.connect(demand, from_slot=0)
     model.check()
 
-def test_storage_max_volume_zero(solver):
+def test_storage_max_volume_zero():
     """Test a that an max_volume of zero results in a NaN for current_pc and no exception
 
     """
 
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -366,13 +364,12 @@ def test_storage_max_volume_zero(solver):
     assert np.isnan(storage.current_pc)
 
 
-def test_storage_max_volume_param(solver):
+def test_storage_max_volume_param():
     """Test a that an max_volume with a Parameter results in the correct current_pc
 
     """
 
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -395,11 +392,10 @@ def test_storage_max_volume_param(solver):
     np.testing.assert_allclose(storage.current_pc, 0.25)
 
 
-def test_storage_initial_volume_pc(solver):
+def test_storage_initial_volume_pc():
     """Test that setting initial volume as a percentage works as expected.
     """
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -424,14 +420,13 @@ def test_storage_initial_volume_pc(solver):
     np.testing.assert_allclose(storage.volume, 20.0)
 
 
-def test_storage_max_volume_param_raises(solver):
+def test_storage_max_volume_param_raises():
     """Test a that an max_volume with a Parameter that has children.
     
     Only some aggregated style parameters should work here.
     """
 
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -449,13 +444,12 @@ def test_storage_max_volume_param_raises(solver):
     np.testing.assert_allclose(storage.current_pc, 0.25)
 
 
-def test_storage_max_volume_param_raises(solver):
+def test_storage_max_volume_param_raises():
     """Test a that an max_volume with a Parameter that has children is an error
 
     """
 
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -483,7 +477,7 @@ def test_storage_initial_volume_table():
     np.testing.assert_allclose(model.nodes["supply2"].initial_volume, 35.0)
 
 
-def test_recursive_delete(solver):
+def test_recursive_delete():
     """Test recursive deletion of child nodes for compound nodes"""
     model = Model()
     n1 = Input(model, "n1")
@@ -499,7 +493,7 @@ def test_recursive_delete(solver):
     assert len(model.graph.nodes()) == 1
 
 
-def test_json_include(solver):
+def test_json_include():
     """Test include in JSON document"""
     filename = os.path.join(TEST_FOLDER, "models", "extra1.json")
     model = Model.load(filename)
@@ -508,16 +502,16 @@ def test_json_include(solver):
     supply2 = model.nodes["supply2"]
     assert(isinstance(supply2.max_flow, ConstantParameter))
 
-def test_json_min_version(solver):
+def test_json_min_version():
     """Test warning is raised if document minimum version is more than we have"""
     filename = os.path.join(TEST_FOLDER, "models", "version1.json")
     with pytest.warns(RuntimeWarning):
         model = Model.load(filename)
 
-def test_initial_timestep(solver):
+def test_initial_timestep():
     """Current timestep before model has started is undefined"""
     filename = os.path.join(TEST_FOLDER, "models", "extra1.json")
-    model = Model.load(filename, solver=solver)
+    model = Model.load(filename)
     assert(model.timestepper.current is None)
     model.run()
     assert(isinstance(model.timestepper.current, Timestep))
@@ -526,17 +520,17 @@ def test_timestepper_repr(model):
     timestepper = model.timestepper
     print(timestepper)
 
-def test_timestep_repr(solver):
+def test_timestep_repr():
     filename = os.path.join(TEST_FOLDER, "models", "simple1.json")
-    model = Model.load(filename, solver=solver)
+    model = Model.load(filename)
     model.timestepper.end = "2015-01-05"
     res = model.run()
     assert(isinstance(res.timestep, Timestep))
     assert("2015-01-05" in str(res.timestep))
 
-def test_virtual_storage_cost(solver):
+def test_virtual_storage_cost():
     """VirtualStorage doesn't (currently) implement its cost attribute"""
-    model = Model(solver=solver)
+    model = Model()
     A = Input(model, "A")
     B = Output(model, "B")
     A.connect(B)
@@ -546,25 +540,25 @@ def test_virtual_storage_cost(solver):
     with pytest.raises(NotImplementedError):
         model.check()
 
-def test_json_invalid(solver):
+def test_json_invalid():
     """JSON exceptions should report file name"""
     filename = os.path.join(TEST_FOLDER, "models", "invalid"+".json")
     with pytest.raises(ValueError) as excinfo:
-        model = Model.load(filename, solver=solver)
+        model = Model.load(filename)
     assert("invalid.json" in str(excinfo.value))
 
-def test_json_invalid_include(solver):
+def test_json_invalid_include():
     """JSON exceptions should report file name, even for includes"""
     filename = os.path.join(TEST_FOLDER, "models", "invalid_include"+".json")
     with pytest.raises(ValueError) as excinfo:
-        model = Model.load(filename, solver=solver)
+        model = Model.load(filename)
     assert("invalid.json" in str(excinfo.value))
 
 
-def test_variable_load(solver):
+def test_variable_load():
     """Current timestep before model has started is undefined"""
     filename = os.path.join(TEST_FOLDER, "models", "demand_saving2_with_variables.json")
-    model = Model.load(filename, solver=solver)
+    model = Model.load(filename)
 
     # Test the correct number of each component is loaded
     assert len(model.variables) == 3

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -17,9 +17,8 @@ storativity = [0.05] # %
 levels = [0.0, 1000.0] # m
 area = 50000 * 50000 # m2
 
-def test_keating_aquifer(solver):
+def test_keating_aquifer():
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01'),
     )

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -65,7 +65,7 @@ def test_simple_model_with_annual_licence(simple_linear_model):
     remaining -= remaining / (365 - 2)
     assert_allclose(lic.value(m.timestepper._next, si), remaining / (365 - 3))
 
-def test_annual_license_json(solver):
+def test_annual_license_json():
     """
     This test demonstrates how an annual licence can be forceably distributed
     evenly across a year. The licence must build up a surplus before it can

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -28,8 +28,8 @@ from numpy.testing import assert_allclose
 TEST_DIR = os.path.dirname(__file__)
 
 @pytest.fixture
-def model(solver):
-    return Model(solver=solver)
+def model():
+    return Model()
 
 
 class TestConstantParameter:
@@ -245,8 +245,8 @@ class TestScenarioMonthlyProfileParameter:
                 si = ScenarioIndex(i, np.array([i], dtype=np.int32))
                 np.testing.assert_allclose(p.value(ts, si), values[i, imth])
 
-    def test_json(self, solver):
-        model = load_model('scenario_monthly_profile.json', solver=solver)
+    def test_json(self):
+        model = load_model('scenario_monthly_profile.json')
 
         # check first day initalised
         assert (model.timestepper.start == datetime.datetime(2015, 1, 1))
@@ -649,7 +649,7 @@ def test_parameter_df_json_load(model, tmpdir):
     p = load_parameter(model, data)
     p.setup()
 
-def test_simple_json_parameter_reference(solver):
+def test_simple_json_parameter_reference():
     # note that parameters in the "parameters" section cannot be literals
     model = load_model("parameter_reference.json")
     max_flow = model.nodes["supply1"].max_flow
@@ -707,11 +707,11 @@ def test_threshold_parameter(simple_linear_model):
     model.run()
 
 
-def test_constant_from_df(solver):
+def test_constant_from_df():
     """
     Test that a dataframe can be used to provide data to ConstantParameter (single values).
     """
-    model = load_model('simple_df.json', solver=solver)
+    model = load_model('simple_df.json')
 
     assert isinstance(model.nodes['demand1'].max_flow, ConstantParameter)
     assert isinstance(model.nodes['demand1'].cost, ConstantParameter)
@@ -723,11 +723,11 @@ def test_constant_from_df(solver):
     np.testing.assert_allclose(model.nodes['demand1'].cost.value(ts, si), -10.0)
 
 
-def test_constant_from_shared_df(solver):
+def test_constant_from_shared_df():
     """
     Test that a shared dataframe can be used to provide data to ConstantParameter (single values).
     """
-    model = load_model('simple_df_shared.json', solver=solver)
+    model = load_model('simple_df_shared.json')
 
     assert isinstance(model.nodes['demand1'].max_flow, ConstantParameter)
     assert isinstance(model.nodes['demand1'].cost, ConstantParameter)
@@ -739,11 +739,11 @@ def test_constant_from_shared_df(solver):
     np.testing.assert_allclose(model.nodes['demand1'].cost.value(ts, si), -10.0)
 
 
-def test_constant_from_multiindex_df(solver):
+def test_constant_from_multiindex_df():
     """
     Test that a dataframe can be used to provide data to ConstantParameter (single values).
     """
-    model = load_model('multiindex_df.json', solver=solver)
+    model = load_model('multiindex_df.json')
 
 
     assert isinstance(model.nodes['demand1'].max_flow, ConstantParameter)
@@ -1172,14 +1172,14 @@ def test_orphaned_components(simple_linear_model):
     with pytest.warns(OrphanedParameterWarning):
         model.check()
 
-def test_deficit_parameter(solver):
+def test_deficit_parameter():
     """Test DeficitParameter
 
     Here we test both uses of the DeficitParameter:
       1) Recording the deficit for a node each timestep
       2) Using yesterday's deficit to control today's flow
     """
-    model = load_model("deficit.json", solver=solver)
+    model = load_model("deficit.json")
 
     model.run()
 

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -9,7 +9,7 @@ import pytest
 from helpers import assert_model, load_model
 
 @pytest.fixture(params=[(10.0, 10.0, 10.0), (5.0, 5.0, 1.0)])
-def simple_piecewise_model(request, solver):
+def simple_piecewise_model(request):
     """
     Make a simple model with a single Input and Output and PiecewiseLink
 
@@ -19,7 +19,7 @@ def simple_piecewise_model(request, solver):
     in_flow, out_flow, benefit = request.param
     min_flow_req = 5.0
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     inpt = pywr.core.Input(model, name="Input", max_flow=in_flow)
     lnk = pywr.core.PiecewiseLink(model, name="Link", cost=[-1.0, 0.0], max_flow=[min_flow_req, None])
 
@@ -45,9 +45,9 @@ def simple_piecewise_model(request, solver):
 def test_piecewise_model(simple_piecewise_model):
     assert_model(*simple_piecewise_model)
 
-def test_piecewise_json(solver):
+def test_piecewise_json():
     """Test loading of a piecewise link from JSON"""
-    model = load_model("piecewise1.json", solver=solver)
+    model = load_model("piecewise1.json")
     sublinks = model.nodes["link1"].sublinks
     max_flows = [sublink.max_flow for sublink in sublinks]
     costs = [sublink.cost for sublink in sublinks]

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -294,8 +294,8 @@ def test_numpy_index_parameter_recorder(simple_storage_model):
     assert_allclose(df.values, np.array([[0, 0, 1, 2, 2]]).T, atol=1e-7)
 
 
-def test_parameter_recorder_json(solver):
-    model = load_model("parameter_recorder.json", solver=solver)
+def test_parameter_recorder_json():
+    model = load_model("parameter_recorder.json")
     rec_demand = model.recorders["demand_max_recorder"]
     rec_supply = model.recorders["supply_max_recorder"]
     model.run()
@@ -437,7 +437,7 @@ def test_csv_recorder(simple_linear_model, tmpdir, complib):
     fh.close()
 
 
-def test_loading_csv_recorder_from_json(solver, tmpdir):
+def test_loading_csv_recorder_from_json(tmpdir):
     """
     Test the CSV Recorder which is loaded from json
     """
@@ -455,7 +455,7 @@ def test_loading_csv_recorder_from_json(solver, tmpdir):
     url = data['recorders']['model_out']['url']
     data['recorders']['model_out']['url'] = str(tmpdir.join(url))
 
-    model = Model.load(data, path=path, solver=solver)
+    model = Model.load(data, path=path)
 
     csvfile = tmpdir.join('output.csv')
     model.run()
@@ -705,11 +705,11 @@ class TestTablesRecorder:
                 else:
                     np.testing.assert_allclose(ca, 10.0)
 
-    def test_demand_saving_with_indexed_array(self, solver, tmpdir):
+    def test_demand_saving_with_indexed_array(self, tmpdir):
         """Test recording various items from demand saving example
 
         """
-        model = load_model("demand_saving2.json", solver=solver)
+        model = load_model("demand_saving2.json")
 
         model.timestepper.end = "2016-01-31"
 
@@ -752,7 +752,7 @@ class TestTablesRecorder:
             assert (rec_storage[11, 0] < (0.5 * max_volume))
             assert_allclose(rec_demand[12, 0], demand_baseline * demand_factor * demand_saving)
 
-    def test_demand_saving_with_indexed_array(self, solver, tmpdir):
+    def test_demand_saving_with_indexed_array(self, tmpdir):
         """Test recording various items from demand saving example.
 
         This time the TablesRecorder is defined in JSON.
@@ -769,7 +769,7 @@ class TestTablesRecorder:
         url = data['recorders']['database']['url']
         data['recorders']['database']['url'] = str(tmpdir.join(url))
 
-        model = Model.load(data, path=path, solver=solver)
+        model = Model.load(data, path=path)
 
         model.timestepper.end = "2016-01-31"
         model.check()
@@ -1033,9 +1033,8 @@ class TestAggregatedRecorder:
         assert_allclose(func([20.0, 40.0]), rec.aggregated_value(), atol=1e-7)
 
 
-def test_reset_timestepper_recorder(solver):
+def test_reset_timestepper_recorder():
     model = Model(
-        solver=solver,
         start=pandas.to_datetime('2016-01-01'),
         end=pandas.to_datetime('2016-01-01')
     )
@@ -1052,8 +1051,8 @@ def test_reset_timestepper_recorder(solver):
 
     model.run()
 
-def test_mean_flow_recorder(solver):
-    model = Model(solver=solver)
+def test_mean_flow_recorder():
+    model = Model()
     model.timestepper.start = pandas.to_datetime("2016-01-01")
     model.timestepper.end = pandas.to_datetime("2016-01-04")
 
@@ -1079,8 +1078,8 @@ def test_mean_flow_recorder(solver):
     for value, expected_value in zip(rec_mean.data[:, 0], expected):
         assert_allclose(value, expected_value)
 
-def test_mean_flow_recorder_days(solver):
-    model = Model(solver=solver)
+def test_mean_flow_recorder_days():
+    model = Model()
     model.timestepper.delta = 7
 
     inpt = Input(model, "input")
@@ -1092,8 +1091,8 @@ def test_mean_flow_recorder_days(solver):
     model.run()
     assert(rec_mean.timesteps == 4)
 
-def test_mean_flow_recorder_json(solver):
-    model = load_model("mean_flow_recorder.json", solver=solver)
+def test_mean_flow_recorder_json():
+    model = load_model("mean_flow_recorder.json")
 
     # TODO: it's not possible to define a FunctionParameter in JSON yet
     supply1 = model.nodes["supply1"]
@@ -1148,8 +1147,8 @@ def test_annual_count_index_parameter_recorder(simple_storage_model):
 #  to compare with the model prediction.
 
 @pytest.fixture
-def timeseries2_model(solver):
-    return load_model('timeseries2.json', solver=solver)
+def timeseries2_model():
+    return load_model('timeseries2.json')
 
 
 @pytest.fixture

--- a/tests/test_river.py
+++ b/tests/test_river.py
@@ -15,7 +15,7 @@ import pytest
 from helpers import assert_model, load_model
 
 @pytest.fixture(params=[(10.0, 10.0, 10.0), (5.0, 5.0, 1.0)])
-def simple_gauge_model(request, solver):
+def simple_gauge_model(request):
     """
     Make a simple model with a single Input and Output and RiverGauge
 
@@ -25,7 +25,7 @@ def simple_gauge_model(request, solver):
     in_flow, out_flow, benefit = request.param
     min_flow_req = 5.0
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     inpt = river.Catchment(model, name="Catchment", flow=in_flow)
     lnk = river.RiverGauge(model, name="Gauge", mrf=min_flow_req, mrf_cost=-1.0)
     inpt.connect(lnk)
@@ -47,7 +47,7 @@ def simple_gauge_model(request, solver):
 
 
 @pytest.fixture
-def simple_river_split_gauge_model(solver):
+def simple_river_split_gauge_model():
     """
     Make a simple model with a single Input and Output and RiverGauge
 
@@ -58,7 +58,7 @@ def simple_river_split_gauge_model(solver):
     in_flow = 100.0
     min_flow_req = 40.0
     out_flow = 50.0
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
 
     inpt = river.Catchment(model, name="Catchment", flow=in_flow)
     lnk = river.RiverSplitWithGauge(model, name="Gauge", mrf=min_flow_req, mrf_cost=-100,
@@ -81,11 +81,11 @@ def simple_river_split_gauge_model(solver):
     return model, expected_node_results
 
 
-def test_river_gauge(solver):
+def test_river_gauge():
     """
     Test loading a model with a RiverGauge from JSON, modifying it, then running it
     """
-    model = load_model("river_mrf1.json", solver=solver)
+    model = load_model("river_mrf1.json")
 
     node = model.nodes["mrf"]
     demand = model.nodes["demand"]
@@ -114,10 +114,10 @@ def test_piecewise_model(simple_gauge_model):
 def test_river_split_gauge(simple_river_split_gauge_model):
     assert_model(*simple_river_split_gauge_model)
 
-def test_river_split_gauge_json(solver):
+def test_river_split_gauge_json():
     """As test_river_split_gauge, but model is defined in JSON"""
 
-    model = load_model("river_split_with_gauge1.json", solver=solver)
+    model = load_model("river_split_with_gauge1.json")
     model.check()
     model.run()
 
@@ -131,7 +131,7 @@ def test_river_split_gauge_json(solver):
     assert_allclose(demand_node.flow, expected_demand_flow)
 
 
-def test_control_curve(solver):
+def test_control_curve():
     """
     Use a simple model of a Reservoir to test that a control curve
     behaves as expected.
@@ -148,7 +148,7 @@ def test_control_curve(solver):
     """
     in_flow = 8
 
-    model = pywr.core.Model(solver=solver)
+    model = pywr.core.Model()
     catchment = river.Catchment(model, name="Catchment", flow=in_flow)
     lnk = river.River(model, name="River")
     catchment.connect(lnk)
@@ -191,9 +191,9 @@ def test_control_curve(solver):
     assert(reservoir.volume == 10)
     assert(demand.flow == 6)
 
-def test_catchment_many_successors(solver):
+def test_catchment_many_successors():
     """Test if node with fixed flow can have multiple successors. See #225"""
-    model = Model(solver=solver)
+    model = Model()
     catchment = Catchment(model, "catchment", flow=100)
     out1 = Output(model, "out1", max_flow=10, cost=-100)
     out2 = Output(model, "out2", max_flow=15, cost=-50)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -15,10 +15,10 @@ from numpy.testing import assert_equal, assert_allclose
 import pytest
 
 
-def test_scenario_collection(solver):
+def test_scenario_collection():
     """ Basic test of Scenario and ScenarioCollection API """
 
-    model = Model(solver=solver)
+    model = Model()
 
     # There is 1 combination when there are no Scenarios
     model.scenarios.setup()
@@ -124,14 +124,14 @@ def test_scenario_two_parameter(simple_linear_model, ):
     assert_model(model, expected_node_results)
 
 
-def test_scenario_storage(solver):
+def test_scenario_storage():
     """Test the behaviour of Storage nodes with multiple scenarios
 
     The model defined has two inflow scenarios: 5 and 10. It is expected that
     the volume in the storage node should increase at different rates in the
     two scenarios.
     """
-    model = Model(solver=solver)
+    model = Model()
 
     i = Input(model, 'input', max_flow=999)
     s = Storage(model, 'storage', num_inputs=1, num_outputs=1, max_volume=1000, initial_volume=500)
@@ -152,7 +152,7 @@ def test_scenario_storage(solver):
     assert_allclose(s_rec.data[1], [510, 520])
 
 
-def test_scenarios_from_json(solver):
+def test_scenarios_from_json():
     """
     Test a simple model with two scenarios.
 
@@ -163,7 +163,7 @@ def test_scenarios_from_json(solver):
     the `MultiIndex` on the `DataFrame` from the recorder.
     """
 
-    model = load_model('simple_with_scenario.json', solver=solver)
+    model = load_model('simple_with_scenario.json')
     assert len(model.scenarios) == 2
 
     model.setup()
@@ -186,9 +186,9 @@ def test_scenarios_from_json(solver):
     assert_allclose(d2, [10, 11, 12, 13, 14]+[15]*5)
 
 
-def test_timeseries_with_scenarios(solver):
+def test_timeseries_with_scenarios():
 
-    model = load_model('timeseries2.json', solver=solver)
+    model = load_model('timeseries2.json')
 
     model.setup()
 
@@ -208,9 +208,9 @@ def test_timeseries_with_scenarios(solver):
     model.finish()
 
 
-def test_timeseries_with_scenarios_hdf(solver):
+def test_timeseries_with_scenarios_hdf():
     # this test uses TablesArrayParameter
-    model = load_model('timeseries2_hdf.json', solver=solver)
+    model = load_model('timeseries2_hdf.json')
 
     model.setup()
 
@@ -231,13 +231,13 @@ def test_timeseries_with_scenarios_hdf(solver):
     model.finish()
 
 
-def test_timeseries_with_wrong_hash(solver):
+def test_timeseries_with_wrong_hash():
     with pytest.raises(HashMismatchError):
-        load_model('timeseries2_hdf_wrong_hash.json', solver=solver)
+        load_model('timeseries2_hdf_wrong_hash.json')
 
 
-def test_tablesarrayparameter_scenario_slice(solver):
-    model = load_model('timeseries2_hdf.json', solver=solver)
+def test_tablesarrayparameter_scenario_slice():
+    model = load_model('timeseries2_hdf.json')
     catchment1 = model.nodes['catchment1']
     scenario = model.scenarios["scenario A"]
     scenario.slice = slice(0, 10, 2)
@@ -251,9 +251,9 @@ def test_tablesarrayparameter_scenario_slice(solver):
     assert_allclose(catchment1.flow, step2[::2], atol=1e-1)
     model.finish()
 
-def test_tablesarrayparameter_scenario_user_combinations(solver):
+def test_tablesarrayparameter_scenario_user_combinations():
     """Test TablesArrayParameter with user defined combination of scenarios"""
-    model = load_model('timeseries2_hdf.json', solver=solver)
+    model = load_model('timeseries2_hdf.json')
     catchment1 = model.nodes['catchment1']
     scenario = model.scenarios["scenario A"]
     scenario2 = Scenario(model, "scenario B", size=2)
@@ -270,10 +270,10 @@ def test_tablesarrayparameter_scenario_user_combinations(solver):
     assert_allclose(catchment1.flow, step2[[0, 2, 6, 2]], atol=1e-1)
     model.finish()
 
-def test_tables_array_index_error(solver):
+def test_tables_array_index_error():
     # check an exception is raised (before the model starts) if the length
     # of the data passed to a TablesArrayParameter is not long enough
-    model = load_model('timeseries2_hdf.json', solver=solver)
+    model = load_model('timeseries2_hdf.json')
     model.timestepper.start = "1920-01-01"
     model.timestepper.end = "1980-01-01"
     with pytest.raises(IndexError):
@@ -362,8 +362,8 @@ def test_scenario_user_combinations(simple_linear_model):
     with pytest.raises(ValueError):
         model.scenarios.user_combinations = [[-1, 2], [2, 2]]
 
-def test_scenario_slices_json(solver):
-    model = load_model('scenario_with_slices.json', solver=solver)
+def test_scenario_slices_json():
+    model = load_model('scenario_with_slices.json')
     scenarios = model.scenarios
     assert(len(scenarios) == 2)
     assert(scenarios["scenario A"].slice == slice(0, None, 2))
@@ -371,8 +371,8 @@ def test_scenario_slices_json(solver):
     combinations = model.scenarios.get_combinations()
     assert(len(combinations) == 5)
 
-def test_scenario_slices_json(solver):
-    model = load_model('scenario_with_user_combinations.json', solver=solver)
+def test_scenario_slices_json():
+    model = load_model('scenario_with_user_combinations.json')
     scenarios = model.scenarios
     assert(len(scenarios) == 2)
     combinations = model.scenarios.get_combinations()


### PR DESCRIPTION
- Env variable is used if solver is not given directly.
- If neither given it retains the current default behaviour.
- Removed the "--solver" argument from pytest and the solver fixture.
- Modified all the tests that depended on this fixture.
- Modified the conda recipe to specify solver by environment variable.

Fixes #618.