### PR TITLE
Use flow instead of max_flow in two_reservoirs

### DIFF
--- a/examples/two_reservoir.json
+++ b/examples/two_reservoir.json
@@ -13,12 +13,12 @@
         {
             "name": "catchment1",
             "type": "catchment",
-            "max_flow": "inflow"
+            "flow": "inflow"
         },
         {
             "name": "catchment2",
             "type": "catchment",
-            "max_flow": "inflow"
+            "flow": "inflow"
         },
         {
             "name": "reservoir1",

--- a/tests/models/two_reservoir.json
+++ b/tests/models/two_reservoir.json
@@ -13,12 +13,12 @@
         {
             "name": "catchment1",
             "type": "catchment",
-            "max_flow": "inflow"
+            "flow": "inflow"
         },
         {
             "name": "catchment2",
             "type": "catchment",
-            "max_flow": "inflow"
+            "flow": "inflow"
         },
         {
             "name": "reservoir1",


### PR DESCRIPTION
The existing code worked because of the costs in the model, but strictly the catchments should use `flow` instead of `max_flow`.

Closes #666.