### PR TITLE
Removed finally caluse in _cached property of BaseOptimisationWrapper

### DIFF
--- a/pywr/optimisation/__init__.py
+++ b/pywr/optimisation/__init__.py
@@ -72,8 +72,7 @@ class BaseOptimisationWrapper(object):
             cache.objectives = cache_objectives(model)
             cache.constraints = cache_constraints(model)
             MODEL_CACHE[self.uid] = cache
-        finally:
-            return cache
+        return cache
 
     @property
     def model(self):

--- a/pywr/optimisation/__init__.py
+++ b/pywr/optimisation/__init__.py
@@ -50,11 +50,15 @@ MODEL_CACHE = {}
 class BaseOptimisationWrapper(object):
     """ A helper class for running pywr optimisations with platypus.
     """
-
     def __init__(self, pywr_model_json, *args, **kwargs):
+        uid = kwargs.pop('uid', None)
         super(BaseOptimisationWrapper, self).__init__(*args, **kwargs)
         self.pywr_model_json = pywr_model_json
-        self.uid = uuid.uuid4()  # Create a unique ID for caching.
+
+        if uid is None:
+            uid = uuid.uuid4().hex  # Create a unique ID for caching.
+        self.uid = uid
+        self.run_stats = None
 
     # The following properties enable attribute caching when repeat execution of the same model is undertaken.
     @property

--- a/pywr/optimisation/platypus.py
+++ b/pywr/optimisation/platypus.py
@@ -28,6 +28,7 @@ class PlatypusWrapper(BaseOptimisationWrapper):
 
         self.problem = platypus.Problem(variable_map[-1], len(objectives), len(constraints))
         self.problem.function = self.evaluate
+        self.problem.wrapper = self
 
         # Setup the problem; subclasses can change this behaviour
         self._make_variables(variables)


### PR DESCRIPTION
There are instances where the `cache` variable might not be assigned. Best to remove the finally clause entirely.