### PR TITLE
Skip test_notebook if missing optional dependencies

### DIFF
--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -9,6 +9,7 @@ from pywr.core import Model, Input, Output, Link, Storage, StorageInput, Storage
 from pywr.nodes import NodeMeta
 from pywr._component import Component
 import pywr.domains
+from pywr.parameters._parameters import get_parameter_from_registry
 
 from .figures import *
 
@@ -22,7 +23,7 @@ with open(os.path.join(folder, "graph.css"), "r") as f:
 def pywr_model_to_d3_json(model, attributes=False):
     """
     Convert a Pywr graph to a structure d3 can display
-    
+
     Parameters
     ----------
     model : `pywr.core.Model`
@@ -74,10 +75,10 @@ def pywr_model_to_d3_json(model, attributes=False):
             node["position"] = node.position["schematic"]
         except KeyError:
             pass
-    
+
         if attributes:
             node_dict["attributes"] = get_node_attr(node)
-        
+
         json_nodes.append(node_dict)
 
     graph = {
@@ -93,30 +94,30 @@ def get_node_attr(node):
 
     Parameters
     ----------
-    node : a pywr node object 
+    node : a pywr node object
     """
     attrs = inspect.getmembers(node, lambda a:not(inspect.isroutine(a)))
     attribute_data = []
     for att in attrs:
-        
+
         attr_name, attr_val = att
         if attr_name.startswith("_"):
             continue
-        attr_type = type(attr_val).__name__ 
-        
+        attr_type = type(attr_val).__name__
+
         attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
                          "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
                          "fully_qualified_name", "allow_isolated"]
         if not attr_val or attr_name.lower() in attrs_to_skip:
-            continue    
-        
-        if isinstance(attr_val, Component): 
+            continue
+
+        if isinstance(attr_val, Component):
             attr_val = attr_val.name
             if not attr_val:
                 attr_val = attr_type
             else:
                 attr_val = attr_val + " - " + attr_type
-     
+
         if isinstance(attr_val, list):
             new_vals = []
             for val in attr_val:
@@ -131,6 +132,7 @@ def get_node_attr(node):
 
     return attribute_data
 
+
 def pywr_json_to_d3_json(model, attributes=False):
     """
     Converts a JSON file or a JSON-derived dict into structure that d3js can use.
@@ -138,9 +140,9 @@ def pywr_json_to_d3_json(model, attributes=False):
     Parameters
     ----------
     model : dict or str
-        str inputs should be a path to a json file containing the model. 
+        str inputs should be a path to a json file containing the model.
     """
-   
+
     if isinstance(model, str):
         with open(model) as d:
             model = json.load(d)
@@ -169,19 +171,19 @@ def pywr_json_to_d3_json(model, attributes=False):
 
                 if name == "type":
                     continue
-                
+
                 attr_val = val
 
                 if isinstance(val, dict):
                     try:
-                        attr_val = val["type"] + " parameter"
+                        attr_val = get_parameter_from_registry(val["type"]).__name__
                     except KeyError:
                         pass
                 elif val in model["parameters"].keys():
                     param = model["parameters"][val]
-                    attr_type = param["type"] + " parameter"
+                    attr_type = get_parameter_from_registry(param["type"]).__name__
                     attr_val = attr_val + " - " + attr_type
-  
+
                 attr_dict = {"attribute": name, "value": attr_val}
                 json_node["attributes"].append(attr_dict)
 
