### PR TITLE
Added UniformDrawdownProfileParameter

### DIFF
--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -88,6 +88,11 @@ cdef class ScenarioWeeklyProfileParameter(Parameter):
     cdef Scenario _scenario
     cdef int _scenario_index
 
+cdef class UniformDrawdownProfileParameter(Parameter):
+    cdef public int reset_day
+    cdef public int reset_month
+    cdef int _reset_idoy
+
 cdef class IndexParameter(Parameter):
     cpdef int index(self, Timestep timestep, ScenarioIndex scenario_index) except? -1
     cdef int[:] __indices

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -837,7 +837,7 @@ cdef class UniformDrawdownProfileParameter(Parameter):
     """Parameter which provides a uniformly reducing value from one to zero.
 
      This parameter is intended to be used with an `AnnualVirtualStorage` node to provide a profile
-     that represents perfect average utilisation of the annual volume. It returns a value one the
+     that represents perfect average utilisation of the annual volume. It returns a value of 1 on the
      reset day, and subsequently reduces by 1/366 every day afterward.
 
     Parameters

--- a/tests/models/virtual_storage2.json
+++ b/tests/models/virtual_storage2.json
@@ -1,0 +1,75 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage",
+        "description": "Annual abstraction licence implemented as an annual virtual storage with a dynamic cost.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-04-01",
+        "end": "2016-04-01",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 10,
+            "cost": "supply1_cost"
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 5,
+            "cost": 5
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -100
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 3000,
+            "initial_volume": 3000,
+            "nodes": [
+                "supply1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 4
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["supply2", "link1"],
+        ["link1", "demand1"]
+    ],
+    "parameters": {
+        "supply1_cost": {
+            "type": "controlcurve",
+            "storage_node": "licence1",
+            "control_curves": [
+                {
+                    "type": "uniformdrawdownprofile",
+                    "reset_day": 1,
+                    "reset_month": 4
+                }
+            ],
+            "values":[0, 10]
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -322,6 +322,19 @@ def test_annual_virtual_storage():
     assert_allclose(rec.data[21], 0) # licence is exhausted
     assert_allclose(rec.data[365], 10) # licence is refreshed
 
+
+def test_annual_virtual_storage_with_dynamic_cost():
+    model = load_model('virtual_storage2.json')
+    model.run()
+    node = model.nodes["supply1"]
+    rec = node.recorders[0]
+
+    assert_allclose(rec.data[0], 10)  # licence is not a constraint
+    assert_allclose(rec.data[1], 5)  # now used slightly too much; switch to the other source
+    assert_allclose(rec.data[2], 10)  # continue back and forth.
+    assert_allclose(rec.data[3], 5)
+
+
 def test_storage_spill_compensation():
     """Test storage spill and compensation flows
 


### PR DESCRIPTION
This commit adds a new parameter that returns a recurring profile that draws down from 1.0 to 0.0 over the course of a year. The day on which to start the drawdown is configurable with the same keywords
as to `AnnualVirtualStorage`.

Basic tests included. Also added a more complex `AnnualVirtualStorage` test model that uses the new `UniformDrawdownProfileParameter` as a control curve in a dynamic cost calculation.