### PR TITLE
Allow use of parameters as values in ControlCurveInterpolatedParameter

### DIFF
--- a/pywr/parameters/_control_curves.pxd
+++ b/pywr/parameters/_control_curves.pxd
@@ -19,6 +19,7 @@ cdef class BaseControlCurveParameter(Parameter):
 
 cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     cdef double[:] _values
+    cdef public list parameters
 
 cdef class ControlCurveIndexParameter(IndexParameter):
     cdef public AbstractStorage storage_node

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -246,19 +246,23 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
         # return the interpolated value for the current level.
         cdef double current_pc = node._current_pc[scenario_index.global_id]
         cdef double weight
-        cdef double[:] values
+        cdef double[:] values  # y values to interpolate between in this time-step
 
         if self.parameters is not None:
+            # If there are parameter use them to gather the interpolation values
             values = np.empty(len(self.parameters))
             for j, value_param in enumerate(self.parameters):
                 values[j] = value_param.get_value(scenario_index)
         else:
+            # Otherwise use the given array of floats.
             # This makes a reference rather than a copy.
             values = self._values
 
+        # Bounds check the current pc storage.
+        # Always return the first value if storage above 100% or NaN
         if current_pc > 1.0 or npy_isnan(current_pc):
             return values[0]
-
+        # Always return last value is storage less than 0%
         if current_pc < 0.0:
             return values[-1]
 

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -183,6 +183,9 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     values : list of float
         A list of values to return corresponding to the control curves. The
         length of the list should be 2 + len(control_curves).
+    parameters : iterable `Parameter` objects or `None`, optional
+        If `values` is `None` then `parameters` can specify a `Parameter` object to use at each
+        of the control curves. The number of parameters should be 2 + len(control_curves)
 
     Examples
     --------
