### PR TITLE
Fix duplicated test function names.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -420,10 +420,8 @@ def test_storage_initial_volume_pc():
     np.testing.assert_allclose(storage.volume, 20.0)
 
 
-def test_storage_max_volume_param_raises():
-    """Test a that an max_volume with a Parameter that has children.
-
-    Only some aggregated style parameters should work here.
+def test_storage_max_volume_nested_param():
+    """Test that a max_volume can be used with a Parameter with children.
     """
 
     model = Model(
@@ -445,8 +443,7 @@ def test_storage_max_volume_param_raises():
 
 
 def test_storage_max_volume_param_raises():
-    """Test a that an max_volume with a Parameter that has children is an error
-
+    """Test that a max_volume can not be used with 2 levels of child parameters.
     """
 
     model = Model(


### PR DESCRIPTION
Storage max_volume test function name was repeated. Also tidied up the docstring for the test functions.