### PR TITLE
Add area recorder

### DIFF
--- a/docs/source/api/pywr.recorders.rst
+++ b/docs/source/api/pywr.recorders.rst
@@ -30,6 +30,7 @@ accessed following a model run before the model instances is destroyed.
    NumpyArrayNodeRecorder
    NumpyArrayStorageRecorder
    NumpyArrayLevelRecorder
+   NumpyArrayAreaRecorder
    NumpyArrayParameterRecorder
    NumpyArrayIndexParameterRecorder
 

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -48,6 +48,10 @@ cdef class NumpyArrayLevelRecorder(StorageRecorder):
     cdef public Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
+cdef class NumpyArrayAreaRecorder(StorageRecorder):
+    cdef public Aggregator _temporal_aggregator
+    cdef double[:, :] _data
+
 cdef class NumpyArrayParameterRecorder(ParameterRecorder):
     cdef public Aggregator _temporal_aggregator
     cdef double[:, :] _data

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -1,5 +1,5 @@
 from pywr._component cimport Component
-from pywr._core cimport Timestep, AbstractNode, AbstractStorage, ScenarioIndex, Scenario
+from pywr._core cimport Timestep, AbstractNode, AbstractStorage, Storage, ScenarioIndex, Scenario
 from pywr.parameters._parameters cimport Parameter, IndexParameter
 
 
@@ -39,18 +39,18 @@ cdef class NumpyArrayNodeRecorder(NodeRecorder):
     cdef Aggregator _temporal_aggregator
     cdef double[:, :] _data
 
-cdef class NumpyArrayStorageRecorder(StorageRecorder):
+cdef class NumpyArrayAbstractStorageRecorder(StorageRecorder):
     cdef public Aggregator _temporal_aggregator
+    cdef double[:, :] _data
+
+cdef class NumpyArrayStorageRecorder(NumpyArrayAbstractStorageRecorder):
     cdef public bint proportional
-    cdef double[:, :] _data
 
-cdef class NumpyArrayLevelRecorder(StorageRecorder):
-    cdef public Aggregator _temporal_aggregator
-    cdef double[:, :] _data
+cdef class NumpyArrayLevelRecorder(NumpyArrayAbstractStorageRecorder):
+    pass
 
-cdef class NumpyArrayAreaRecorder(StorageRecorder):
-    cdef public Aggregator _temporal_aggregator
-    cdef double[:, :] _data
+cdef class NumpyArrayAreaRecorder(NumpyArrayAbstractStorageRecorder):
+    pass
 
 cdef class NumpyArrayParameterRecorder(ParameterRecorder):
     cdef public Aggregator _temporal_aggregator

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -872,8 +872,31 @@ cdef class NumpyArrayLevelRecorder(StorageRecorder):
     property data:
         def __get__(self, ):
             return np.array(self._data)
-
 NumpyArrayLevelRecorder.register()
