### PR TITLE
Fix loading PiecewiseLink with parameters from JSON.

### DIFF
--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -146,6 +146,14 @@ class RiverSplit(MultiSplitLink):
 
         super(RiverSplit, self).__init__(*args, **kwargs)
 
+    @classmethod
+    def load(cls, data, model):
+        max_flow = load_parameter(model, data.pop('max_flow', None))
+        cost = load_parameter(model, data.pop('cost', 0.0))
+
+        del(data["type"])
+        return cls(model, max_flow=max_flow, cost=cost, **data)
+
 
 class RiverSplitWithGauge(RiverSplit):
     """A split in the river network with a minimum residual flow

--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -612,21 +612,12 @@ class PiecewiseLink(Node):
 
     @classmethod
     def load(cls, data, model):
-        # accept plurals of max_flow and cost
-        try:
-            max_flow = data.pop("max_flows")
-        except KeyError:
-            pass
-        else:
-            data["max_flow"] = [load_parameter(p) for p in max_flow]
-        try:
-            cost = data.pop("costs")
-        except KeyError:
-            pass
-        else:
-            data["cost"] = [load_parameter(p) for p in cost]
+        # max_flow and cost should be lists of parameter definitions
+        max_flow = [load_parameter(model, p) for p in data.pop('max_flow')]
+        cost = [load_parameter(model, p) for p in data.pop('cost')]
+
         del(data["type"])
-        return cls(model, **data)
+        return cls(model, max_flow=max_flow, cost=cost, **data)
 
 
 class MultiSplitLink(PiecewiseLink):

--- a/tests/models/piecewise1_with_parameters.json
+++ b/tests/models/piecewise1_with_parameters.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "title": "Piecewise link with parameters",
+        "description": "Example of a piecewise link that uses parameters",
+        "minimum_version": "1.2.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100
+        },
+        {
+            "name": "link1",
+            "type": "piecewiselink",
+            "cost": ["cost1", "cost2"],
+            "max_flow": ["max_flow1", null]
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 50,
+            "cost": 0.0
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "cost1": {
+            "type": "constant",
+            "value": -10.0
+        },
+        "cost2": {
+            "type": "constant",
+            "value": 5.0
+        },
+        "max_flow1": {
+            "type": "constant",
+            "value": 20.0
+        }
+    }
+}

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -1,13 +1,10 @@
-
-from __future__ import print_function
 import pywr.core
 from pywr.parameters import ConstantParameter
-import datetime
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
-
 from helpers import assert_model, load_model
+
 
 @pytest.fixture(params=[(10.0, 10.0, 10.0), (5.0, 5.0, 1.0)])
 def simple_piecewise_model(request):
@@ -28,9 +25,6 @@ def simple_piecewise_model(request):
     otpt = pywr.core.Output(model, name="Output", min_flow=out_flow, cost=-benefit)
     lnk.connect(otpt)
 
-    default = inpt.domain
-
-
     expected_sent = in_flow if benefit > 1.0 else out_flow
 
     expected_node_results = {
@@ -45,6 +39,7 @@ def simple_piecewise_model(request):
 
 def test_piecewise_model(simple_piecewise_model):
     assert_model(*simple_piecewise_model)
+
 
 def test_piecewise_json():
     """Test loading of a piecewise link from JSON"""

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -1,6 +1,7 @@
 
 from __future__ import print_function
 import pywr.core
+from pywr.parameters import ConstantParameter
 import datetime
 import numpy as np
 from numpy.testing import assert_allclose
@@ -54,4 +55,19 @@ def test_piecewise_json():
     assert_allclose(max_flows, [20, np.inf])
     assert_allclose(costs, [-10, 5])
     model.run()
+    assert_allclose(model.nodes["demand1"].flow, 20)
+
+
+def test_piecewise_with_parameters_json():
+    """Test using parameters with piecewise link."""
+    model = load_model("piecewise1_with_parameters.json")
+    sublinks = model.nodes["link1"].sublinks
+
+    assert isinstance(sublinks[0].max_flow, ConstantParameter)
+    assert np.isinf(sublinks[1].max_flow)
+    assert isinstance(sublinks[0].cost, ConstantParameter)
+    assert isinstance(sublinks[1].cost, ConstantParameter)
+
+    model.run()
+
     assert_allclose(model.nodes["demand1"].flow, 20)


### PR DESCRIPTION
The load method on PiecewiseLink was broken when given parameters. It was also a little ambiguous regarding the use of 'max_flow' or 'max_flows', and 'cost' or 'costs'. This is now made explicit to use the singular case. That is consistent with the init methods of the class. Plural keys are no longer supported.

Add a test for loading parameters on to PiecewiseLink sublinks.

Fixes #748 