### PR TITLE
WIP: Recover from GLPK errors using glp_error_hook/setjmp

### DIFF
--- a/pywr/solvers/glpk.pxi
+++ b/pywr/solvers/glpk.pxi
@@ -1,4 +1,5 @@
 from libc.float cimport DBL_MAX
+from libc.setjmp cimport longjmp, jmp_buf
 
 status_string = [
     None,
@@ -44,6 +45,14 @@ cdef int term_hook(void *info, const char *s):
     else:
         print(message)
     return 1
+
+
+class GLPKError(Exception):
+    pass
+
+
+cdef void error_hook(void *info):
+    longjmp((<jmp_buf*>info)[0], <int>1)
 
 
 cdef inline int constraint_type(double a, double b):
@@ -153,6 +162,7 @@ cdef extern from "glpk.h":
     int glp_get_status(glp_prob *P)
     int glp_term_out(int flag)
     void glp_term_hook(int (*func)(void *info, const char *s), void *info)
+    void glp_error_hook(void (*func)(void *info), void *info)
 
     double glp_get_row_prim(glp_prob *P, int i)
     double glp_get_col_prim(glp_prob *P, int j)

--- a/tests/models/aggregated1.json
+++ b/tests/models/aggregated1.json
@@ -20,6 +20,16 @@
             "max_flow": 50
         },
         {
+            "name": "C",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "X",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
             "name": "Z",
             "type": "output",
             "max_flow": 100,
@@ -28,15 +38,17 @@
         {
             "name": "agg",
             "type": "AggregatedNode",
-            "nodes": ["A", "B"],
-            "factors": [2.0, 4.0],
-            "flow_weights": [1.0, 1.0],
+            "nodes": ["A", "B", "C", "X"],
+            "factors": [1.0, 1.0, 1.0, 1.0],
+            "flow_weights": [1.0, 1.0, 1.0, 1.0],
             "max_flow": 30.0,
             "min_flow": 5.0
         }
     ],
     "edges": [
-        ["A", "Z"],
-        ["B", "Z"]
+        ["A", "X"],
+        ["X", "Z"],
+        ["B", "Z"],
+        ["C", "Z"]
     ]
 }

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -212,6 +212,7 @@ def test_aggregated_node_max_flow_same_route(model):
 
 def test_aggregated_constraint_json():
     model = load_model("aggregated1.json")
+    model.run()
 
     agg = model.nodes["agg"]
     assert(agg.nodes == [model.nodes["A"], model.nodes["B"]])


### PR DESCRIPTION
So far I've only done this for the non-edge GLPK solver, in the setup() method. I guess it should be used in solve() also. It seems to catch the error raised in #758.

Closes #759.