@@ -205,14 +208,27 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     >>> cost = ControlCurveInterpolatedParameter(storage_node, ccs, values)
     >>> storage_node.cost = cost
     """
-    def __init__(self, model, storage_node, control_curves, values):
-        super(ControlCurveInterpolatedParameter, self).__init__(model, storage_node, control_curves)
+    def __init__(self, model, storage_node, control_curves, values=None, parameters=None, **kwargs):
+        super(ControlCurveInterpolatedParameter, self).__init__(model, storage_node, control_curves, **kwargs)
         # Expected number of values is number of control curves plus two.
         nvalues = len(self.control_curves) + 2
-        if len(values) != nvalues:
-            raise ValueError('Length of values should be two more than the number of '
-                             'control curves ({}).'.format(nvalues))
-        self.values = values
+        self.parameters = None
+
+        if values is not None:
+            if len(values) != nvalues:
+                raise ValueError('Length of values should be two more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self.values = np.asarray(values)
+
+        elif parameters is not None:
+            if len(parameters) != nvalues:
+                raise ValueError('Length of parameters should be two more than the number of '
+                                 'control curves ({}).'.format(nvalues))
+            self.parameters = list(parameters)
+            for p in self.parameters:
+                p.parents.add(self)
+        else:
+            raise ValueError('One of values or parameters keywords must be given.')
 
     property values:
         def __get__(self):
@@ -223,18 +239,27 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         cdef int i = scenario_index.global_id
         cdef int j
-        cdef Parameter cc_param
+        cdef Parameter cc_param, value_param
         cdef double cc, cc_prev
         cdef Storage node = self._storage_node
         # return the interpolated value for the current level.
         cdef double current_pc = node._current_pc[i]
         cdef double weight
+        cdef double[:] values
+
+        if self.parameters is not None:
+            values = np.empty(len(self.parameters))
+            for i, value_param in enumerate(self.parameters):
+                values[i] = value_param.get_value(scenario_index)
+        else:
+            # This makes a reference rather than a copy.
+            values = self._values
 
         if current_pc > 1.0 or npy_isnan(current_pc):
-            return self._values[0]
+            return values[0]
 
         if current_pc < 0.0:
-            return self._values[-1]
+            return values[-1]
 
         # Assumes control_curves is sorted highest to lowest
         # First level 100%
@@ -247,8 +272,8 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
                     weight = (current_pc - cc) / (cc_prev - cc)
                 except ZeroDivisionError:
                     # Last two control curves identical; return the next value
-                    return self._values[j+1]
-                return self._values[j]*weight + self._values[j+1]*(1.0 - weight)
+                    return values[j+1]
+                return values[j]*weight + values[j+1]*(1.0 - weight)
             # Update previous value for next iteration
             cc_prev = cc
 
@@ -259,16 +284,20 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
             weight = (current_pc - cc) / (cc_prev - cc)
         except ZeroDivisionError:
             # cc_prev == cc  i.e. last control curve is close to 0%
-            return self._values[-2]
-        return self._values[-2]*weight + self._values[-1]*(1.0 - weight)
+            return values[-2]
+        return values[-2]*weight + values[-1]*(1.0 - weight)
 
     @classmethod
     def load(cls, model, data):
         control_curves = super(ControlCurveInterpolatedParameter, cls)._load_control_curves(model, data)
         storage_node = super(ControlCurveInterpolatedParameter, cls)._load_storage_node(model, data)
-        values = load_parameter_values(model, data)
-        parameter = cls(model, storage_node, control_curves, values)
-        return parameter
+        if "parameters" in data:
+            parameters = [load_parameter(model, p) for p in data.pop("parameters")]
+            values = None
+        else:
+            values = load_parameter_values(model, data)
+            parameters = None
+        return cls(model, storage_node, control_curves, values=values, parameters=parameters)
 
 ControlCurveInterpolatedParameter.register()
 

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -225,6 +225,8 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
                 raise ValueError('Length of parameters should be two more than the number of '
                                  'control curves ({}).'.format(nvalues))
             self.parameters = list(parameters)
+            # Make sure these parameters depend on this parameter to ensure they are evaluated
+            # in the correct order.
             for p in self.parameters:
                 p.parents.add(self)
         else:
@@ -427,6 +429,8 @@ cdef class ControlCurveParameter(BaseControlCurveParameter):
                 raise ValueError('Length of parameters should be one more than the number of '
                                  'control curves ({}).'.format(nvalues))
             self.parameters = list(parameters)
+            # Make sure these parameters depend on this parameter to ensure they are evaluated
+            # in the correct order.
             for p in self.parameters:
                 p.parents.add(self)
         else:

--- a/pywr/parameters/_control_curves.pyx
+++ b/pywr/parameters/_control_curves.pyx
@@ -237,20 +237,19 @@ cdef class ControlCurveInterpolatedParameter(BaseControlCurveParameter):
             self._values = np.array(values)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef int i = scenario_index.global_id
         cdef int j
         cdef Parameter cc_param, value_param
         cdef double cc, cc_prev
         cdef Storage node = self._storage_node
         # return the interpolated value for the current level.
-        cdef double current_pc = node._current_pc[i]
+        cdef double current_pc = node._current_pc[scenario_index.global_id]
         cdef double weight
         cdef double[:] values
 
         if self.parameters is not None:
             values = np.empty(len(self.parameters))
-            for i, value_param in enumerate(self.parameters):
-                values[i] = value_param.get_value(scenario_index)
+            for j, value_param in enumerate(self.parameters):
+                values[j] = value_param.get_value(scenario_index)
         else:
             # This makes a reference rather than a copy.
             values = self._values

--- a/tests/models/reservoir_with_cc_param_values.json
+++ b/tests/models/reservoir_with_cc_param_values.json
@@ -1,0 +1,45 @@
+{
+    "metadata": {
+        "title": "Reservoir with cc",
+        "description": "A model with a reservoir and control curve",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "reservoir1",
+            "type": "Storage",
+            "max_volume": 1000,
+            "initial_volume": 1000,
+            "outputs": 0,
+            "cost": {
+                "type": "ControlCurveInterpolated",
+                "control_curve": {
+                    "type": "dailyprofile",
+                    "url": "control_curve.csv",
+                    "parse_dates": false,
+                    "column": "Control Curve"
+                },
+                "storage_node": "reservoir1",
+                "parameters": [
+                    {"type": "constant", "value":  -8},
+                    {"type": "constant", "value":  -6},
+                    {"type": "constant", "value":  -4}
+                ]
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 300,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["reservoir1", "demand1"]
+    ]
+}

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -283,7 +283,8 @@ class TestPiecewiseControlCurveParameter:
             m.run()
 
 
-def test_control_curve_interpolated(model):
+@pytest.mark.parametrize("use_parameters", [False, True])
+def test_control_curve_interpolated(model, use_parameters):
     m = model
     m.timestepper.delta = 200
 
@@ -293,7 +294,14 @@ def test_control_curve_interpolated(model):
 
     cc = ConstantParameter(model, 0.8)
     values = [20.0, 5.0, 0.0]
-    s.cost = p = ControlCurveInterpolatedParameter(model, s, cc, values)
+
+    if use_parameters:
+        # Create the parameter using parameters for the values
+        parameters = [ConstantParameter(model, v) for v in values]
+        s.cost = p = ControlCurveInterpolatedParameter(model, s, cc, parameters=parameters)
+    else:
+        # Create the parameter using a list of values
+        s.cost = p = ControlCurveInterpolatedParameter(model, s, cc, values)
 
     @assert_rec(model, p)
     def expected_func(timestep, scenario_index):
@@ -314,10 +322,14 @@ def test_control_curve_interpolated(model):
             model.run()
 
 
-def test_control_curve_interpolated_json():
+@pytest.mark.parametrize("use_parameters", [False, True])
+def test_control_curve_interpolated_json(use_parameters):
     # this is a little hack-y, as the parameters don't provide access to their
     # data once they've been initalised
-    model = load_model("reservoir_with_cc.json")
+    if use_parameters:
+        model = load_model("reservoir_with_cc_param_values.json")
+    else:
+        model = load_model("reservoir_with_cc.json")
     reservoir1 = model.nodes["reservoir1"]
     model.setup()
     path = os.path.join(os.path.dirname(__file__), "models", "control_curve.csv")


### PR DESCRIPTION
This copies the approach of ControlCurveParameter and allows the user
to provide either values as an iterable of floats or parameters as
an iterable of Parameter instances. Each parameter's value is used
during the calculation in the same way as the current list of values.

Tests extended to check this behaviour and support loading from JSON.