@@ -227,7 +229,7 @@ def draw_graph(model, width=500, height=400, labels=False, attributes=False, css
         If True, each graph node is labelled with its name. If false, the node names are displayed
         during mouseover events
     attributes : bool
-        If True, a table of node attributes is displayed during mouseover events 
+        If True, a table of node attributes is displayed during mouseover events
     css : string
         Stylesheet data to use instead of default
     """
@@ -256,4 +258,4 @@ def _draw_graph(model, width=500, height=400, labels=False, attributes=False, cs
         ),
         lib="http://d3js.org/d3.v3.min.js",
     )
-    return js 
+    return js

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -1382,6 +1382,22 @@ cdef class DeficitParameter(Parameter):
 DeficitParameter.register()
 
 
+def get_parameter_from_registry(parameter_type):
+    key = parameter_type.lower()
+    try:
+        return parameter_registry[key]
+    except KeyError:
+        pass
+    if key.endswith("parameter"):
+        key.replace("parameter", "")
+    else:
+        key = key + "parameter"
+    try:
+        return parameter_registry[key]
+    except KeyError:
+        raise TypeError('Unknown parameter type: "{}"'.format(parameter_type))
+
+
 def load_parameter(model, data, parameter_name=None):
     """Load a parameter from a dict"""
     if isinstance(data, basestring):
@@ -1413,18 +1429,7 @@ def load_parameter(model, data, parameter_name=None):
         except:
             pass
 
-        name = parameter_type.lower()
-        try:
-            cls = parameter_registry[name]
-        except KeyError:
-            if name.endswith("parameter"):
-                name = name.replace("parameter", "")
-            else:
-                name += "parameter"
-            try:
-                cls = parameter_registry[name]
-            except KeyError:
-                raise TypeError('Unknown parameter type: "{}"'.format(parameter_type))
+        cls = get_parameter_from_registry(parameter_type)
 
         kwargs = dict([(k,v) for k,v in data.items()])
         del(kwargs["type"])

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,46 +1,50 @@
-import os
-from pywr.notebook import pywr_model_to_d3_json, pywr_json_to_d3_json
+import pytest
+
+try:
+    import IPython
+    import jinja2
+    import matplotlib
+    matplotlib.use("tkagg")
+except ImportError:
+    pytestmark = pytest.mark.skip("IPython + jinja2 + matplotlib required to test pywr.notebook")
+else:
+    from pywr.notebook import pywr_model_to_d3_json, pywr_json_to_d3_json
 from pywr.model import Model
+import os
+
+from helpers import load_model
+
 
 def get_node(nodes, name):
     for node in nodes:
         if node["name"] == name:
             return node
 
+
 def get_node_attribute(node, attr_name):
     for attr in node["attributes"]:
         if attr["attribute"] == attr_name:
-            return attr 
+            return attr
 
-def test_from_model():
 
-    json_path = os.path.join(os.path.dirname(__file__), "models", "river1.json")
-    model = Model.load(json_path)
-    json_dict = pywr_model_to_d3_json(model, attributes=True)
-
-    assert "nodes" in json_dict.keys()
-    assert "links" in json_dict.keys()
-
-    node_names = ["catchment1", "river1", "abs1", "link1", "term1", "demand1"]
-    for node in json_dict["nodes"]:
-        assert node["name"] in node_names
-
-    catchment = get_node(json_dict["nodes"], "catchment1")
-    catchment_max_flow = get_node_attribute(catchment, "max_flow")
-    assert catchment_max_flow["value"] == "5.0"
-    
-def test_from_json():
-
+@pytest.mark.parametrize("from_json", [True, False])
+def test_from_json(from_json):
     json_path = os.path.join(os.path.dirname(__file__), "models", "demand_saving2_with_variables.json")
-    json_dict = pywr_json_to_d3_json(json_path, attributes=True)
-    
+
+    if from_json:
+        json_dict = pywr_json_to_d3_json(json_path, attributes=True)
+    else:
+        model = load_model("demand_saving2_with_variables.json")
+        json_dict = pywr_model_to_d3_json(model, attributes=True)
+
     assert "nodes" in json_dict.keys()
     assert "links" in json_dict.keys()
-        
+
     node_names = ["Inflow", "Reservoir", "Demand", "Spill"]
     for node in json_dict["nodes"]:
         assert node["name"] in node_names
 
     demand = get_node(json_dict["nodes"], "Demand")
     demand_max_flow = get_node_attribute(demand, "max_flow")
-    assert demand_max_flow["value"] == "demand_max_flow - aggregated parameter"
+
+    assert demand_max_flow["value"] == "demand_max_flow - AggregatedParameter"


### PR DESCRIPTION
* Skip test_notebook if missing optional dependencies
* Use tkagg backend for matplotlib in tests - I was getting errors otherwise because my default backend (osx) doens't actually work with the way I've installed Python.
* New function `get_parameter_from_registry`.

Closes #624.

I'm wondering if accepting both `"type": "constant"` and `"type": "constantparameter"` is actually a bad code smell and we should require it one way or the other. Perhaps this should be defined as an attribute on `Parameter`, e.g.:

```python
class ConstantParameter(Parameter):
    __name__ = "constant"
    ...
```

That's another issue/PR though.