### PR TITLE
Additional cython compiler directives.

### DIFF
--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -331,9 +331,9 @@ cdef class ControlCurveIndexParameter(IndexParameter):
 
     @classmethod
     def load(cls, model, data):
-        storage_node = model._get_node_from_ref(model, data["storage_node"])
-        control_curves = [load_parameter(model, data) for data in data["control_curves"]]
-        return cls(model, storage_node, control_curves)
+        storage_node = model._get_node_from_ref(model, data.pop("storage_node"))
+        control_curves = [load_parameter(model, d) for d in data.pop("control_curves")]
+        return cls(model, storage_node, control_curves, **data)
 ControlCurveIndexParameter.register()
 
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ if '--enable-trace' in sys.argv:
     print('Tracing is enabled.')
     compiler_directives['linetrace'] = True
     define_macros.append(('CYTHON_TRACE', '1'))
+    define_macros.append(('CYTHON_TRACE_NOGIL', '1'))
     sys.argv.remove('--enable-trace')
 
 compile_time_env = {}
@@ -85,6 +86,11 @@ if '--enable-debug' in sys.argv:
     sys.argv.remove('--enable-debug')
 else:
     compile_time_env['SOLVER_DEBUG'] = False
+
+# See the following documentation for a description of these directives
+#  https://cython.readthedocs.io/en/latest/src/reference/compilation.html#compiler-directives
+compiler_directives['language_level'] = 3
+compiler_directives['embedsignature'] = True
 
 
 extensions = [


### PR DESCRIPTION
See [here](https://cython.readthedocs.io/en/latest/src/reference/compilation.html#compiler-directives).

Turns on:
 - `language_level=3`
 - `embedsignature=True`
 - `CYTHON_TRACE_NOGIL=1` when profiling is enabled.

I've not turned `binding` on. I'm not sure if it has a performance penalty. 

When experimenting with these there was a test failure in `ControlCurveIndexParameter` that highlighted some dodgy local scoping. I've fixed that too.
