### PR TITLE
pop comment from data passed to pandas.read_xxxxx

### DIFF
--- a/pywr/dataframe_tools.py
+++ b/pywr/dataframe_tools.py
@@ -239,6 +239,8 @@ def read_dataframe(model, data):
 
         filetype = "dict"
 
+    data.pop("comment", None) # remove kwargs from data before passing to Pandas
+        
     if filetype == "csv":
         if hasattr(data, "index_col"):
             data["parse_dates"] = True


### PR DESCRIPTION
This prevents passing a "comment" argument to Pandas when reading from an external source.