### PR TITLE
Fix resetting licences to maximum volume by default.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -105,7 +105,7 @@ cdef class Storage(AbstractStorage):
     cdef Parameter _max_volume_param
     cdef Parameter _level_param
     cdef Parameter _area_param
-    cpdef _reset_storage_only(self)
+    cpdef _reset_storage_only(self, bint use_initial_volume = *)
     cpdef double get_min_volume(self, ScenarioIndex scenario_index) except? -1
     cpdef double get_max_volume(self, ScenarioIndex scenario_index) except? -1
     cpdef double get_level(self, ScenarioIndex scenario_index) except? -1

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -909,7 +909,14 @@ cdef class Storage(AbstractStorage):
         AbstractStorage.reset(self)
         self._reset_storage_only()
 
-    cpdef _reset_storage_only(self):
+    cpdef _reset_storage_only(self, bint use_initial_volume=True):
+        """Reset the current volume of the storage node.
+
+        Parameters
+        ==========
+        use_initial_volume : bool (default: True)
+            Reset the volume to the initial volume of the storage node. If false the volume is reset to max_volume.
+        """
         cdef int i
         cdef double mxv = self._max_volume
         cdef ScenarioIndex si
@@ -940,12 +947,15 @@ cdef class Storage(AbstractStorage):
             if self._max_volume_param is not None:
                 mxv = self._max_volume_param.get_value(si)
 
-            if np.isfinite(self._initial_volume_pc):
-                self._volume[i] = self._initial_volume_pc * mxv
-            elif np.isfinite(self._initial_volume):
-                self._volume[i] = self._initial_volume
+            if use_initial_volume:
+                if np.isfinite(self._initial_volume_pc):
+                    self._volume[i] = self._initial_volume_pc * mxv
+                elif np.isfinite(self._initial_volume):
+                    self._volume[i] = self._initial_volume
+                else:
+                    raise RuntimeError('Initial volume must be set as either a percentage or absolute volume.')
             else:
-                raise RuntimeError('Initial volume must be set as either a percentage or absolute volume.')
+                self._volume[i] = mxv
 
             try:
                 self._current_pc[i] = self._volume[i] / mxv

--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -496,13 +496,21 @@ class AnnualVirtualStorage(VirtualStorage):
         The day of the month (0-31) to reset the volume to the initial value.
     reset_month: int
         The month of the year (0-12) to reset the volume to the initial value.
+    reset_to_initial_volume: bool
+        Reset the volume to the initial volume instead of maximum volume each year (default is False).
+
     """
     def __init__(self, *args, **kwargs):
         self.reset_day = kwargs.pop('reset_day', 1)
         self.reset_month = kwargs.pop('reset_month', 1)
+        self.reset_to_initial_volume = kwargs.pop('reset_to_initial_volume', False)
         self._last_reset_year = None
 
         super(AnnualVirtualStorage, self).__init__(*args, **kwargs)
+
+    def reset(self):
+        super(AnnualVirtualStorage, self).reset()
+        self._last_reset_year = None
 
     def before(self, ts):
         super(AnnualVirtualStorage, self).before(ts)
@@ -513,7 +521,8 @@ class AnnualVirtualStorage(VirtualStorage):
             # ... we're at or past the reset month/day
             if ts.month > self.reset_month or \
                     (ts.month == self.reset_month and ts.day >= self.reset_day):
-                self._reset_storage_only()
+                # Reset to maximum volume (i.e. full capacity. )
+                self._reset_storage_only(use_initial_volume=self.reset_to_initial_volume)
                 self._last_reset_year = ts.year
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -13,7 +13,7 @@ from pywr.nodes import Storage, Input, Output, Link
 import pywr.solvers
 import pywr.parameters.licenses
 import pywr.domains.river
-
+from pywr.recorders import assert_rec
 from helpers import load_model
 
 import pywr.parameters
@@ -321,6 +321,33 @@ def test_annual_virtual_storage():
     assert_allclose(rec.data[20], 5) # licence is constraint
     assert_allclose(rec.data[21], 0) # licence is exhausted
     assert_allclose(rec.data[365], 10) # licence is refreshed
+
+
+@pytest.mark.parametrize('reset_to_initial_volume', [None, False, True])
+def test_annual_virtual_storage_reset_to_max_volume(reset_to_initial_volume):
+    """Test that AnnualVirtualStorage resets to maximum volume. """
+    model = load_model('virtual_storage1.json')
+    licence1 = model.nodes['licence1']
+    if reset_to_initial_volume is not None:
+        licence1.reset_to_initial_volume = reset_to_initial_volume
+    licence1.initial_volume = 100
+    licence1.reset_month = 4
+
+    model.setup()
+    # After reset the current volume is always the initial volume
+    assert_allclose(licence1.volume, [100.0])
+
+
+    model.timestepper.start = '2015-04-01'
+    model.reset()
+    # After stepping over the reset day the volume should have been reset 
+    # before the solve to either initial volume or maximum volume.
+    model.step()
+    if reset_to_initial_volume:
+        expected_volume = 90.0
+    else:
+        expected_volume = 195.0
+    assert_allclose(licence1.volume, [expected_volume])
 
 
 def test_annual_virtual_storage_with_dynamic_cost():


### PR DESCRIPTION
This commit adds a new keyword argument to the internal storage reset method. The keyword determines whether initial volume or maximum volume are used to reset the current volume. The default remains to use initial volume. However, the AnnualVirtualStorage node uses the keyword to reset to either value based on its own keyword setting. This gives the user the choice whether the AVS node should reset to initial or maximum volume. Tests included.

Fixes #859.