### PR TITLE
Refactor of setup.py

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ build_script:
   - cmd: copy %GLPK_HOME%\COPYING pywr\.libs\licenses\COPYING
 
   # build pywr and create a wheel
-  - "python setup.py build_ext -I%GLPK_HOME%\\src -L%GLPK_HOME%\\w64 --with-glpk bdist_wheel"
+  - "python setup.py build_ext -I%GLPK_HOME%\\src -L%GLPK_HOME%\\w64 --with-glpk --without-lpsolve bdist_wheel"
 
   # install the wheel
   # - ps: python -m pip install --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
 
   global:
     BUILD_HOME: "C:\\build"
+  
     GLPK_VER: "4.65"
     GLPK_HOME: "C:\\glpk-%GLPK_VER%"
     GLPK_PKG_LIB: "glpk_4_65.lib"
@@ -11,6 +12,16 @@ environment:
     GLPK_PKG_DLL: "glpk_4_65.dll"
     GLPK_DLL: "glpk.dll"
     GLPK_URL: "https://sourceforge.net/projects/winglpk/files/winglpk/GLPK-%GLPK_VER%/winglpk-%GLPK_VER%.zip/download"
+
+    LPSOLVE_VER: "5.5.2.5"
+    LPSOLVE_HOME: "C:\\lpsolve-%LPSOLVE_VER%"
+    LPSOLVE_LIB: "lpsolve55.lib"
+    LPSOLVE_DLL: "lpsolve55.dll"
+    LPSOLVE_URL: "https://sourceforge.net/projects/lpsolve/files/lpsolve/%LPSOLVE_VER%/lp_solve_%LPSOLVE_VER%_dev_win64.zip/download"
+
+    INCLUDE: "%GLPK_HOME%\\src;%LPSOLVE_HOME%"
+    LIB: "%GLPK_HOME%\\w64;%LPSOLVE_HOME%\\lpsolve"
+
     PYTHON_ARCH: "64"
 
   matrix:
@@ -48,6 +59,9 @@ install:
     - ps: "ls \"C:/\""
     - ps: "ls %GLPK_HOME%"
 
+    - curl -L --output lpsolve.zip %LPSOLVE_URL%
+    - 7z x lpsolve.zip -o%LPSOLVE_HOME%\lpsolve
+
     - "SET PACKAGE_DATA=true"
 
     - cd C:\projects\pywr
@@ -80,8 +94,10 @@ build_script:
   - cmd: copy %GLPK_HOME%\w64\%GLPK_PKG_DLL% pywr\.libs\%GLPK_PKG_DLL%
   - cmd: copy %GLPK_HOME%\COPYING pywr\.libs\licenses\COPYING
 
+  - cmd: copy %LPSOLVE_HOME%\lpsolve\%LPSOLVE_DLL% pywr\.libs\%LPSOLVE_DLL%
+
   # build pywr and create a wheel
-  - "python setup.py build_ext -I%GLPK_HOME%\\src -L%GLPK_HOME%\\w64 --with-glpk --without-lpsolve bdist_wheel"
+  - "python setup.py build_ext --with-glpk --with-lpsolve bdist_wheel"
 
   # install the wheel
   # - ps: python -m pip install --upgrade pip
@@ -99,6 +115,9 @@ test_script:
   - "python -m pytest"
 
   - "SET PYWR_SOLVER=glpk-edge"
+  - "python -m pytest"
+
+  - "SET PYWR_SOLVER=lpsolve"
   - "python -m pytest"
 
   - "jupyter nbconvert --to html --execute tests\\notebook.ipynb"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ def setup_package():
                 compile_time_env=compile_time_env,
                 annotate=annotate,
             )
-            self.include_dirs = [numpy.get_include()]
+            if not self.include_dirs:
+                self.include_dirs = []
+            self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 
     metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,10 @@ def setup_package():
                 compile_time_env=compile_time_env,
                 annotate=annotate,
             )
-            print("include_dirs", self.include_dirs)
             if not self.include_dirs:
                 self.include_dirs = []
+            elif isinstance(self.include_dirs, str):
+                self.include_dirs = [self.include_dirs]
             self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,12 @@ def setup_package():
         else:
             lpsolve_macros = define_macros
         ext_modules.append(
-            Extension("pywr.solvers.cython_lpsolve", ["pywr/solvers/cython_lpsolve.pyx"], define_macros=lpsolve_macros)
+            Extension(
+                "pywr.solvers.cython_lpsolve",
+                ["pywr/solvers/cython_lpsolve.pyx"],
+                libraries=["lpsolve55"],
+                define_macros=lpsolve_macros,
+            )
         )
 
     annotate = config["annotate"]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def setup_package():
                 compile_time_env=compile_time_env,
                 annotate=annotate,
             )
