### PR TITLE
WIP: Refactor of several recorders

### DIFF
--- a/docs/source/api/pywr.recorders.rst
+++ b/docs/source/api/pywr.recorders.rst
@@ -61,6 +61,8 @@ Statistical recorders
 
    MeanFlowNodeRecorder
    TotalFlowNodeRecorder
+   MeanParameterRecorder
+   TotalParameterRecorder
    RollingMeanFlowNodeRecorder
    MinimumVolumeStorageRecorder
    MinimumThresholdVolumeStorageRecorder

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -109,3 +109,14 @@ cdef class AnnualCountIndexParameterRecorder(IndexParameterRecorder):
 
 cdef class SeasonalFlowDurationCurveRecorder(FlowDurationCurveRecorder):
     cdef set _months
+
+
+cdef class BaseConstantParameterRecorder(ParameterRecorder):
+    cdef double[:] _values
+
+cdef class TotalParameterRecorder(BaseConstantParameterRecorder):
+    cdef public double factor
+    cdef public bint integrate
+
+cdef class MeanParameterRecorder(BaseConstantParameterRecorder):
+    cdef public double factor

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -3,13 +3,18 @@ from pywr._core cimport Timestep, AbstractNode, AbstractStorage, ScenarioIndex, 
 from pywr.parameters._parameters cimport Parameter, IndexParameter
 
 
+cdef class Aggregator:
+    cdef object _user_func
+    cdef int _func
+    cpdef double aggregate_1d(self, double[:] data, ignore_nan=*)
+    cpdef double[:] aggregate_2d(self, double[:, :] data, axis=*, ignore_nan=*)
+
 cdef class Recorder(Component):
     cdef int _is_objective
     cdef public bint is_constraint
     cdef public double epsilon
     cdef public bint ignore_nan
-    cdef object _agg_user_func
-    cdef int _agg_func
+    cdef Aggregator _scenario_aggregator
     cpdef double aggregated_value(self) except? -1
     cpdef double[:] values(self)
 
