### PR TITLE
Added __contains__ method to NamedIterator and NodeIterator

### DIFF
--- a/docs/source/json.rst
+++ b/docs/source/json.rst
@@ -192,6 +192,43 @@ Instead of defining the data inline using the ``"values"`` property, external da
         }
     ]}
 
+
+Loading a JSON document
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A Pywr JSON document can be loaded into a `Model` instance by using the `Model.load` class-method:
+
+.. code-block:: python
+    from pywr.model import Model
+    my_model = model.load('/path/to/my_model.json')
+    my_model.run()
+
+Once a model is loaded if a reference to an actual node is required, using .get ...
+
+.. code-block:: python
+    node = my_model.nodes.get("River Thames")
+    if node:
+        print(f"max_flow: {node.max_flow}")
+    else:
+        print("Not found")
+
+... or try-except is preferable to avoid searching twice.
+
+.. code-block:: python
+    try:
+        node = model.nodes["River Thames"]
+    except KeyError:
+        print("Not found")
+    else:
+        print(f"max_flow: {node.max_flow}")
+
+It is also possible to test for node and component membership using their names:
+
+.. code-block:: python
+    assert "River Thames" in model.nodes
+    assert "Demand" in model.parameters
+
+
 Debugging and syntax errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -799,6 +799,12 @@ class NodeIterator(object):
         """Returns the number of nodes in the model"""
         return len(list(self._nodes()))
 
+    def __contains__(self, value):
+        for node in self._nodes():
+            if node.name == value or node == value:
+                return True
+        return False
+
     def __iter__(self):
         return self
 

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -858,6 +858,12 @@ class NamedIterator(object):
     def __iter__(self):
         return iter(self._objects)
 
+    def __contains__(self, value):
+        for obj in self._objects:
+            if obj.name == value or obj == value:
+                return True
+        return False
+
     def append(self, obj):
         # TODO: check for name collisions / duplication
         self._objects.append(obj)

--- a/tests/test_named_iterator.py
+++ b/tests/test_named_iterator.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pywr.model import NamedIterator
+
+class Item:
+    def __init__(self, name):
+        self.name = name
+
+@pytest.fixture
+def items():
+    return [
+        Item("Hello"),
+        Item("World"),
+        Item("River Thames"),
+    ]
+
+@pytest.fixture
+def iterator(items):
+    i = NamedIterator()
+    for item in items:
+        i[item.name] = item
+    return i
+
+
+def test_iterator_keys_and_values(items, iterator):
+    expected_names = {"Hello", "World", "River Thames"}
+    assert set(iterator.keys()) == expected_names
+    assert set(iterator.values()) == set(items)
+
+
+def test_iterator_contains(items, iterator):
+    assert "Hello" in iterator
+    assert "River Thames" in iterator
+    assert items[0] in iterator
+    assert items[-1] in iterator
+
+
+def test_iterator_length(iterator):
+    assert len(iterator) == 3
+
+
+def test_iterator_delete(iterator):
+    del iterator["World"]
+    assert {i.name for i in iterator} == {"Hello", "River Thames"}
+
+
+def test_iterator_append(iterator):
+    new_item = Item("New Item")
+    iterator.append(new_item)
+    assert len(iterator) == 4
+    assert new_item in iterator

--- a/tests/test_node_iterator.py
+++ b/tests/test_node_iterator.py
@@ -1,0 +1,35 @@
+from pywr.nodes import Node
+
+from fixtures import simple_linear_model, simple_storage_model
+
+model = simple_linear_model
+
+
+def test_keys_and_values(model):
+    expected_names = {"Input", "Link", "Output"}
+    assert set(model.nodes.keys()) == expected_names
+    nodes = {node for node in model.nodes}
+    assert len(nodes) == 3
+    assert set(model.nodes.values()) == nodes
+
+
+def test_contains(model):
+    assert "Input" in model.nodes
+    assert "Output" in model.nodes
+    output = model.nodes["Output"]
+    assert isinstance(output, Node)
+    assert output in model.nodes
+
+
+def test_delete(model):
+    del(model.nodes["Output"])
+    assert len(model.nodes) == 2
+    assert {node.name for node in model.nodes} == {"Input", "Link"}
+
+
+def test_delete_compound_node(simple_storage_model):
+    """Removal of a compound node removes child nodes also"""
+    assert len(list(simple_storage_model.nodes._nodes(hide_children=False))) == 5
+    del(simple_storage_model.nodes["Storage"])
+    assert len(list(simple_storage_model.nodes._nodes(hide_children=False))) == 2
+    assert {node.name for node in simple_storage_model.nodes} == {"Input", "Output"}


### PR DESCRIPTION
It's now possible to test for node and component membership using their names:

```python
assert "River Thames" in model.nodes
assert "Demand" in model.parameters
```

If a reference to the actual node is required, using try-except or `.get` is preferable to avoid searching twice.

```python
node = model.nodes.get("River Thames")
if node:
    print(f"max_flow: {node.max_flow}")
else:
    print("Not found")
```

```python
try:
    node = model.nodes["River Thames"]
except KeyError:
    print("Not found")
else:
    print(f"max_flow: {node.max_flow}")
```

Closes #786.