### PR TITLE
Add new HydroPowerTargetParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All issue numbers are relative to https://github.com/pywr/pywr/issues unless oth
 
 ### New features
 
+- Added `HydropowerTargetParameter` to specify a flow target from a hydropower target (#631)
+- Renamed `HydroPowerRecorder` to `HydropowerRecorder` (#631)
 - Allow solver to be defined by the environment variable `PYWR_SOLVER`. (#619)
 - Added flow weights to `AggregatedNode`. (#603)
 - Added additional labeling functionality to notebook graphing functions. (#612)

--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -90,7 +90,7 @@ Control curve parameters
     control_curves.ControlCurveInterpolatedParameter
     control_curves.ControlCurveIndexParameter
 
-Hydro-power parameters
+Hydropower parameters
 ----------------------
 
 .. autosummary::

--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -91,12 +91,12 @@ Control curve parameters
     control_curves.ControlCurveIndexParameter
 
 Hydro-power parameters
----------------------
+----------------------
 
 .. autosummary::
    :toctree: generated/
 
-   HydroPowerTargetParameter
+   HydropowerTargetParameter
 
 
 Other parameters

--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -90,6 +90,14 @@ Control curve parameters
     control_curves.ControlCurveInterpolatedParameter
     control_curves.ControlCurveIndexParameter
 
+Hydro-power parameters
+---------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   HydroPowerTargetParameter
+
 
 Other parameters
 ----------------

--- a/docs/source/api/pywr.recorders.rst
+++ b/docs/source/api/pywr.recorders.rst
@@ -91,5 +91,5 @@ Hydro-power recorders
 .. autosummary::
    :toctree: generated/
 
-   HydroPowerRecorder
+   HydropowerRecorder
    TotalHydroEnergyRecorder

--- a/pywr/parameters/_hydropower.pxd
+++ b/pywr/parameters/_hydropower.pxd
@@ -3,7 +3,7 @@ from ._parameters cimport Parameter, IndexParameter
 
 
 
-cdef class HydroPowerTargetParameter(Parameter):
+cdef class HydropowerTargetParameter(Parameter):
     cdef Parameter _water_elevation_parameter
     cdef Parameter _target
     cdef Parameter _max_flow

--- a/pywr/parameters/_hydropower.pxd
+++ b/pywr/parameters/_hydropower.pxd
@@ -1,0 +1,16 @@
+from .._core cimport Timestep, Scenario, ScenarioIndex, AbstractNode, Storage, AbstractStorage
+from ._parameters cimport Parameter, IndexParameter
+
+
+
+cdef class HydroPowerTargetParameter(Parameter):
+    cdef Parameter _water_elevation_parameter
+    cdef Parameter _target
+    cdef Parameter _max_flow
+    cdef Parameter _min_flow
+    cdef public double min_head
+    cdef public double turbine_elevation
+    cdef public double flow_unit_conversion
+    cdef public double energy_unit_conversion
+    cdef public double density
+    cdef public double efficiency

--- a/pywr/parameters/_hydropower.pyx
+++ b/pywr/parameters/_hydropower.pyx
@@ -60,7 +60,7 @@ cpdef double inverse_hydropower_calculation(double power, double water_elevation
     return flow
 
 
-cdef class HydroPowerTargetParameter(Parameter):
+cdef class HydropowerTargetParameter(Parameter):
     """ A parameter that returns flow from a hydropower generation target.
 
     This parameter calculates the flow required to generate a particular hydropower production target. It
@@ -112,13 +112,13 @@ cdef class HydroPowerTargetParameter(Parameter):
     See Also
     --------
     pywr.recorders.TotalHydroEnergyRecorder
-    pywr.recorders.HydroPowerRecorder
+    pywr.recorders.HydropowerRecorder
 
     """
     def __init__(self, model, target, water_elevation_parameter=None, max_flow=None, min_flow=None,
                  turbine_elevation=0.0, efficiency=1.0, density=1000, min_head=0.0,
                  flow_unit_conversion=1.0, energy_unit_conversion=1e-6, **kwargs):
-        super(HydroPowerTargetParameter, self).__init__(model, **kwargs)
+        super(HydropowerTargetParameter, self).__init__(model, **kwargs)
 
         self.target = target
         self.water_elevation_parameter = water_elevation_parameter
@@ -225,4 +225,4 @@ cdef class HydroPowerTargetParameter(Parameter):
 
         return cls(model, target, water_elevation_parameter=water_elevation_parameter,
                    max_flow=max_flow, min_flow=min_flow, **data)
-HydroPowerTargetParameter.register()
+HydropowerTargetParameter.register()

--- a/pywr/parameters/_hydropower.pyx
+++ b/pywr/parameters/_hydropower.pyx
@@ -1,0 +1,228 @@
+""" Parameters for """
+from ._parameters import load_parameter, ConstantParameter
+
+
+cpdef double inverse_hydropower_calculation(double power, double water_elevation, double turbine_elevation, double efficiency,
+                                    double flow_unit_conversion=1.0, double energy_unit_conversion=1e-6,
+                                    double density=1000.0):
+    """
+    Calculate the flow required to produce power using the hydropower equation.
+    
+   
+    Parameters
+    ----------
+    power: double
+        Hydropower requirement in rate in units of energy per day.
+    water_elevation : double
+        Elevation of water entering the turbine. The difference of this value with the `turbine_elevation` gives
+        the working head of the turbine.
+    turbine_elevation : double
+        Elevation of the turbine itself. The difference between the `water_elevation` and this value gives
+        the working head of the turbine.
+    efficiency : double
+        An efficiency scaling factor for the power output of the turbine.
+    flow_unit_conversion : double (default=1.0)
+        A factor used to transform the units of flow to be compatible with the equation here. This
+        should convert flow to units of $m^3/day$
+    energy_unit_conversion : double (default=1e-6)
+        A factor used to transform the units of power. Defaults to 1e-6 to assuming input of $MJ$/day. 
+    density : double (default=1000)
+        Density of water in $kgm^{-3}$.
+        
+    Returns
+    -------
+    flow : double 
+        Required flow rate of water through the turbine. Converted using `flow_unit_conversion` to 
+        units of $m^3£ per day (not per second).
+    
+    Notes
+    -----
+    The inverse hydropower calculation uses the following equation.
+    
+    .. math:: q = \frac{P}{\rho * g * \deltaH}
+    
+    The energy rate in should be converted to units of energy per day.    
+    
+    """
+    cdef double head
+    cdef double flow
+
+    head = water_elevation - turbine_elevation
+    if head < 0.0:
+        head = 0.0
+
+    # Power
+    try:
+        flow = power / (energy_unit_conversion * density * 9.81 * head * flow_unit_conversion)
+    except ZeroDivisionError:
+        flow = float('inf')
+
+    return flow
+
+
+cdef class HydroPowerTargetParameter(Parameter):
+    """ A parameter that returns flow from a hydropower generation target.
+
+    This parameter calculates the flow required to generate a particular hydropower production target. It
+    is intended to be used on a node representing a turbine where a particular production target is required
+    each time-step.
+
+    Parameters
+    ----------
+
+    target : Parameter instance
+        Hydropower production target. Units should be in units of energy per day.
+    water_elevation_parameter : Parameter instance (default=None)
+        Elevation of water entering the turbine. The difference of this value with the `turbine_elevation` gives
+        the working head of the turbine.
+    max_flow : Parameter instance (default=None)
+        Upper bounds on the calculated flow. If set the flow returned by this parameter is at most the value
+        of the max_flow parameter.
+    min_flow : Parameter instance (default=None)
+        Lower bounds on the calculated flow. If set the flow returned by this parameter is at least the value
+        of the min_flow parameter.
+    min_head : double (default=0.0)
+        Minimum head for flow to occur. If actual head is less than this value zero flow is returned.
+    turbine_elevation : double
+        Elevation of the turbine itself. The difference between the `water_elevation` and this value gives
+        the working head of the turbine.
+    efficiency : float (default=1.0)
+        The efficiency of the turbine.
+    density : float (default=1000.0)
+        The density of water.
+    flow_unit_conversion : float (default=1.0)
+        A factor used to transform the units of flow to be compatible with the equation here. This
+        should convert flow to units of :math:`m^3/day`
+    energy_unit_conversion : float (default=1e-6)
+        A factor used to transform the units of total energy. Defaults to 1e-6 to return :math:`MJ`.
+
+    Notes
+    -----
+    The inverse hydropower calculation uses the following equation.
+
+    .. math:: q = \\frac{P}{\\rho * g * \\delta H}
+
+    The energy rate in should be converted to units of energy per day. The returned flow rate in should is
+    converted from units of :math:`m^3` per day to those used by the model using the `flow_unit_conversion` parameter.
+
+    Head is calculated from the given `water_elevation_parameter` and `turbine_elevation` value. If water elevation
+    is given then head is the difference in elevation between the water and the turbine. If water elevation parameter
+    is `None` then the head is simply the turbine elevation.
+
+    See Also
+    --------
+    pywr.recorders.TotalHydroEnergyRecorder
+    pywr.recorders.HydroPowerRecorder
+
+    """
+    def __init__(self, model, target, water_elevation_parameter=None, max_flow=None, min_flow=None,
+                 turbine_elevation=0.0, efficiency=1.0, density=1000, min_head=0.0,
+                 flow_unit_conversion=1.0, energy_unit_conversion=1e-6, **kwargs):
+        super(HydroPowerTargetParameter, self).__init__(model, **kwargs)
+
+        self.target = target
+        self.water_elevation_parameter = water_elevation_parameter
+        self.max_flow = max_flow
+        self.min_flow = min_flow
+        self.min_head = min_head
+        self.turbine_elevation = turbine_elevation
+        self.efficiency = efficiency
+        self.density = density
+        self.flow_unit_conversion = flow_unit_conversion
+        self.energy_unit_conversion = energy_unit_conversion
+
+    property water_elevation_parameter:
+        def __get__(self):
+            return self._water_elevation_parameter
+        def __set__(self, parameter):
+            if self._water_elevation_parameter:
+                self.children.remove(self._water_elevation_parameter)
+            self.children.add(parameter)
+            self._water_elevation_parameter = parameter
+
+    property target:
+        def __get__(self):
+            return self._target
+        def __set__(self, parameter):
+            if self._target:
+                self.children.remove(self._target)
+            self.children.add(parameter)
+            self._target = parameter
+
+    property max_flow:
+        def __get__(self):
+            return self._max_flow
+        def __set__(self, parameter):
+            if self._max_flow:
+                self.children.remove(self._max_flow)
+            self.children.add(parameter)
+            self._max_flow = parameter
+
+    property min_flow:
+        def __get__(self):
+            return self._min_flow
+        def __set__(self, parameter):
+            if self._min_flow:
+                self.children.remove(self._min_flow)
+            self.children.add(parameter)
+            self._min_flow = parameter
+
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+        cdef int i
+        cdef double q, head, power
+
+        power = self._target.get_value(scenario_index)
+
+        if self._water_elevation_parameter is not None:
+            head = self._water_elevation_parameter.get_value(scenario_index)
+            if self.turbine_elevation is not None:
+                head -= self.turbine_elevation
+        elif self.turbine_elevation is not None:
+            head = self.turbine_elevation
+        else:
+            raise ValueError('One or both of storage_node or level must be set.')
+
+        # -ve head is not valid
+        head = max(head, 0.0)
+
+        # Apply minimum head threshold.
+        if head < self.min_head:
+            return 0.0
+
+        # Get the flow from the current node
+        q = inverse_hydropower_calculation(power, head, 0.0, self.efficiency, density=self.density,
+                                           flow_unit_conversion=self.flow_unit_conversion,
+                                           energy_unit_conversion=self.energy_unit_conversion)
+
+        # Bound the flow if required
+        if self._max_flow is not None:
+            q = min(self._max_flow.get_value(scenario_index), q)
+        if self._min_flow is not None:
+            q = max(self._min_flow.get_value(scenario_index), q)
+
+        assert q >= 0.0
+
+        return q
+
+    @classmethod
+    def load(cls, model, data):
+
+        target = load_parameter(model, data.pop("target"))
+        if "water_elevation_parameter" in data:
+            water_elevation_parameter = load_parameter(model, data.pop("water_elevation_parameter"))
+        else:
+            water_elevation_parameter = None
+
+        if "max_flow" in data:
+            max_flow = load_parameter(model, data.pop("max_flow"))
+        else:
+            max_flow = None
+
+        if "min_flow" in data:
+            min_flow = load_parameter(model, data.pop("min_flow"))
+        else:
+            min_flow = None
+
+        return cls(model, target, water_elevation_parameter=water_elevation_parameter,
+                   max_flow=max_flow, min_flow=min_flow, **data)
+HydroPowerTargetParameter.register()

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -15,7 +15,7 @@ from ._parameters import (
 from . import licenses
 from ._polynomial import Polynomial1DParameter, Polynomial2DStorageParameter
 from ._thresholds import StorageThresholdParameter, RecorderThresholdParameter
-from ._hydropower import HydroPowerTargetParameter
+from ._hydropower import HydropowerTargetParameter
 from past.builtins import basestring
 import numpy as np
 from scipy.interpolate import interp1d

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -15,6 +15,7 @@ from ._parameters import (
 from . import licenses
 from ._polynomial import Polynomial1DParameter, Polynomial2DStorageParameter
 from ._thresholds import StorageThresholdParameter, RecorderThresholdParameter
+from ._hydropower import HydroPowerTargetParameter
 from past.builtins import basestring
 import numpy as np
 from scipy.interpolate import interp1d

--- a/pywr/recorders/_hydropower.pxd
+++ b/pywr/recorders/_hydropower.pxd
@@ -3,7 +3,7 @@ from pywr.parameters._parameters cimport Parameter
 from .._core cimport Timestep, Scenario, ScenarioIndex
 
 
-cdef class HydroPowerRecorder(NumpyArrayNodeRecorder):
+cdef class HydropowerRecorder(NumpyArrayNodeRecorder):
     cdef Parameter _water_elevation_parameter
     cdef public double turbine_elevation
     cdef public double flow_unit_conversion

--- a/pywr/recorders/_hydropower.pyx
+++ b/pywr/recorders/_hydropower.pyx
@@ -59,7 +59,7 @@ cpdef double hydropower_calculation(double flow, double water_elevation, double 
     return power * energy_unit_conversion
 
 
-cdef class HydroPowerRecorder(NumpyArrayNodeRecorder):
+cdef class HydropowerRecorder(NumpyArrayNodeRecorder):
     """ Calculates the power production using the hydropower equation
 
     This recorder saves an array of the hydrpower production in each timestep. It can be converted to a dataframe
@@ -100,12 +100,12 @@ cdef class HydroPowerRecorder(NumpyArrayNodeRecorder):
     See Also
     --------
     TotalHydroEnergyRecorder
-    pywr.parameters.HydroPowerTargetParameter
+    pywr.parameters.HydropowerTargetParameter
 
     """
     def __init__(self, model, node, water_elevation_parameter=None, turbine_elevation=0.0, efficiency=1.0, density=1000,
                  flow_unit_conversion=1.0, energy_unit_conversion=1e-6, **kwargs):
-        super(HydroPowerRecorder, self).__init__(model, node, **kwargs)
+        super(HydropowerRecorder, self).__init__(model, node, **kwargs)
 
         self.water_elevation_parameter = water_elevation_parameter
         self.turbine_elevation = turbine_elevation
@@ -161,7 +161,7 @@ cdef class HydroPowerRecorder(NumpyArrayNodeRecorder):
             water_elevation_parameter = None
 
         return cls(model, node, water_elevation_parameter=water_elevation_parameter, **data)
-HydroPowerRecorder.register()
+HydropowerRecorder.register()
 
 
 cdef class TotalHydroEnergyRecorder(BaseConstantNodeRecorder):
@@ -204,8 +204,8 @@ cdef class TotalHydroEnergyRecorder(BaseConstantNodeRecorder):
 
     See Also
     --------
-    HydroPowerRecorder
-    pywr.parameters.HydroPowerTargetParameter
+    HydropowerRecorder
+    pywr.parameters.HydropowerTargetParameter
 
     """
     def __init__(self, model, node, water_elevation_parameter=None, turbine_elevation=0.0, efficiency=1.0, density=1000,

--- a/pywr/recorders/_hydropower.pyx
+++ b/pywr/recorders/_hydropower.pyx
@@ -100,6 +100,7 @@ cdef class HydroPowerRecorder(NumpyArrayNodeRecorder):
     See Also
     --------
     TotalHydroEnergyRecorder
+    pywr.parameters.HydroPowerTargetParameter
 
     """
     def __init__(self, model, node, water_elevation_parameter=None, turbine_elevation=0.0, efficiency=1.0, density=1000,
@@ -204,7 +205,7 @@ cdef class TotalHydroEnergyRecorder(BaseConstantNodeRecorder):
     See Also
     --------
     HydroPowerRecorder
-
+    pywr.parameters.HydroPowerTargetParameter
 
     """
     def __init__(self, model, node, water_elevation_parameter=None, turbine_elevation=0.0, efficiency=1.0, density=1000,

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,9 @@ extensions = [
     Extension('pywr.parameters._control_curves', ['pywr/parameters/_control_curves.pyx'],
               include_dirs=[np.get_include()],
               define_macros=define_macros),
+    Extension('pywr.parameters._hydropower', ['pywr/parameters/_hydropower.pyx'],
+              include_dirs=[np.get_include()],
+              define_macros=define_macros),
 
     # Other modules
     Extension('pywr.recorders._recorders', ['pywr/recorders/_recorders.pyx'],

--- a/tests/models/hydropower_target_example.json
+++ b/tests/models/hydropower_target_example.json
@@ -1,0 +1,105 @@
+{
+    "metadata": {
+        "title": "Hydropower example",
+        "description": "A model with a single reservoir and hydro-power recorder",
+        "minimum_version": "0.6"
+    },
+    "timestepper": {
+        "start": "2100-01-01",
+        "end": "2101-01-01",
+        "timestep": 7
+    },
+    "nodes": [
+        {
+            "name": "catchment1",
+            "type": "catchment",
+            "flow": 0.0
+        },
+        {
+            "name": "reservoir1",
+            "type": "storage",
+            "max_volume": 200000,
+            "initial_volume": 200000
+        },
+        {
+            "name": "release1",
+            "type": "link",
+            "max_flow": 10,
+            "cost": -500
+        },
+        {
+            "name": "turbine1",
+            "type": "link",
+            "max_flow": "turbine1_discharge",
+            "cost": -200
+        },
+        {
+            "name": "spill1",
+            "type": "link",
+            "cost": 1000
+        },
+        {
+            "name": "reach1",
+            "type": "link"
+        },
+        {
+            "name": "end1",
+            "type": "output"
+        }
+    ],
+    "edges": [
+        ["catchment1", "reservoir1"],
+        ["reservoir1", "release1"],
+        ["reservoir1", "turbine1"],
+        ["reservoir1", "spill1"],
+        ["release1", "reach1"],
+        ["turbine1", "reach1"],
+        ["spill1", "reach1"],
+        ["reach1", "end1"]
+    ],
+    "parameters": {
+        "reservoir1_level": {
+          "type": "interpolatedvolume",
+          "node": "reservoir1",
+          "volumes": [0, 25000, 50000, 75000, 100000, 150000, 200000],
+          "values": [0, 29.2, 36.8, 42.2, 46.4, 53.1, 58.5],
+          "kind": "cubic"
+        },
+        "turbine1_discharge": {
+            "type": "HydroPowerTarget",
+            "water_elevation_parameter": "reservoir1_level",
+            "turbine_elevation": 35.0,
+            "efficiency": 0.85,
+            "flow_unit_conversion": 1e3,
+            "target": { "type": "constant", "value": 1e5},
+            "max_flow": { "type": "constant", "value": 1000.0},
+            "min_flow": { "type": "constant", "value": 500.0}
+        }
+    },
+    "recorders": {
+        "turbine1_energy": {
+            "type": "HydroPowerRecorder",
+            "node": "turbine1",
+            "water_elevation_parameter": "reservoir1_level",
+            "turbine_elevation": 35.0,
+            "efficiency": 0.85,
+            "flow_unit_conversion": 1e3
+        },
+        "catchment1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "catchment1"
+        },
+        "reservoir1_storage": {
+            "type": "numpyarraystoragerecorder",
+            "node": "reservoir1"
+        },
+        "turbine1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "turbine1"
+        },
+        "release1_flow": {
+            "type": "numpyarraynoderecorder",
+            "node": "release1"
+        }
+    }
+}

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1239,10 +1239,10 @@ class TestHydroPowerTargets:
             turbine1 = model.nodes["turbine1"]
             assert turbine1.flow[0] > 0
 
-            if turbine1.flow[0] <= 500.0:
+            if np.allclose(turbine1.flow[0], 500.0):
                 # If flow is bounded by min_flow then more HP is produced.
                 assert rec.data[i, 0] > param.target.get_value(si)
-            elif turbine1.flow[0] >= 1000.0:
+            elif np.allclose(turbine1.flow[0], 1000.0):
                 # If flow is bounded by max_flow then less HP is produced.
                 assert rec.data[i, 0] < param.target.get_value(si)
             else:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1224,7 +1224,7 @@ def test_deficit_parameter():
 
 class TestHydroPowerTargets:
     def test_target_json(self):
-        """ Test loading a HydroPowerTargetParameter from JSON. """
+        """ Test loading a HydropowerTargetParameter from JSON. """
         model = load_model("hydropower_target_example.json")
         si = ScenarioIndex(0, np.array([0], dtype=np.int32))
 

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -21,7 +21,7 @@ from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
                             PercentBiasNodeRecorder, RMSEStandardDeviationRatioNodeRecorder, NashSutcliffeEfficiencyNodeRecorder,
                             EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder, EventStatisticRecorder,
                             FlowDurationCurveRecorder, FlowDurationCurveDeviationRecorder, StorageDurationCurveRecorder,
-                            HydroPowerRecorder, TotalHydroEnergyRecorder,
+                            HydropowerRecorder, TotalHydroEnergyRecorder,
                             SeasonalFlowDurationCurveRecorder, load_recorder, ParameterNameWarning)
 
 from pywr.recorders.progress import ProgressRecorder
@@ -1419,14 +1419,14 @@ def test_progress_recorder(simple_linear_model):
 class TestHydroPowerRecorder:
 
     def test_constant_level(self, simple_storage_model):
-        """ Test HydroPowerRecorder """
+        """ Test HydropowerRecorder """
         m = simple_storage_model
 
         strg = m.nodes['Storage']
         otpt = m.nodes['Output']
 
         elevation = ConstantParameter(m, 100)
-        rec = HydroPowerRecorder(m, otpt, elevation)
+        rec = HydropowerRecorder(m, otpt, elevation)
         rec_total = TotalHydroEnergyRecorder(m, otpt, elevation)
 
         m.setup()
@@ -1444,7 +1444,7 @@ class TestHydroPowerRecorder:
         np.testing.assert_allclose(rec_total.values()[0], 2* 1000 * 9.81 * 8 * 100 * 1e-6)
 
     def test_varying_level(self, simple_storage_model):
-        """ Test HydroPowerRecorder with varying level on Storage node """
+        """ Test HydropowerRecorder with varying level on Storage node """
         from pywr.parameters import InterpolatedVolumeParameter
         m = simple_storage_model
 
@@ -1452,7 +1452,7 @@ class TestHydroPowerRecorder:
         otpt = m.nodes['Output']
 
         elevation = InterpolatedVolumeParameter(m, strg, [0, 10, 20], [0, 100, 200])
-        rec = HydroPowerRecorder(m, otpt, elevation)
+        rec = HydropowerRecorder(m, otpt, elevation)
         rec_total = TotalHydroEnergyRecorder(m, otpt, elevation)
 
         m.setup()
@@ -1471,7 +1471,7 @@ class TestHydroPowerRecorder:
         np.testing.assert_allclose(rec_total.values()[0], 1000 * 9.81 * 8 * 170 * 1e-6)
 
     def test_varying_level_with_turbine_level(self, simple_storage_model):
-        """ Test HydroPowerRecorder with varying level on Storage and defined level on the recorder """
+        """ Test HydropowerRecorder with varying level on Storage and defined level on the recorder """
         from pywr.parameters import InterpolatedVolumeParameter
         m = simple_storage_model
 
@@ -1479,7 +1479,7 @@ class TestHydroPowerRecorder:
         otpt = m.nodes['Output']
 
         elevation = InterpolatedVolumeParameter(m, strg, [0, 10, 20], [0, 100, 200])
-        rec = HydroPowerRecorder(m, otpt, elevation, turbine_elevation=80)
+        rec = HydropowerRecorder(m, otpt, elevation, turbine_elevation=80)
         rec_total = TotalHydroEnergyRecorder(m, otpt, elevation, turbine_elevation=80)
 
         m.setup()


### PR DESCRIPTION
This parameter can be used to calculate flow given an energy target. See docstring.

Test included and modifications to existing hydropower recorders docstring to reference this new one. Added a new section to parameters API docs for hydropower.