### PR TITLE
Remove GIT_VERSION.txt and pywr.__git_hash__

### DIFF
--- a/pywr/__init__.py
+++ b/pywr/__init__.py
@@ -11,17 +11,3 @@ except DistributionNotFound:
 if sys.platform == "win32":
     libdir = os.path.join(os.path.dirname(__file__), ".libs")
     os.environ["PATH"] = os.environ["PATH"] + ";" + libdir
-
-
-def get_git_hash():
-    """Get the git hash for this build, if available"""
-    try:
-        folder = os.path.dirname(os.path.abspath(__file__))
-        path = os.path.join(folder, "GIT_VERSION.txt")
-        with open(path, "r") as f:
-            data = f.read().rstrip()
-    except FileNotFoundError:
-        data = None
-    return data
-
-__git_hash__ = get_git_hash()

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -593,7 +593,6 @@ class Model(object):
             solver_name=self.solver.name,
             solver_stats=self.solver.stats,
             version=pywr.__version__,
-            git_hash=pywr.__git_hash__,
         )
         logger.info('Model run complete!')
         return result
@@ -853,7 +852,7 @@ class NamedIterator(object):
 
 class ModelResult(object):
     def __init__(self, num_scenarios, timestep, time_taken, time_taken_with_overhead, speed,
-                 solver_name, solver_stats, version, git_hash):
+                 solver_name, solver_stats, version):
         self.timestep = timestep
         self.timesteps = timestep.index + 1
         self.time_taken = time_taken
@@ -863,7 +862,6 @@ class ModelResult(object):
         self.solver_name = solver_name
         self.solver_stats = solver_stats
         self.version = version
-        self.git_hash = git_hash
 
     def to_dict(self):
         return {attr: value for attr, value in self.__dict__.items()}

--- a/setup.py
+++ b/setup.py
@@ -173,16 +173,6 @@ setup_kwargs['package_data'] = {
     'pywr.notebook': ['*.js', '*.css']
 }
 
-# store the current git hash in the module
-try:
-    git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).rstrip().decode("utf-8")
-except subprocess.CalledProcessError:
-    pass
-else:
-    with open("pywr/GIT_VERSION.txt", "w") as f:
-        f.write(git_hash + "\n")
-    setup_kwargs["package_data"]["pywr"] = ["GIT_VERSION.txt"]
-
 # build the core extension(s)
 setup_kwargs['ext_modules'] = cythonize(extensions + extensions_optional,
                                         compiler_directives=compiler_directives, annotate=annotate,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -49,7 +49,6 @@ def test_model_results():
     assert (isinstance(res, ModelResult))
     assert (res.timesteps == 365)
     assert (res.version == pywr.__version__)
-    assert (res.git_hash == pywr.__git_hash__)
     assert res.solver_stats['number_of_cols']
     assert res.solver_stats['number_of_rows']
     assert res.solver_name == model.solver.name


### PR DESCRIPTION
The git hash is part of the version number since we started using
setuptools_scm. This commit removes the generation of a separate
hash file GIT_VERSION.txt as part of setup.py

Fixes #739 and #751