### PR TITLE
.labels is deprecated, use .codes instead

### DIFF
--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -315,9 +315,9 @@ def test_scenario_slices(simple_linear_model):
     assert(len(index.levels) == 2)
     assert(len(index.levels[0]) == 10)
     assert(len(index.levels[1]) == 3)
-    assert(len(index.labels) == 2)
-    assert(len(index.labels[0]) == 10 * 3)
-    assert(len(index.labels[1]) == 10 * 3)
+    assert(len(index.codes) == 2)
+    assert(len(index.codes[0]) == 10 * 3)
+    assert(len(index.codes[1]) == 10 * 3)
     assert(index.names == ["A", "B"])
 
     s2.slice = slice(1, 3, 1)


### PR DESCRIPTION
Removes a warning:

```
test_scenarios.py::test_scenario_slices
  /Users/snorf/Desktop/pywr/tests/test_scenarios.py:318: FutureWarning: .labels was deprecated in version 0.24.0. Use .codes instead.
    assert(len(index.labels) == 2)
```