### PR TITLE
Fix a bug calculating of AggregatedStorage's initial volume.

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -1001,6 +1001,7 @@ cdef class AggregatedStorage(AbstractStorage):
         cdef ScenarioIndex si
 
         for i, si in enumerate(self.model.scenarios.combinations):
+            mxv = 0.0
             for s in self._storage_nodes:
                 mxv += s.get_max_volume(si)
 

--- a/tests/test_aggregated_nodes.py
+++ b/tests/test_aggregated_nodes.py
@@ -45,6 +45,12 @@ def test_aggregated_storage_scenarios(three_storage_model):
     inpt1 = m.nodes['Input 1'].max_flow = ConstantScenarioParameter(m, sc, range(sc.size))
 
     m.setup()
+
+    # Test initial volume
+    np.testing.assert_allclose(agg_stg.volume, sum(s.initial_volume for s in stgs))
+    current_pc = sum(s.initial_volume for s in stgs) / (sum(s.max_volume for s in stgs))
+    np.testing.assert_allclose(agg_stg.current_pc, current_pc)
+
     m.step()
 
     # Finally check volume is summed correctly


### PR DESCRIPTION
The previous calculation did not reset the max volume calculation on each loop of the scenarios. Consequently the max volume accumulated with each scenario, and made the current_pc calculation
incorrect. The bug would only impact the first timestep.