+            print("include_dirs", self.include_dirs)
             if not self.include_dirs:
                 self.include_dirs = []
             self.include_dirs.append(numpy.get_include())

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
-        setup_requires=["setuptools", "setuptools_scm", "cython", "numpy",],
+        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy",],
         install_requires=["pandas", "networkx", "scipy", "tables", "xlrd", "packaging", "matplotlib", "jinja2",],
         extras_require={"test": ["pytest"]},
         cmdclass={"build_ext": get_new_build_ext},

--- a/setup.py
+++ b/setup.py
@@ -1,185 +1,184 @@
-#!/usr/bin/env python
+import os
+import sys
 
 try:
     from setuptools import setup
     from setuptools import Extension
-    print('Using setuptools for setup!')
 except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
-    print('Using distutils for setup!')
-from distutils.errors import CCompilerError, DistutilsExecError, \
-    DistutilsPlatformError
-from Cython.Distutils import build_ext
-from Cython.Build import cythonize
-import numpy as np
-import sys
-import os
-from packaging.version import Version
-import subprocess
-
-with open('README.rst') as fh:
-    long_description = fh.read()
-
-setup_kwargs = {
-    'name': 'pywr',
-    'description': 'Python Water Resource model',
-    'long_description': long_description,
-    'long_description_content_type': 'text/x-rst',
-    'author': 'Joshua Arnott',
-    'author_email': 'josh@snorfalorpagus.net',
-    'url': 'https://github.com/pywr/pywr',
-    'packages': ['pywr', 'pywr.solvers', 'pywr.domains', 'pywr.parameters', 'pywr.recorders', 'pywr.notebook', 'pywr.optimisation'],
-    'use_scm_version': True,
-    'setup_requires': ['setuptools_scm'],
-    'install_requires': [
-        'pandas',
-        'networkx',
-        'scipy',
-        'tables',
-        'xlrd',
-        'packaging',
-        'matplotlib',
-        'jinja2'
-    ]
-}
 
 
-define_macros = []
+def setup_package():
+    compiler_directives = {
+        "language_level": 3,
+        "embedsignature": True,
+    }
 
-# HACK: optional features are too difficult to do properly
-# http://stackoverflow.com/a/4056848/1300519
-optional = set()
-if '--with-glpk' in sys.argv:
-    optional.add('glpk')
-    sys.argv.remove('--with-glpk')
-elif os.environ.get('PYWR_BUILD_GLPK', 'false').lower() == 'true':
-    optional.add('glpk')
+    define_macros = []
 
-if '--with-lpsolve' in sys.argv:
-    optional.add('lpsolve')
-    sys.argv.remove('--with-lpsolve')
-elif os.environ.get('PYWR_BUILD_LPSOLVE', 'false').lower() == 'true':
-    optional.add('lpsolve')
+    compile_time_env = {
+        "SOLVER_DEBUG": False,
+    }
 
-if '--annotate' in sys.argv:
-    annotate = True
-    sys.argv.remove('--annotate')
-else:
     annotate = False
-if not optional:
-    # default is to attempt to build everything
-    optional.add('glpk')
-    optional.add('lpsolve')
 
-compiler_directives = {}
-if '--enable-profiling' in sys.argv:
-     compiler_directives['profile'] = True
-     sys.argv.remove('--enable-profiling')
+    def get_new_build_ext(args):
+        # Defer the import of Cython and NumPy until after setup_requires
+        from setuptools.command.build_ext import build_ext as _build_ext
+        from Cython.Build.Dependencies import cythonize
+        import numpy
 
-build_trace = False
-if '--enable-trace' in sys.argv:
-    sys.argv.remove('--enable-trace')
-    build_trace = True
-elif os.environ.get('PYWR_BUILD_TRACE', 'false').lower() == 'true':
-    build_trace = True
+        class new_build_ext(_build_ext):
+            def finalize_options(self):
+                self.distribution.ext_modules[:] = cythonize(
+                    self.distribution.ext_modules,
+                    compiler_directives=compiler_directives,
+                    compile_time_env=compile_time_env,
+                    annotate=annotate,
+                )
+                self.include_dirs = [numpy.get_include()]
+                super().finalize_options()
 
