### PR TITLE
Initial implementation of including python modules.

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -207,29 +207,45 @@ class Model(object):
         """
         if "includes" in data:
             for filename in data["includes"]:
+                _, ext = os.path.splitext(filename)
                 if path is not None:
                     filename = os.path.join(os.path.dirname(path), filename)
-                with open(filename, "r") as f:
-                    try:
-                        include_data = json.loads(f.read())
-                    except ValueError as e:
-                        message = e.args[0]
-                        if path:
-                            e.args = ("{} [{}]".format(e.args[0], os.path.basename(filename)),)
-                        raise(e)
-                for key, value in include_data.items():
-                    if isinstance(value, list):
-                        try:
-                            data[key].extend(value)
-                        except KeyError:
-                            data[key] = value
-                    elif isinstance(value, dict):
-                        try:
-                            data[key].update(value)
-                        except KeyError:
-                            data[key] = value
-                    else:
-                        raise TypeError("Invalid type for key \"{}\" in include \"{}\".".format(key, path))
+
+                ext = ext.lower()
+                if ext == '.json':
+                    cls._load_json_include(data, filename)
+                elif ext == '.py':
+                    cls._load_py_include(filename)
+                else:
+                    raise NotImplementedError(f'Include file type "{ext}" not supported.')
+
+    @classmethod
+    def _load_py_include(cls, filename):
+        import runpy
+        runpy.run_path(filename)
+
+    @classmethod
+    def _load_json_include(cls, data, filename):
+        with open(filename, "r") as f:
+            try:
+                include_data = json.loads(f.read())
+            except ValueError as e:
+                message = e.args[0]
+                e.args = ("{} [{}]".format(e.args[0], os.path.basename(filename)),)
+                raise(e)
+        for key, value in include_data.items():
+            if isinstance(value, list):
+                try:
+                    data[key].extend(value)
+                except KeyError:
+                    data[key] = value
+            elif isinstance(value, dict):
+                try:
+                    data[key].update(value)
+                except KeyError:
+                    data[key] = value
+            else:
+                raise TypeError("Invalid type for key \"{}\" in include \"{}\".".format(key, filename))
         return None  # data modified in-place
 
     @classmethod

--- a/tests/models/my_parameter.py
+++ b/tests/models/my_parameter.py
@@ -1,0 +1,6 @@
+from pywr.parameters import ConstantParameter
+
+
+class MyParameter(ConstantParameter):
+    pass
+MyParameter.register()

--- a/tests/models/python_include.json
+++ b/tests/models/python_include.json
@@ -1,0 +1,39 @@
+{
+    "metadata": {
+        "title": "Python include",
+        "description": "An example of including a Python file to define a custom parameter.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "includes": [
+        "my_parameter.py"
+    ],
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": {
+                "type": "MyParameter",
+                "value": 15
+            }
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ]
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -502,6 +502,15 @@ def test_json_include():
     supply2 = model.nodes["supply2"]
     assert(isinstance(supply2.max_flow, ConstantParameter))
 
+
+def test_py_include():
+    """Test include in Python document"""
+    filename = os.path.join(TEST_FOLDER, "models", "python_include.json")
+    model = Model.load(filename)
+
+    model.run()
+
+
 def test_json_min_version():
     """Test warning is raised if document minimum version is more than we have"""
     filename = os.path.join(TEST_FOLDER, "models", "version1.json")


### PR DESCRIPTION
This approach simply detects the file extension of filenames referenced in the existing "includes" section. For .py files runpy is used to execute the code.

Begins to solve #764.