### PR TITLE
Add ScenarioWrapperParameter

### DIFF
--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -120,5 +120,6 @@ Other parameters
 
    AnnualHarmonicSeriesParameter
    DeficitParameter
+   ScenarioWrapperParameter
 
 

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -189,6 +189,60 @@ class InterpolatedQuadratureParameter(AbstractInterpolatedParameter):
 InterpolatedQuadratureParameter.register()
 
 
+class ScenarioWrapperParameter(Parameter):
+    def __init__(self, model, scenario, parameters, **kwargs):
+        """Parameter that utilises a different child parameter in each scenario ensemble.
+
+    This parameter is used to switch between different child parameters based on different
+    ensembles in a given `Scenario`. It can be used to vary data in a non-scenario aware
+    parameter type across multiple scenario ensembles. For example, many of control curve or
+    interpolation parameters do not explicitly support scenarios. This parameter can be used
+    to test multiple control curve definitions as part of a single simulation.
+
+    Parameters
+    ----------
+    scenario : Scenario
+        The scenario instance which is used to select the parameters.
+    parameters : iterable of Parameter instances
+        The child parameters that are used in each of `scenario`'s ensembles. The number
+        of parameters must equal the size of the given scenario.
+
+    """
+        super().__init__(model, **kwargs)
+        if scenario.size != len(parameters):
+            raise ValueError("The number of parameters must equal the size of the scenario.")
+        self.scenario = scenario
+        self.parameters = []
+        for p in parameters:
+            self.children.add(p)
+            self.parameters.append(p)
+        # Initialise internal attributes
+        self._scenario_index = None
+
+    def setup(self):
+        super().setup()
+        # This setup must find out the index of self._scenario in the model
+        # so that it can return the correct value in value()
+        self._scenario_index = self.model.scenarios.get_scenario_index(self.scenario)
+
+    def value(self, ts, scenario_index):
+        # This is a bit confusing.
+        # scenario_indices contains the current scenario number for all
+        # the Scenario objects in the model run. We have cached the
+        # position of self._scenario in self._scenario_index to lookup the
+        # correct number to use in this instance.
+        parameter = self.parameters[scenario_index.indices[self._scenario_index]]
+        return parameter.get_value(scenario_index)
+
+    @classmethod
+    def load(cls, model, data):
+        scenario = model.scenarios[data.pop('scenario')]
+
+        parameters = [load_parameter(model, p) for p in data.pop('parameters')]
+        return cls(model, scenario, parameters, **data)
+ScenarioWrapperParameter.register()
+
+
 def pop_kwarg_parameter(kwargs, key, default):
     """Pop a parameter from the keyword arguments dictionary
 

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -190,8 +190,7 @@ InterpolatedQuadratureParameter.register()
 
 
 class ScenarioWrapperParameter(Parameter):
-    def __init__(self, model, scenario, parameters, **kwargs):
-        """Parameter that utilises a different child parameter in each scenario ensemble.
+    """Parameter that utilises a different child parameter in each scenario ensemble.
 
     This parameter is used to switch between different child parameters based on different
     ensembles in a given `Scenario`. It can be used to vary data in a non-scenario aware
@@ -208,6 +207,7 @@ class ScenarioWrapperParameter(Parameter):
         of parameters must equal the size of the given scenario.
 
     """
+    def __init__(self, model, scenario, parameters, **kwargs):
         super().__init__(model, **kwargs)
         if scenario.size != len(parameters):
             raise ValueError("The number of parameters must equal the size of the scenario.")

--- a/tests/models/simple_with_scenario_wrapper.json
+++ b/tests/models/simple_with_scenario_wrapper.json
@@ -1,0 +1,73 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "scenarios": [
+        {
+            "name": "scenario A",
+            "size": 10
+        },
+        {
+            "name": "scenario B",
+            "size": 2,
+            "ensemble_names": ["First", "Second"]
+        }
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": "supply1_max_flow"
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": {
+                "type": "constantscenario",
+                "scenario": "scenario B",
+                "values": [10, 15]
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "supply1_max_flow": {
+            "type": "scenariowrapper",
+            "scenario": "scenario A",
+            "parameters": [
+                {"type": "constant", "value": 10},
+                {"type": "constant", "value": 11},
+                {"type": "constant", "value": 12},
+                {"type": "constant", "value": 13},
+                {"type": "constant", "value": 14},
+                {"type": "constant", "value": 15},
+                {"type": "constant", "value": 16},
+                {"type": "constant", "value": 17},
+                {"type": "constant", "value": 18},
+                {"type": "constant", "value": 19}
+            ]
+        }
+    },
+    "recorders": {
+        "demand1": {
+            "comment": "Actual flow to demand1",
+            "type": "NumpyArrayNode",
+            "node": "demand1"
+        }
+    }
+}

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -152,7 +152,8 @@ def test_scenario_storage():
     assert_allclose(s_rec.data[1], [510, 520])
 
 
-def test_scenarios_from_json():
+@pytest.mark.parametrize("json_file", ['simple_with_scenario.json', 'simple_with_scenario_wrapper.json'])
+def test_scenarios_from_json(json_file):
     """
     Test a simple model with two scenarios.
 
@@ -163,7 +164,7 @@ def test_scenarios_from_json():
     the `MultiIndex` on the `DataFrame` from the recorder.
     """
 
-    model = load_model('simple_with_scenario.json')
+    model = load_model(json_file)
     assert len(model.scenarios) == 2
 
     model.setup()


### PR DESCRIPTION
A new parameter for quickly using multiple parameter definitions across
a scenario's ensembles. Useful for cases where non-scenario aware
parameters need to be changed with a scenario's ensemble. For example,
reservoir release rules.