### PR TITLE
Fix a bug in the AnnualHarmonicSeriesParameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All issue numbers are relative to https://github.com/pywr/pywr/issues unless oth
 - Added additional labeling functionality to notebook graphing functions. (#612)
 - New and improved variable API for Parameters. (#601, #258)
 
+### Bug fixes
+
+- Fix a bug in `AnnualHarmonicSeriesParameter` related to updating the `amplitude` and `phase` values with `set_double_variables` (#622)
+
 ## v0.5.1
 
 ### Miscellaneous

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -892,8 +892,8 @@ cdef class AnnualHarmonicSeriesParameter(Parameter):
     cpdef set_double_variables(self, double[:] values):
         n = len(self.amplitudes)
         self.mean = values[0]
-        self.amplitudes[...] = values[1:n+1]
-        self.phases[...] = values[n+1:]
+        self._amplitudes[...] = values[1:n+1]
+        self._phases[...] = values[n+1:]
 
     cpdef double[:] get_double_variables(self):
         return np.r_[np.array([self.mean, ]), np.array(self.amplitudes), np.array(self.phases)]

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -862,11 +862,11 @@ cdef class AnnualHarmonicSeriesParameter(Parameter):
 
     property amplitudes:
         def __get__(self):
-            return np.array(self._amplitudes)
+            return np.asarray(self._amplitudes)
 
     property phases:
         def __get__(self):
-            return np.array(self._phases)
+            return np.asarray(self._phases)
 
     cpdef reset(self):
         Parameter.reset(self)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -371,7 +371,7 @@ class TestAnnualHarmonicSeriesParameter:
         np.testing.assert_allclose(p1.get_double_variables(), new_var)
 
         with pytest.raises(NotImplementedError):
-            p1.set_integer_variables(new_var)
+            p1.set_integer_variables(np.arange(3, dtype=np.int32))
 
         with pytest.raises(NotImplementedError):
             p1.get_integer_variables()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -359,6 +359,29 @@ class TestAnnualHarmonicSeriesParameter:
             doy = (ts.datetime.dayofyear - 1) / 365
             np.testing.assert_allclose(p1.value(ts, si), 0.5 + 0.25 * np.cos(doy * 2 * np.pi + np.pi / 4))
 
+    def test_variable(self, model):
+        """ Test that variable updating works. """
+        p1 = AnnualHarmonicSeriesParameter(model, 0.5, [0.25], [np.pi/4], is_variable=True)
+
+        assert p1.double_size == 3
+        assert p1.integer_size == 0
+
+        new_var = np.array([0.6, 0.1, np.pi/2])
+        p1.set_double_variables(new_var)
+        np.testing.assert_allclose(p1.get_double_variables(), new_var)
+
+        with pytest.raises(NotImplementedError):
+            p1.set_integer_variables(new_var)
+
+        with pytest.raises(NotImplementedError):
+            p1.get_integer_variables()
+
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+
+        for ts in model.timestepper:
+            doy = (ts.datetime.dayofyear - 1)/365
+            np.testing.assert_allclose(p1.value(ts, si), 0.6 + 0.1*np.cos(doy*2*np.pi + np.pi/2))
+
 
 class TestAggregatedParameter:
     """Tests for AggregatedParameter"""


### PR DESCRIPTION
amplitude and phase were not updated correctly. This is pretty subtle, but I think to do with when numpy/cython does or does not make a copy of the underlying memoryview. Anyway I'm pretty sure it wasn't work right, but this makes it much more explicit in any case.