### PR TITLE
Refactor of named parameter/recorder loading

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -8,6 +8,7 @@ from packaging.version import parse as parse_version
 import warnings
 import inspect
 import time
+from functools import wraps
 import logging
 logger = logging.getLogger(__name__)
 
@@ -349,39 +350,29 @@ class Model(object):
             nodes_to_load[node_name] = node_data
         model._nodes_to_load = nodes_to_load
 
-        # collect parameters to load
-        try:
-            parameters_to_load = data["parameters"]
-        except KeyError:
-            parameters_to_load = {}
-        else:
-            for key, value in parameters_to_load.items():
-                if isinstance(value, dict):
-                    parameters_to_load[key]["name"] = key
-        model._parameters_to_load = parameters_to_load
+        def collect_components(data, key):
+            components_data = data.get(key, {})
+            for name, component_data in components_data.items():
+                component_data["name"] = name
+            return components_data
 
-        # collect recorders to load
-        try:
-            recorders_to_load = data["recorders"]
-        except KeyError:
-            recorders_to_load = {}
-        else:
-            for key, value in recorders_to_load.items():
-                if isinstance(value, dict):
-                    recorders_to_load[key]["name"] = key
-        model._recorders_to_load = recorders_to_load
+        model._parameters_to_load = collect_components(data, "parameters")
+        model._recorders_to_load = collect_components(data, "recorders")
 
-        # load parameters and recorders
-        for name, rdata in model._recorders_to_load.items():
-            load_recorder(model, rdata)
-        while True:
-            try:
-                name, pdata = model._parameters_to_load.popitem()
-            except KeyError:
-                break
-            parameter = load_parameter(model, pdata, name)
+        @listify
+        def load_components(components_to_load, load_component):
+            while True:
+                try:
+                    name, component_data = components_to_load.popitem()
+                except KeyError:
+                    break
+                component = load_component(model, component_data, name)
+                yield component
+
+        load_components(model._recorders_to_load, load_recorder)
+        for parameter in load_components(model._parameters_to_load, load_parameter):
             if not isinstance(parameter, BaseParameter):
-                raise TypeError("Named parameters cannot be literal values. Use type \"constant\" instead.")
+                raise TypeError("Named parameters cannot be literal values. Use type `constant` instead.")
 
         # load the remaining nodes
         for node_name in list(nodes_to_load.keys()):
@@ -894,3 +885,10 @@ class ModelResult(object):
 
     def _repr_html_(self):
         return self.to_dataframe()._repr_html_()
+
+
+def listify(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return list(f(*args, **kwargs))
+    return wrapper

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -282,9 +282,8 @@ cdef class AggregatedRecorder(Recorder):
 
     @classmethod
     def load(cls, model, data):
-        recorder_names = data["recorders"]
-        recorders = [model.recorders[name] for name in recorder_names]
-        del(data["recorders"])
+        recorder_names = data.pop("recorders")
+        recorders = [load_recorder(model, name) for name in recorder_names]
         rec = cls(model, recorders, **data)
 
 AggregatedRecorder.register()

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1406,13 +1406,11 @@ cdef class AnnualCountIndexParameterRecorder(IndexParameterRecorder):
 AnnualCountIndexParameterRecorder.register()
 
 
-def load_recorder(model, data):
+def load_recorder(model, data, recorder_name=None):
     recorder = None
 
     if isinstance(data, basestring):
         recorder_name = data
-    else:
-        recorder_name = None
 
     # check if recorder has already been loaded
     for rec in model.recorders:
@@ -1426,7 +1424,7 @@ def load_recorder(model, data):
             # we're still in the process of loading data from JSON and
             # the parameter requested hasn't been loaded yet - do it now
             try:
-                data = model._recorders_to_load[recorder_name]
+                data = model._recorders_to_load.pop(recorder_name)
             except KeyError:
                 raise KeyError("Unknown recorder: '{}'".format(data))
             recorder = load_recorder(model, data)


### PR DESCRIPTION
Refactor of the code used to load named parameters and recorders to use shared functions (as they are both components).

Closes #674.