+
+cdef class NumpyArrayAreaRecorder(StorageRecorder):
+
+    cpdef setup(self):
+        cdef int ncomb = len(self.model.scenarios.combinations)
+        cdef int nts = len(self.model.timestepper)
+        self._data = np.zeros((nts, ncomb))
+
+    cpdef reset(self):
+        self._data[:, :] = 0.0
+
+    cpdef after(self):
+        cdef int i
+        cdef ScenarioIndex scenario_index
+        cdef Timestep ts = self.model.timestepper.current
+        for i, scenario_index in enumerate(self.model.scenarios.combinations):
+            self._data[ts._index,i] = self._node.get_area(scenario_index)
+        return 0
+
+    property data:
+        def __get__(self, ):
+            return np.array(self._data)
+
+NumpyArrayAreaRecorder.register()
 
 cdef class NumpyArrayParameterRecorder(ParameterRecorder):
     """Recorder for timeseries information from a `Parameter`.

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -13,7 +13,7 @@ import tables
 import json
 from numpy.testing import assert_allclose, assert_equal
 from fixtures import simple_linear_model, simple_storage_model
-from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayAreaRecorder,
+from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayAreaRecorder, NumpyArrayLevelRecorder,
                             AggregatedRecorder, CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder,
                             TotalFlowNodeRecorder, RollingMeanFlowNodeRecorder, MeanFlowNodeRecorder, NumpyArrayParameterRecorder,
                             NumpyArrayIndexParameterRecorder, RollingWindowParameterRecorder, AnnualCountIndexParameterRecorder,
@@ -261,6 +261,26 @@ def test_numpy_storage_recorder(simple_storage_model, proportional):
     assert_allclose(df.values, expected, atol=1e-7)
 
 
+def test_numpy_array_level_recorder(simple_storage_model):
+    model = simple_storage_model
+
+    storage = model.nodes["Storage"]
+    level_param = InterpolatedVolumeParameter(model, storage, [0, 20], [0, 100])
+    storage.level = level_param
+    level_rec = NumpyArrayLevelRecorder(model, storage, temporal_agg_func='min')
+
+    model.run()
+
+    expected = np.array([[50, 35, 20, 5, 0]]).T
+    assert_allclose(level_rec.data, expected, atol=1e-7)
+
+    df = level_rec.to_dataframe()
+    assert df.shape == (5, 1)
+    assert_allclose(df.values, expected, atol=1e-7)
+
+    assert_allclose(level_rec.aggregated_value(), np.min(expected))
+
+
 def test_numpy_array_area_recorder(simple_storage_model):
 
     model = simple_storage_model
@@ -268,12 +288,18 @@ def test_numpy_array_area_recorder(simple_storage_model):
     storage = model.nodes["Storage"]
     area_param = InterpolatedVolumeParameter(model, storage, [0, 20], [0, 100])
     storage.area = area_param
-    area_rec = NumpyArrayAreaRecorder(model, storage)
+    area_rec = NumpyArrayAreaRecorder(model, storage, temporal_agg_func='min')
     
     model.run()
 
-    expected = np.array([[35, 20, 5, 0, 0]]).T
+    expected = np.array([[50, 35, 20, 5, 0]]).T
     assert_allclose(area_rec.data, expected, atol=1e-7)
+
+    df = area_rec.to_dataframe()
+    assert df.shape == (5, 1)
+    assert_allclose(df.values, expected, atol=1e-7)
+
+    assert_allclose(area_rec.aggregated_value(), np.min(expected))
 
 
 def test_numpy_parameter_recorder(simple_linear_model):

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -13,7 +13,7 @@ import tables
 import json
 from numpy.testing import assert_allclose, assert_equal
 from fixtures import simple_linear_model, simple_storage_model
-from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
+from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder, NumpyArrayAreaRecorder,
                             AggregatedRecorder, CSVRecorder, TablesRecorder, TotalDeficitNodeRecorder,
                             TotalFlowNodeRecorder, RollingMeanFlowNodeRecorder, MeanFlowNodeRecorder, NumpyArrayParameterRecorder,
                             NumpyArrayIndexParameterRecorder, RollingWindowParameterRecorder, AnnualCountIndexParameterRecorder,
@@ -27,7 +27,8 @@ from pywr.recorders import (NumpyArrayNodeRecorder, NumpyArrayStorageRecorder,
 
 from pywr.recorders.progress import ProgressRecorder
 
-from pywr.parameters import DailyProfileParameter, FunctionParameter, ArrayIndexedParameter, ConstantParameter
+from pywr.parameters import (DailyProfileParameter, FunctionParameter, ArrayIndexedParameter, ConstantParameter,
+                             InterpolatedVolumeParameter)
 from helpers import load_model
 import os
 import sys
@@ -258,6 +259,21 @@ def test_numpy_storage_recorder(simple_storage_model, proportional):
     df = rec.to_dataframe()
     assert df.shape == (5, 1)
     assert_allclose(df.values, expected, atol=1e-7)
+
+
+def test_numpy_array_area_recorder(simple_storage_model):
+
+    model = simple_storage_model
+
+    storage = model.nodes["Storage"]
+    area_param = InterpolatedVolumeParameter(model, storage, [0, 20], [0, 100])
+    storage.area = area_param
+    area_rec = NumpyArrayAreaRecorder(model, storage)
+    
+    model.run()
+
+    expected = np.array([[35, 20, 5, 0, 0]]).T
+    assert_allclose(area_rec.data, expected, atol=1e-7)
 
 
 def test_numpy_parameter_recorder(simple_linear_model):


### PR DESCRIPTION
some work on #669 

Currently the area stored by the recorder is calculated using reservoir volume from the previous timestep. I think this is because the `get_area` method of the storage node calls `get_value` on the area parameter which returns the area value calculated in `calc_values`, which is calculated before the reservoir volume is updated for the current timestep.

I’m not sure if this is desirable behavior or not. Changing the `get_area` method so that it calls `value` rather than `get_value` seems to work in terms of recording the area of the current timestep. Should I make this change? 
