### PR TITLE
Add year and ordinal threshold params

### DIFF
--- a/pywr/parameters/_thresholds.pxd
+++ b/pywr/parameters/_thresholds.pxd
@@ -26,3 +26,9 @@ cdef class ParameterThresholdParameter(AbstractThresholdParameter):
 cdef class RecorderThresholdParameter(AbstractThresholdParameter):
     cdef public Recorder recorder
     cdef public initial_value
+
+cdef class CurrentYearThresholdParameter(AbstractThresholdParameter):
+    pass
+
+cdef class CurrentOrdinalDayThresholdParameter(AbstractThresholdParameter):
+    pass

--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -253,3 +253,33 @@ cdef class RecorderThresholdParameter(AbstractThresholdParameter):
         predicate = data.pop("predicate", None)
         return cls(model, recorder, threshold, values=values, predicate=predicate, **data)
 RecorderThresholdParameter.register()
+
+
+cdef class CurrentYearThresholdParameter(AbstractThresholdParameter):
+    """ Returns one of two values depending on the year of the current timestep..
+    """
+    cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return float(timestep.year)
+
+    @classmethod
+    def load(cls, model, data):
+        threshold = load_parameter(model, data.pop("threshold"))
+        values = data.pop("values", None)
+        predicate = data.pop("predicate", None)
+        return cls(model, threshold, values=values, predicate=predicate, **data)
+CurrentYearThresholdParameter.register()
+
+
+cdef class CurrentOrdinalDayThresholdParameter(AbstractThresholdParameter):
+    """ Returns one of two values depending on the ordinal of the current timestep.
+    """
+    cpdef double _value_to_compare(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
+        return float(timestep.datetime.toordinal())
+
+    @classmethod
+    def load(cls, model, data):
+        threshold = load_parameter(model, data.pop("threshold"))
+        values = data.pop("values", None)
+        predicate = data.pop("predicate", None)
+        return cls(model, threshold, values=values, predicate=predicate, **data)
+CurrentOrdinalDayThresholdParameter.register()

--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -54,7 +54,7 @@ cdef class AbstractThresholdParameter(IndexParameter):
             self.values = np.array(values, np.float64)
         if predicate is None:
             predicate = Predicates.LT
-        elif isinstance(predicate, basestring):
+        elif isinstance(predicate, str):
             predicate = _predicate_lookup[predicate.upper()]
         self.predicate = predicate
         self.ratchet = ratchet

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1404,6 +1404,55 @@ class TestThresholdParameters:
         # flow < 5
         assert p1.index(m.timestepper.current, si) == 0
 
+    def test_current_year_threshold_parameter(self, simple_linear_model):
+        """Test CurrentYearThresholdParameter"""
+        m = simple_linear_model
+
+        m.timestepper.start = '2020-01-01'
+        m.timestepper.end = '2030-01-01'
+
+        data = {
+            'type': 'currentyearthreshold',
+            'threshold': 2025,
+            "predicate": ">=",
+        }
+
+        p = load_parameter(m, data)
+
+        @assert_rec(m, p, get_index=True)
+        def expected_func(timestep, scenario_index):
+            current_year = timestep.year
+            value = 1 if current_year >= 2025 else 0
+            return value
+
+        m.run()
+
+    def test_current_ordinal_threshold_parameter(self, simple_linear_model):
+        """Test CurrentYearThresholdParameter"""
+        m = simple_linear_model
+
+        m.timestepper.start = '2020-01-01'
+        m.timestepper.end = '2030-01-01'
+
+        threshold = datetime.date(2025, 6, 15).toordinal()
+
+        data = {
+            'type': 'currentordinaldaythreshold',
+            'threshold': threshold,
+            "predicate": ">=",
+        }
+
+        p = load_parameter(m, data)
+
+        @assert_rec(m, p, get_index=True)
+        def expected_func(timestep, scenario_index):
+            o = timestep.datetime.toordinal()
+            value = 1 if o >= threshold else 0
+            return value
+
+        m.run()
+
+
 def test_orphaned_components(simple_linear_model):
     model = simple_linear_model
     model.nodes["Input"].max_flow = ConstantParameter(model, 10.0)


### PR DESCRIPTION
These two parameters allow for a comparison against the current year and ordinal day of the simulation respectively. They are useful for triggering things at specific dates in the simulation.

Also 
 - adds support for testing index values from the assertion recorder.
 - removes an old `basestring` usage in `_thresholds.pyx`