### PR TITLE
Drop CI support for Python 2.7 and 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ env:
 matrix:
     include:
       - os: linux
-        env: CONDA_PY=27
-      - os: linux
-        env: CONDA_PY=34
-      - os: linux
         env: CONDA_PY=36 BUILD_DOC=1
       - os: osx
         env: CONDA_PY=36

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Pywr is a tool for solving network resource allocation problems. It has many sim
 Installation
 ============
 
-Pywr should work on Python 2.7 (or later) and 3.4 (or later) on Windows, Linux or OS X.
+Pywr should work on Python 3.6 (or later) on Windows, Linux or OS X.
 
 See the documentation for `detailed installation instructions <https://pywr.github.io/pywr-docs/install.html>`__.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,6 @@ environment:
 
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x64
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,7 +1,7 @@
 Installing Pywr
 ===============
 
-Pywr should work on Python 2.7 (or later) and 3.4 (or later) on Windows, Linux or OS X.
+Pywr should work on Python 3.6 (or later) on Windows, Linux or OS X.
 
 Building Pywr from source requires a working C compiler. It has been built successfully with MSVC on Windows, GCC on Linux and clang/LLVM on OS X.
 


### PR DESCRIPTION
Good bye Python 2.7. You have served us well!

Updates README, docs and CI files.

Fixes #572.