### PR TITLE
Add support for percentile and percentileofscore aggregation functions.

### DIFF
--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -5,6 +5,8 @@ from pywr.parameters._parameters cimport Parameter, IndexParameter
 
 cdef class Aggregator:
     cdef object _user_func
+    cdef public list func_args
+    cdef public dict func_kwargs
     cdef int _func
     cpdef double aggregate_1d(self, double[:] data, ignore_nan=*) except *
     cpdef double[:] aggregate_2d(self, double[:, :] data, axis=*, ignore_nan=*) except *

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,6 +1,7 @@
-
+from functools import partial
 from pywr.recorders import Aggregator
 from pywr.recorders._recorders import _agg_func_lookup
+from scipy.stats import percentileofscore
 import numpy as np
 import pytest
 
@@ -20,6 +21,21 @@ def custom_test_func(array, axis=None):
     return np.sum(array**2, axis=axis)
 
 
+def percentileofscore_with_axis(values, *args, axis=0, **kwargs):
+    if values.ndim == 1:
+        # For 1D data we just calculate the percentile
+        out = percentileofscore(values, *args, **kwargs)
+    elif axis == 0:
+        # 2D data by axis 0
+        out = [percentileofscore(values[:, i], *args, **kwargs) for i in range(values.shape[1])]
+    elif axis == 1:
+        # 2D data by axis 1
+        out = [percentileofscore(values[i, :], *args, **kwargs) for i in range(values.shape[0])]
+    else:
+        raise ValueError('Axis "{}" not supported'.format(axis))
+    return out
+
+
 @pytest.fixture(params=_agg_func_lookup.keys())
 def agg_func(request):
     agg_func_name = request.param
@@ -27,6 +43,22 @@ def agg_func(request):
     if agg_func_name == "custom":
         # When using custom you assign the function rather than a string.
         agg_func_name = npy_func = custom_test_func
+    elif agg_func_name == "percentile":
+        agg_func_name = {
+            "func": "percentile",
+            "args": [95],
+            "kwargs": {}
+        }
+        npy_func = partial(np.percentile, q=95)
+    elif agg_func_name == "percentileofscore":
+        agg_func_name = {
+            "func": "percentileofscore",
+            "kwargs": {
+                "score": 0.5,
+                "kind": "rank"
+            }
+        }
+        npy_func = partial(percentileofscore_with_axis, score=0.5, kind="rank")
     else:
         npy_func = npy_funcs[agg_func_name]
     return agg_func_name, npy_func
@@ -36,7 +68,10 @@ def test_get_set_aggregator(agg_func):
     """Test getter and setter for Aggregator.func"""
     agg_func_name, _ = agg_func
     agg = Aggregator(agg_func_name)
-    assert agg.func == agg_func_name
+    if isinstance(agg_func_name, dict):
+        assert agg.func == agg_func_name['func']
+    else:
+        assert agg.func == agg_func_name
     agg.func = "sum"
     assert agg.func == "sum"
 
@@ -52,7 +87,8 @@ def test_aggregator_1d(agg_func):
     np.testing.assert_allclose(agg.aggregate_1d(data), npy_func(data))
 
 
-def test_aggregator_2d(agg_func):
+@pytest.mark.parametrize('axis', [0, 1])
+def test_aggregator_2d(agg_func, axis):
     """ Test Aggregator.aggregate_2d function. """
     agg_func_name, npy_func = agg_func
 
@@ -60,4 +96,6 @@ def test_aggregator_2d(agg_func):
 
     data = np.random.rand(100, 10)
 
-    np.testing.assert_allclose(agg.aggregate_2d(data), npy_func(data, axis=0))
+    result = agg.aggregate_2d(data, axis=axis)
+    assert len(result) == data.shape[1 - axis]
+    np.testing.assert_allclose(result, npy_func(data, axis=axis))


### PR DESCRIPTION
This PR adds support for two additional aggregation functions in the `Aggregator`. These functions are `percentile` and `percentileofscore`; following the names of the underlying numpy/scipy functions. Because these functions require some arguments (unlike the existing min, mean, max, etc) there is a new supported format for specifying agg funcs in the JSON. For example,

```json
{
  "func": "percentile",
  "args": [95],
  "kwargs": {}
}
```

This would allow is to implement more functions in the future. 