### PR TITLE
Updated url in setup.py metadata to GitHub project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup_kwargs = {
     'long_description_content_type': 'text/x-rst',
     'author': 'Joshua Arnott',
     'author_email': 'josh@snorfalorpagus.net',
-    'url': 'http://snorf.net/pywr/',
+    'url': 'https://github.com/pywr/pywr',
     'packages': ['pywr', 'pywr.solvers', 'pywr.domains', 'pywr.parameters', 'pywr.recorders', 'pywr.notebook', 'pywr.optimisation'],
     'use_scm_version': True,
     'setup_requires': ['setuptools_scm'],


### PR DESCRIPTION
This has become significant as we're publishing to PyPI now, which includes a link to the URL as defined in the setup.py metadata. The current URL doesn't actually resolve. I think it's quite normal to just use the GitHub project for this.