### PR TITLE
Fix warning when incrementing timestep by integers

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -201,8 +201,9 @@ def test_timeseries_excel(simple_linear_model, filename):
     ts = DataFrameParameter.load(model, data)
 
     # model (intentionally not aligned)
-    model.timestepper.start = ts.dataframe.index[0] + 5
-    model.timestepper.end = ts.dataframe.index[-1] - 12
+    index = ts.dataframe.index
+    model.timestepper.start = index[0] + (5 * index.freq)
+    model.timestepper.end = index[-1] - (12 * index.freq)
 
     # need to assign parameter for it's setup method to be called
     model.nodes["Input"].max_flow = ts


### PR DESCRIPTION
Fixes the following warning(s):

```
test_core.py::test_timeseries_excel[models/timeseries1.csv]
  /Users/snorf/Desktop/pywr/tests/test_core.py:205: FutureWarning: Addition/subtraction of integers and integer-arrays to Timestamp is deprecated, will be removed in a future version.  Instead of adding/subtracting `n`, use `n * self.freq`
    model.timestepper.end = ts.dataframe.index[-1] - 12
```