-if build_trace:
-    print('Tracing is enabled.')
-    compiler_directives['linetrace'] = True
-    define_macros.append(('CYTHON_TRACE', '1'))
-    define_macros.append(('CYTHON_TRACE_NOGIL', '1'))
+        return new_build_ext(args)
 
-compile_time_env = {}
-if '--enable-debug' in sys.argv:
-    compile_time_env['SOLVER_DEBUG'] = True
-    sys.argv.remove('--enable-debug')
-else:
-    compile_time_env['SOLVER_DEBUG'] = False
-
-# See the following documentation for a description of these directives
-#  https://cython.readthedocs.io/en/latest/src/reference/compilation.html#compiler-directives
-compiler_directives['language_level'] = 3
-compiler_directives['embedsignature'] = True
-
-
-extensions = [
-    Extension('pywr._core', ['pywr/_core.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr._model', ['pywr/_model.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr._component', ['pywr/_component.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-
-    # Parameters sub-package
-
-    Extension('pywr.parameters._parameters', ['pywr/parameters/_parameters.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.parameters._polynomial', ['pywr/parameters/_polynomial.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.parameters._thresholds', ['pywr/parameters/_thresholds.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.parameters._control_curves', ['pywr/parameters/_control_curves.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.parameters._hydropower', ['pywr/parameters/_hydropower.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-
-    # Other modules
-    Extension('pywr.recorders._recorders', ['pywr/recorders/_recorders.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.recorders._thresholds', ['pywr/recorders/_thresholds.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-    Extension('pywr.recorders._hydropower', ['pywr/recorders/_hydropower.pyx'],
-              include_dirs=[np.get_include()],
-              define_macros=define_macros),
-
-
-]
-
-extensions_optional = []
-if 'glpk' in optional:
-    extensions_optional.extend([
-        Extension('pywr.solvers.cython_glpk', ['pywr/solvers/cython_glpk.pyx'],
-                  include_dirs=[np.get_include()],
-                  libraries=['glpk'],
-                  define_macros=define_macros),
-        Extension('pywr.solvers.cython_glpk_edge', ['pywr/solvers/cython_glpk_edge.pyx'],
-                  include_dirs=[np.get_include()],
-                  libraries=['glpk'],
-                  define_macros=define_macros),
-    ])
-if 'lpsolve' in optional:
-    if os.name == 'nt':
-        define_macros.append(('WIN32', 1))
-    extensions_optional.append(
-        Extension('pywr.solvers.cython_lpsolve', ['pywr/solvers/cython_lpsolve.pyx'],
-                  include_dirs=[np.get_include()],
-                  libraries=['lpsolve55'],
-                  define_macros=define_macros),
+    metadata = dict(
+        name="pywr",
+        description="Python Water Resource model",
+        long_description=long_description(),
+        long_description_content_type="text/x-rst",
+        author="Joshua Arnott",
+        author_email="josh@snorfalorpagus.net",
+        url="https://github.com/pywr/pywr",
+        setup_requires=["setuptools", "setuptools_scm", "cython", "numpy",],
+        install_requires=["pandas", "networkx", "scipy", "tables", "xlrd", "packaging", "matplotlib", "jinja2",],
+        extras_require={"test": ["pytest"]},
+        cmdclass={"build_ext": get_new_build_ext},
+        packages=[
+            "pywr",
+            "pywr.solvers",
+            "pywr.domains",
+            "pywr.parameters",
+            "pywr.recorders",
+            "pywr.notebook",
+            "pywr.optimisation",
+        ],
+        package_data=package_data(),
+        use_scm_version=True,
     )
 
-setup_kwargs['package_data'] = {
-    'pywr.notebook': ['*.js', '*.css']
-}
+    metadata["ext_modules"] = ext_modules = [
+        Extension("pywr._core", ["pywr/_core.pyx"]),
+        Extension("pywr._model", ["pywr/_model.pyx"]),
+        Extension("pywr._component", ["pywr/_component.pyx"]),
+        Extension("pywr.parameters._parameters", ["pywr/parameters/_parameters.pyx"]),
+        Extension("pywr.parameters._polynomial", ["pywr/parameters/_polynomial.pyx"]),
+        Extension("pywr.parameters._thresholds", ["pywr/parameters/_thresholds.pyx"]),
+        Extension("pywr.parameters._control_curves", ["pywr/parameters/_control_curves.pyx"]),
+        Extension("pywr.parameters._hydropower", ["pywr/parameters/_hydropower.pyx"]),
+        Extension("pywr.recorders._recorders", ["pywr/recorders/_recorders.pyx"]),
+        Extension("pywr.recorders._thresholds", ["pywr/recorders/_thresholds.pyx"]),
+        Extension("pywr.recorders._hydropower", ["pywr/recorders/_hydropower.pyx"]),
+    ]
 
-# build the core extension(s)
-setup_kwargs['ext_modules'] = cythonize(extensions + extensions_optional,
-                                        compiler_directives=compiler_directives, annotate=annotate,
-                                        compile_time_env=compile_time_env)
+    config = parse_optional_arguments()
 
-if os.environ.get('PACKAGE_DATA', 'false').lower() == 'true':
-    pkg_data = setup_kwargs["package_data"].get("pywr", [])
-    pkg_data.extend(['.libs/*', '.libs/licenses/*'])
-    setup_kwargs["package_data"]["pywr"] = pkg_data
+    if config["glpk"]:
+        ext_modules.extend(
+            [
+                Extension("pywr.solvers.cython_glpk", ["pywr/solvers/cython_glpk.pyx"], libraries=["glpk"],),
+                Extension("pywr.solvers.cython_glpk_edge", ["pywr/solvers/cython_glpk_edge.pyx"], libraries=["glpk"],),
+            ]
+        )
 
-setup(**setup_kwargs)
+    if config["lpsolve"]:
+        if os.name == "nt":
+            lpsolve_macros = define_macros + [("WIN32", 1)]
+        else:
+            lpsolve_macros = define_macros
+        ext_modules.append(
+            Extension("pywr.solvers.cython_lpsolve", ["pywr/solvers/cython_lpsolve.pyx"], define_macros=lpsolve_macros)
+        )
+
+    annotate = config["annotate"]
+
+    if config["profile"]:
+        compiler_directives["profile"] = True
+
+    if config["trace"]:
+        compiler_directives["linetrace"] = True
+        define_macros.extend(
+            [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1"),]
+        )
+
+    if config["debug"]:
+        compile_time_env["SOLVER_DEBUG"] = True
+
+    setup(**metadata)
+
+
+def long_description():
+    with open("README.rst") as f:
+        return f.read()
+
+
+def package_data():
+    pkg_data = {
+        "pywr.notebook": ["*.js", "*.css"],
+    }
+    if os.environ.get("PACKAGE_DATA", "false").lower() == "true":
+        pkg_data["pywr"] = [".libs/*", ".libs/licenses/*"]
+    return pkg_data
+
+
+def parse_optional_arguments():
+    config = {
+        "glpk": True,
+        "lpsolve": True,
+        "annotate": False,
+        "profile": False,
+        "trace": False,
+        "debug": False,
+    }
+
+    if "--with-glpk" in sys.argv:
+        config["glpk"] = True
+        sys.argv.remove("--with-glpk")
+    elif "PYWR_BUILD_GLPK" in os.environ:
+        config["glpk"] = os.environ["PYWR_BUILD_GLPK"].lower() in ("true", "1",)
+    elif "--without-glpk" in sys.argv:
+        config["glpk"] = False
+        sys.argv.remove("--without-glpk")
+
+    if "--with-lpsolve" in sys.argv:
+        config["lpsolve"] = True
+        sys.argv.remove("--with-lpsolve")
+    elif "PYWR_BUILD_LPSOLVE" in os.environ:
+        config["lpsolve"] = os.environ["PYWR_BUILD_LPSOLVE"].lower() in ("true", "1",)
+    elif "--without-lpsolve" in sys.argv:
+        config["lpsolve"] = False
+        sys.argv.remove("--without-lpsolve")
+
+    if "--annotate" in sys.argv:
+        config["annotate"] = True
+        sys.argv.remove("--annotate")
+
+    if "--enable-profiling" in sys.argv:
+        config["profile"] = True
+        sys.argv.remove("--enable-profiling")
+
+    if "--enable-trace" in sys.argv:
+        config["trace"] = True
+        sys.argv.remove("--enable-trace")
+    elif "PYWR_BUILD_TRACE" in os.environ:
+        config["trace"] = os.environ["PYWR_BUILD_TRACE"].lower() in ("true", "1",)
+
+    if "--enable-debug" in sys.argv:
+        config["debug"] = True
+        sys.argv.remove("--enable-debug")
+
+    return config
+
+
+if __name__ == "__main__":
+    setup_package()


### PR DESCRIPTION
Some refactoring of `setup.py`. It is no longer required to pre-install cython, numpy and packaging - they should be installed automatically.

Closes #809 and #808 