@@ -31,29 +36,30 @@ cdef class IndexParameterRecorder(Recorder):
     cdef readonly IndexParameter _param
 
 cdef class NumpyArrayNodeRecorder(NodeRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
 cdef class NumpyArrayStorageRecorder(StorageRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
 cdef class NumpyArrayLevelRecorder(StorageRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
 cdef class NumpyArrayParameterRecorder(ParameterRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
 cdef class NumpyArrayIndexParameterRecorder(IndexParameterRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef int[:, :] _data
 
 cdef class FlowDurationCurveRecorder(NumpyArrayNodeRecorder):
-    cdef object fdc_agg_func
-    cdef int _fdc_agg_func
     cdef double[:] _percentiles
     cdef double[:, :] _fdc
 
 cdef class StorageDurationCurveRecorder(NumpyArrayStorageRecorder):
-    cdef object sdc_agg_func
-    cdef int _sdc_agg_func
     cdef double[:] _percentiles
     cdef double[:, :] _sdc
 
@@ -65,6 +71,7 @@ cdef class FlowDurationCurveDeviationRecorder(FlowDurationCurveRecorder):
     cdef public Scenario scenario
 
 cdef class RollingWindowParameterRecorder(ParameterRecorder):
+    cdef Aggregator _temporal_aggregator
     cdef public int window
     cdef int position
     cdef double[:, :] _memory

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1,6 +1,7 @@
 import numpy as np
 cimport numpy as np
 import pandas as pd
+import warnings
 from past.builtins import basestring
 
 recorder_registry = {}
@@ -40,29 +41,109 @@ _obj_direction_lookup = {
     "min": ObjDirection.MINIMISE,
 }
 
+cdef class Aggregator:
+    """Utility class for computing aggregate values."""
+    def __init__(self, func):
+        self.func = func
+
+    property func:
+        def __set__(self, func):
+            self._user_func = None
+            if isinstance(func, basestring):
+                func = _agg_func_lookup[func.lower()]
+            elif callable(func):
+                self._user_func = func
+                func = AggFuncs.CUSTOM
+            else:
+                raise ValueError("Unrecognised aggregation function: \"{}\".".format(func))
+            self._func = func
+
+    cpdef double aggregate_1d(self, double[:] data, ignore_nan=False):
+        """Compuate an aggreagted value across 1D array. 
+        """
+        cdef double[:] values = data
+
+        if ignore_nan:
+            values = np.array(values)[~np.isnan(values)]
+
+        if self._func == AggFuncs.PRODUCT:
+            return np.product(values)
+        elif self._func == AggFuncs.SUM:
+            return np.sum(values)
+        elif self._func == AggFuncs.MAX:
+            return np.max(values)
+        elif self._func == AggFuncs.MIN:
+            return np.min(values)
+        elif self._func == AggFuncs.MEAN:
+            return np.mean(values)
+        elif self._func == AggFuncs.MEDIAN:
+            return np.median(values)
+        else:
+            return self._user_func(np.array(values))
+
+    cpdef double[:] aggregate_2d(self, double[:, :] data, axis=0, ignore_nan=False):
+        """Compute an aggregated value along an axis of a 2D array.
+        """
+        cdef double[:, :] values = data
+
+        if ignore_nan:
+            values = np.array(values)[~np.isnan(values)]
+
+        if self._func == AggFuncs.PRODUCT:
+            return np.product(values, axis=axis)
+        elif self._func == AggFuncs.SUM:
+            return np.sum(values, axis=axis)
+        elif self._func == AggFuncs.MAX:
+            return np.max(values, axis=axis)
+        elif self._func == AggFuncs.MIN:
+            return np.min(values, axis=axis)
+        elif self._func == AggFuncs.MEAN:
+            return np.mean(values, axis=axis)
+        elif self._func == AggFuncs.MEDIAN:
+            return np.median(values, axis=axis)
+        else:
+            return self._user_func(np.array(values), axis=0)
+
+
 cdef class Recorder(Component):
+    """Base class for recording information from a `pywr.model.Model`.
+
+    Recorder components are used to calculate, aggregate and save data from a simulation. This
+    base class provides the basic functionality for all recorders.
+
+    Parameters
+    ==========
+    model : `pywr.core.Model`
+    agg_func : str or callable (default="mean")
+        Scenario aggregation function to use when `aggregated_value` is called.
+    name : str (default=None)
+        Name of the recorder.
+    comment : str (default=None)
+        Comment or description of the recorder.
+    ignore_nan : bool (default=False)
+        Flag to ignore NaN values when calling `aggregated_value`.
+    is_objective : {None, 'maximize', 'maximise', 'max', 'minimize', 'minimise', 'min'}
+        Flag to denote the direction, if any, of optimisation undertaken with this recorder.
+    is_constraint : bool (default=False)
+        Flag to denote whether this recorder is to be used as a constraint during optimisation.
+    epsilon : float (default=1.0)
+        Epsilon distance used by some optimisation algorithms.
+    """
     def __init__(self, model, agg_func="mean", ignore_nan=False, is_objective=None, epsilon=1.0,
                  is_constraint=False, name=None, **kwargs):
         if name is None:
             name = self.__class__.__name__.lower()
         super(Recorder, self).__init__(model, name=name, **kwargs)
-        self.agg_func = agg_func
         self.ignore_nan = ignore_nan
         self.is_objective = is_objective
         self.is_constraint = is_constraint
         self.epsilon = epsilon
+        # Create the aggregator for scenarios
+        self._scenario_aggregator = Aggregator(agg_func)
 
     property agg_func:
         def __set__(self, agg_func):
-            self._agg_user_func = None
-            if isinstance(agg_func, basestring):
-                agg_func = _agg_func_lookup[agg_func.lower()]
-            elif callable(agg_func):
-                self._agg_user_func = agg_func
-                agg_func = AggFuncs.CUSTOM
-            else:
-                raise ValueError("Unrecognised aggregation function: \"{}\".".format(agg_func))
-            self._agg_func = agg_func
+            self._scenario_aggregator.func = agg_func
 
     property is_objective:
         def __set__(self, value):
@@ -86,24 +167,7 @@ cdef class Recorder(Component):
 
     cpdef double aggregated_value(self) except? -1:
         cdef double[:] values = self.values()
-
-        if self.ignore_nan:
-            values = np.array(values)[~np.isnan(values)]
-
-        if self._agg_func == AggFuncs.PRODUCT:
-            return np.product(values)
-        elif self._agg_func == AggFuncs.SUM:
-            return np.sum(values)
-        elif self._agg_func == AggFuncs.MAX:
-            return np.max(values)
-        elif self._agg_func == AggFuncs.MIN:
-            return np.min(values)
-        elif self._agg_func == AggFuncs.MEAN:
-            return np.mean(values)
-        elif self._agg_func == AggFuncs.MEDIAN:
-            return np.median(values)
-        else:
-            return self._agg_user_func(np.array(values))
+        return self._scenario_aggregator.aggregate_1d(values)
 
     cpdef double[:] values(self):
         raise NotImplementedError()
@@ -344,6 +408,32 @@ IndexParameterRecorder.register()
 
 
 cdef class NumpyArrayNodeRecorder(NodeRecorder):
+    """Recorder for timeseries information from a `Node`.
+
+    This class stores flow from a specific node for each time-step of a simulation. The
+    data is saved internally using a memory view. The data can be accessed through the `data`
+    attribute or `to_dataframe()` method.
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+    node : `pyre.core.Node`
+        Node instance to record.
+    temporal_agg_func : str or callable (default="mean")
+        Aggregation function used over time when computing a value per scenario. This can be used
+        to return, for example, the median flow over a simulation. For aggregation over scenarios
+        see the `agg_func` keyword argument.
+    """
+    def __init__(self, model, AbstractNode node, **kwargs):
+        # Optional different method for aggregating across time.
+        temporal_agg_func = kwargs.pop('temporal_agg_func', 'mean')
+        super(NumpyArrayNodeRecorder, self).__init__(model, node, **kwargs)
+        self._temporal_aggregator = Aggregator(temporal_agg_func)
+
+    property temporal_agg_func:
+        def __set__(self, agg_func):
+            self._temporal_aggregator.func = agg_func
+
     cpdef setup(self):
         cdef int ncomb = len(self.model.scenarios.combinations)
         cdef int nts = len(self.model.timestepper)
@@ -362,6 +452,11 @@ cdef class NumpyArrayNodeRecorder(NodeRecorder):
     property data:
         def __get__(self, ):
             return np.array(self._data)
+        
+    cpdef double[:] values(self):
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
 
     def to_dataframe(self):
         """ Return a `pandas.DataFrame` of the recorder data
@@ -397,24 +492,21 @@ cdef class FlowDurationCurveRecorder(NumpyArrayNodeRecorder):
     fdc_agg_func: str, optional
         optional different function for aggregating across scenarios.
     """
-
     def __init__(self, model, AbstractNode node, percentiles, **kwargs):
 
         # Optional different method for aggregating across percentiles
-        agg_func = kwargs.pop('fdc_agg_func', kwargs.get('agg_func', 'mean'))
+        if 'fdc_agg_func' in kwargs:
+            # Support previous behaviour
+            warnings.warn('The "fdc_agg_func" key is deprecated for defining the temporal '
+                          'aggregation in {}. Please "temporal_agg_func" instead.'
+                          .format(self.__class__.__name__))
+            if "temporal_agg_func" in kwargs:
+                raise ValueError('Both "fdc_agg_func" and "temporal_agg_func" keywords given.'
+                                 'This is ambiguous. Please use "temporal_agg_func" only.')
+            kwargs["temporal_agg_func"] = kwargs.pop("fdc_agg_func")
+
         super(FlowDurationCurveRecorder, self).__init__(model, node, **kwargs)
-
-        if isinstance(agg_func, basestring):
-            agg_func = _agg_func_lookup[agg_func.lower()]
-        elif callable(agg_func):
-            self.agg_user_func = agg_func
-            agg_func = AggFuncs.CUSTOM
-        else:
-            raise ValueError("Unrecognised recorder aggregation function: \"{}\".".format(agg_func))
-        self._fdc_agg_func = agg_func
-
         self._percentiles = np.asarray(percentiles, dtype=np.float64)
-
 
     cpdef finish(self):
         self._fdc = np.percentile(np.asarray(self._data), np.asarray(self._percentiles), axis=0)
@@ -424,21 +516,9 @@ cdef class FlowDurationCurveRecorder(NumpyArrayNodeRecorder):
             return np.array(self._fdc)
 
     cpdef double[:] values(self):
-
-        if self._fdc_agg_func == AggFuncs.PRODUCT:
-            return np.product(self._fdc, axis=0)
-        elif self._fdc_agg_func == AggFuncs.SUM:
-            return np.sum(self._fdc, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MAX:
-            return np.max(self._fdc, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MIN:
-            return np.min(self._fdc, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MEAN:
-            return np.mean(self._fdc, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MEDIAN:
-            return np.median(self._fdc, axis=0)
-        else:
-            return self._agg_user_func(np.array(self._fdc), axis=0)
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._fdc, axis=0, ignore_nan=self.ignore_nan)
 
     def to_dataframe(self):
         """ Return a `pandas.DataFrame` of the recorder data
@@ -557,7 +637,6 @@ cdef class FlowDurationCurveDeviationRecorder(FlowDurationCurveRecorder):
         cdef double[:] utrgt_fdc, ltrgt_fdc
         cdef double udev, ldev
 
-
         # We have to do this the slow way by iterating through all scenario combinations
         sc_index = self.model.scenarios.get_scenario_index(self.scenario)
         self._fdc_deviations = np.empty((self._lower_target_fdc.shape[0], len(self.model.scenarios.combinations)), dtype=np.float64)
@@ -588,22 +667,11 @@ cdef class FlowDurationCurveDeviationRecorder(FlowDurationCurveRecorder):
         def __get__(self, ):
             return np.array(self._fdc_deviations)
 
-    cpdef double[:] values(self):
 
-        if self._fdc_agg_func == AggFuncs.PRODUCT:
-            return np.nanprod(self._fdc_deviations, axis=0)
-        elif self._fdc_agg_func == AggFuncs.SUM:
-            return np.nansum(self._fdc_deviations, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MAX:
-            return np.nanmax(self._fdc_deviations, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MIN:
-            return np.nanmin(self._fdc_deviations, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MEAN:
-            return np.nanmean(self._fdc_deviations, axis=0)
-        elif self._fdc_agg_func == AggFuncs.MEDIAN:
-            return np.nanmedian(self._fdc_deviations, axis=0)
-        else:
-            return self._agg_user_func(np.array(self._fdc_deviations), axis=0)
+    cpdef double[:] values(self):
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._fdc_deviations, axis=0, ignore_nan=self.ignore_nan)
 
     def to_dataframe(self, return_fdc=False):
         """ Return a `pandas.DataFrame` of the deviations from the target FDCs
@@ -627,6 +695,18 @@ FlowDurationCurveDeviationRecorder.register()
 
 
 cdef class NumpyArrayStorageRecorder(StorageRecorder):
+
+    def __init__(self, model, AbstractStorage node, **kwargs):
+        # Optional different method for aggregating across time.
+        temporal_agg_func = kwargs.pop('temporal_agg_func', 'mean')
+        super(NumpyArrayStorageRecorder, self).__init__(model, node, **kwargs)
+
+        self._temporal_aggregator = Aggregator(temporal_agg_func)
+
+    property temporal_agg_func:
+        def __set__(self, agg_func):
+            self._temporal_aggregator.func = agg_func
+
     cpdef setup(self):
         cdef int ncomb = len(self.model.scenarios.combinations)
         cdef int nts = len(self.model.timestepper)
@@ -645,6 +725,11 @@ cdef class NumpyArrayStorageRecorder(StorageRecorder):
     property data:
         def __get__(self, ):
             return np.array(self._data)
+
+    cpdef double[:] values(self):
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
 
     def to_dataframe(self):
         """ Return a `pandas.DataFrame` of the recorder data
@@ -683,19 +768,17 @@ cdef class StorageDurationCurveRecorder(NumpyArrayStorageRecorder):
 
     def __init__(self, model, AbstractStorage node, percentiles, **kwargs):
 
-        # Optional different method for aggregating across percentiles
-        agg_func = kwargs.pop('sdc_agg_func', kwargs.get('agg_func', 'mean'))
+        if "sdc_agg_func" in kwargs:
+            # Support previous behaviour
+            warnings.warn('The "sdc_agg_func" key is deprecated for defining the temporal '
+                          'aggregation in {}. Please "temporal_agg_func" instead.'
+                          .format(self.__class__.__name__))
+            if "temporal_agg_func" in kwargs:
+                raise ValueError('Both "sdc_agg_func" and "temporal_agg_func" keywords given.'
+                                 'This is ambiguous. Please use "temporal_agg_func" only.')
+            kwargs["temporal_agg_func"] = kwargs.pop("sdc_agg_func")
+
         super(StorageDurationCurveRecorder, self).__init__(model, node, **kwargs)
-
-        if isinstance(agg_func, basestring):
-            agg_func = _agg_func_lookup[agg_func.lower()]
-        elif callable(agg_func):
-            self.agg_user_func = agg_func
-            agg_func = AggFuncs.CUSTOM
-        else:
-            raise ValueError("Unrecognised recorder aggregation function: \"{}\".".format(agg_func))
-        self._sdc_agg_func = agg_func
-
         self._percentiles = np.asarray(percentiles, dtype=np.float64)
 
 
@@ -707,21 +790,9 @@ cdef class StorageDurationCurveRecorder(NumpyArrayStorageRecorder):
             return np.array(self._sdc)
 
     cpdef double[:] values(self):
-
-        if self._sdc_agg_func == AggFuncs.PRODUCT:
-            return np.product(self._sdc, axis=0)
-        elif self._sdc_agg_func == AggFuncs.SUM:
-            return np.sum(self._sdc, axis=0)
-        elif self._sdc_agg_func == AggFuncs.MAX:
-            return np.max(self._sdc, axis=0)
-        elif self._sdc_agg_func == AggFuncs.MIN:
-            return np.min(self._sdc, axis=0)
-        elif self._sdc_agg_func == AggFuncs.MEAN:
-            return np.mean(self._sdc, axis=0)
-        elif self._sdc_agg_func == AggFuncs.MEDIAN:
-            return np.median(self._sdc, axis=0)
-        else:
-            return self._agg_user_func(np.array(self._sdc), axis=0)
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._sdc, axis=0, ignore_nan=self.ignore_nan)
 
     def to_dataframe(self):
         """ Return a `pandas.DataFrame` of the recorder data
@@ -761,6 +832,17 @@ cdef class NumpyArrayLevelRecorder(StorageRecorder):
 NumpyArrayLevelRecorder.register()
 
 cdef class NumpyArrayParameterRecorder(ParameterRecorder):
+    def __init__(self, model, Parameter param, **kwargs):
+        # Optional different method for aggregating across time.
+        temporal_agg_func = kwargs.pop('temporal_agg_func', 'mean')
+        super(NumpyArrayParameterRecorder, self).__init__(model, param, **kwargs)
+
+        self._temporal_aggregator = Aggregator(temporal_agg_func)
+
+    property temporal_agg_func:
+        def __set__(self, agg_func):
+            self._temporal_aggregator.func = agg_func
+
     cpdef setup(self):
         cdef int ncomb = len(self.model.scenarios.combinations)
         cdef int nts = len(self.model.timestepper)
@@ -780,6 +862,11 @@ cdef class NumpyArrayParameterRecorder(ParameterRecorder):
         def __get__(self, ):
             return np.array(self._data)
 
+    cpdef double[:] values(self):
+        """Compute a value for each scenario using `temporal_agg_func`.
+        """
+        return self._temporal_aggregator.aggregate_2d(self._fdc, axis=0, ignore_nan=self.ignore_nan)
+
     def to_dataframe(self):
         """ Return a `pandas.DataFrame` of the recorder data
         This DataFrame contains a MultiIndex for the columns with the recorder name
@@ -792,7 +879,19 @@ cdef class NumpyArrayParameterRecorder(ParameterRecorder):
         return pd.DataFrame(data=np.array(self._data), index=index, columns=sc_index)
 NumpyArrayParameterRecorder.register()
 
+
 cdef class NumpyArrayIndexParameterRecorder(IndexParameterRecorder):
+    def __init__(self, model, IndexParameter param, **kwargs):
+        # Optional different method for aggregating across time.
+        temporal_agg_func = kwargs.pop('temporal_agg_func', 'mean')
+        super(NumpyArrayIndexParameterRecorder, self).__init__(model, param, **kwargs)
+
+        self._temporal_aggregator = Aggregator(temporal_agg_func)
+
+    property temporal_agg_func:
+        def __set__(self, agg_func):
+            self._temporal_aggregator.func = agg_func
+
     cpdef setup(self):
         cdef int ncomb = len(self.model.scenarios.combinations)
         cdef int nts = len(self.model.timestepper)
@@ -824,16 +923,28 @@ cdef class NumpyArrayIndexParameterRecorder(IndexParameterRecorder):
         return pd.DataFrame(data=np.array(self._data), index=index, columns=sc_index)
 NumpyArrayIndexParameterRecorder.register()
 
+
 cdef class RollingWindowParameterRecorder(ParameterRecorder):
-    """Records the mean value of a Parameter for the last N timesteps"""
-    def __init__(self, model, Parameter param, int window, agg_func, *args, **kwargs):
+    """Records the mean value of a Parameter for the last N timesteps.
+    """
+    def __init__(self, model, Parameter param, int window, *args, **kwargs):
+
+        if "agg_func" in kwargs and "temporal_agg_func" not in kwargs:
+            # Support previous behaviour
+            warnings.warn('The "agg_func" key is deprecated for defining the temporal '
+                          'aggregation in {}. Please "temporal_agg_func" instead.'
+                          .format(self.__class__.__name__))
+            temporal_agg_func = kwargs.get("agg_func")
+        else:
+            temporal_agg_func = kwargs.pop("temporal_agg_func", "mean")
+
         super(RollingWindowParameterRecorder, self).__init__(model, param, *args, **kwargs)
         self.window = window
-        self.agg_func = agg_func
+        self._temporal_aggregator = Aggregator(temporal_agg_func)
 
-        valid_funcs = (AggFuncs.MEAN, AggFuncs.SUM, AggFuncs.MAX, AggFuncs.MIN)
-        if self._agg_func not in valid_funcs:
-            raise ValueError("Aggregation function for {} must be MIN/MAX/SUM/MEAN.".format(self.__class__.__name__))
+    property temporal_agg_func:
+        def __set__(self, agg_func):
+            self._temporal_aggregator.func = agg_func
 
     cpdef setup(self):
         cdef int ncomb = len(self.model.scenarios.combinations)
@@ -855,22 +966,13 @@ cdef class RollingWindowParameterRecorder(ParameterRecorder):
         for i, scenario_index in enumerate(self.model.scenarios.combinations):
             self._memory[self.position, i] = self._param.get_value(scenario_index)
 
-        if timestep.index < self.window:
-            n = timestep.index + 1
+        if timestep._index < self.window:
+            n = timestep._index + 1
         else:
             n = self.window
 
-        if self._agg_func == AggFuncs.MEAN:
-            value = np.mean(self._memory[0:n, :], axis=0)
-        elif self._agg_func == AggFuncs.SUM:
-            value = np.sum(self._memory[0:n, :], axis=0)
-        elif self._agg_func == AggFuncs.MIN:
-            value = np.min(self._memory[0:n, :], axis=0)
-        elif self._agg_func == AggFuncs.MAX:
-            value = np.max(self._memory[0:n, :], axis=0)
-        else:
-            raise NotImplementedError("Aggregation function for {} must be MIN/MAX/SUM/MEAN.".format(self.__class__.__name__))
-        self._data[<int>(timestep.index), :] = value
+        value = self._temporal_aggregator.aggregate_2d(self._memory[0:n, :], axis=0)
+        self._data[timestep._index, :] = value
 
         self.position += 1
         if self.position >= self.window:
@@ -890,8 +992,7 @@ cdef class RollingWindowParameterRecorder(ParameterRecorder):
         from pywr.parameters import load_parameter
         parameter = load_parameter(model, data.pop("parameter"))
         window = int(data.pop("window"))
-        agg_func = data.pop("agg_func")
-        return cls(model, parameter, window, agg_func, **data)
+        return cls(model, parameter, window, **data)
 
 RollingWindowParameterRecorder.register()
 

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -322,10 +322,14 @@ def test_parameter_mean_recorder(daily_profile_model):
     scenario = Scenario(model, "dummy", size=3)
 
     timesteps = 3
-    rec_mean = RollingWindowParameterRecorder(model, node.max_flow, timesteps, "mean", name="rec_mean")
-    rec_sum = RollingWindowParameterRecorder(model, node.max_flow, timesteps, "sum", name="rec_sum")
-    rec_min = RollingWindowParameterRecorder(model, node.max_flow, timesteps, "min", name="rec_min")
-    rec_max = RollingWindowParameterRecorder(model, node.max_flow, timesteps, "max", name="rec_max")
+    rec_mean = RollingWindowParameterRecorder(model, node.max_flow, timesteps,
+                                              temporal_agg_func="mean", name="rec_mean")
+    rec_sum = RollingWindowParameterRecorder(model, node.max_flow, timesteps,
+                                             temporal_agg_func="sum", name="rec_sum")
+    rec_min = RollingWindowParameterRecorder(model, node.max_flow, timesteps,
+                                             temporal_agg_func="min", name="rec_min")
+    rec_max = RollingWindowParameterRecorder(model, node.max_flow, timesteps,
+                                             temporal_agg_func="max", name="rec_max")
 
     model.run()
 

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -22,6 +22,7 @@ from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
                             EventRecorder, Event, StorageThresholdRecorder, NodeThresholdRecorder, EventDurationRecorder, EventStatisticRecorder,
                             FlowDurationCurveRecorder, FlowDurationCurveDeviationRecorder, StorageDurationCurveRecorder,
                             HydroPowerRecorder, TotalHydroEnergyRecorder,
+                            TotalParameterRecorder, MeanParameterRecorder,
                             SeasonalFlowDurationCurveRecorder, load_recorder, ParameterNameWarning)
 
 from pywr.recorders.progress import ProgressRecorder
@@ -302,8 +303,8 @@ def test_parameter_recorder_json():
     assert_allclose(rec_demand.data, 10)
     assert_allclose(rec_supply.data, 15)
 
-
-def test_parameter_mean_recorder(simple_linear_model):
+@pytest.fixture()
+def daily_profile_model(simple_linear_model):
     model = simple_linear_model
     # using leap year simplifies test
     model.timestepper.start = pandas.to_datetime("2016-01-01")
@@ -311,8 +312,13 @@ def test_parameter_mean_recorder(simple_linear_model):
 
     node = model.nodes["Input"]
     values = np.arange(0, 366, dtype=np.float64)
-    node.max_flow = DailyProfileParameter(model, values)
+    node.max_flow = DailyProfileParameter(model, values, name='profile')
+    return model
 
+
+def test_parameter_mean_recorder(daily_profile_model):
+    model = daily_profile_model
+    node = model.nodes["Input"]
     scenario = Scenario(model, "dummy", size=3)
 
     timesteps = 3
@@ -344,6 +350,73 @@ def test_parameter_mean_recorder_json(simple_linear_model):
     }
 
     rec = load_recorder(model, data)
+
+
+class TestTotalParameterRecorder:
+
+    @pytest.mark.parametrize('factor, integrate',
+                             [[1.0, False], [1.0, True], [2.0, False], [0.5, True]])
+    def test_values(self, daily_profile_model, factor, integrate):
+        model = daily_profile_model
+        model.timestepper.delta = 2
+        param = model.parameters['profile']
+        rec = TotalParameterRecorder(model, param, name="total", factor=factor, integrate=integrate)
+        model.run()
+
+        expected = np.arange(0, 366, dtype=np.float64)[::2].sum()*factor
+        if integrate:
+            expected *= 2
+        assert_allclose(rec.values(), expected)
+
+    @pytest.mark.parametrize('integrate', [None, True, False])
+    def test_from_json(self, daily_profile_model, integrate):
+
+        model = daily_profile_model
+
+        data = {
+            "type": "totalparameter",
+            "parameter": "profile",
+            "agg_func": "mean",
+            "factor": 2.0,
+        }
+
+        if integrate is not None:
+            data['integrate'] = integrate
+
+        rec = load_recorder(model, data)
+        assert rec.factor == 2.0
+
+        if integrate is not None:
+            assert rec.integrate == integrate
+        else:
+            assert not rec.integrate
+
+
+class TestMeanParameterRecorder:
+    @pytest.mark.parametrize('factor', [1.0, 2.0, 0.5])
+    def test_values(self, daily_profile_model, factor):
+        model = daily_profile_model
+        model.timestepper.delta = 2
+        param = model.parameters['profile']
+        rec = MeanParameterRecorder(model, param, name="mean", factor=factor)
+        model.run()
+
+        expected = np.arange(0, 366, dtype=np.float64)[::2].mean()*factor
+        assert_allclose(rec.values(), expected)
+
+    def test_from_json(self, daily_profile_model):
+
+        model = daily_profile_model
+
+        data = {
+            "type": "meanparameter",
+            "parameter": "profile",
+            "agg_func": "mean",
+            "factor": 2.0,
+        }
+
+        rec = load_recorder(model, data)
+        assert rec.factor == 2.0
 
 
 def test_concatenated_dataframes(simple_storage_model):

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -83,8 +83,8 @@ def test_two_scenarios(simple_linear_model, ):
     assert np.all(index.levels[1] == ['High', 'Low'])
 
     # add numpy recorders to input and output nodes
-    NumpyArrayNodeRecorder(model, model.nodes["Input"], "input")
-    NumpyArrayNodeRecorder(model, model.nodes["Output"], "output")
+    NumpyArrayNodeRecorder(model, model.nodes["Input"], name="input")
+    NumpyArrayNodeRecorder(model, model.nodes["Output"], name="output")
 
     expected_node_results = {
         "Input": [3.0, 5.0, 3.0, 8.0],


### PR DESCRIPTION
This started out as adding two new recorders: `TotalParameterRecorder` and `MeanParameterRecorder` to be equivalent of the total and mean flow recorders for a node. 

However, it made me realise that the standard `NumpArrayXXX` parameters should support arbitrary temporal aggregation and support the `.values()` and `.aggregated_value()` methods. Following that I refactored the existing recorders that have some sort of temporal aggregation (e.g. `FlowDurationCurveRecorder`) to use a consistent naming `temporal_agg_func` as opposed to recorder specific keywords. This is all then achieved through a common `Aggregator` function that abstracts the setting and application of "agg_func" properties to all the recorder subclasses.

Along the way I tried to improve some docstrings too.

Todo:
- [ ] `Aggregator` needs some tests of its own.
- [ ] More docstrings need completing. 
- [ ] Checking I've not missed anything obvious here.