### PR TITLE
Api constantscenarioparameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs/
 # PyInstaller
 # Usually these files are written by a python script from a template
 # before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -66,3 +67,5 @@ venv/
 
 pywr_glpk_debug.lp
 pywr_glpk_debug.mps
+
+build.bat

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -454,6 +454,13 @@ cdef class ConstantScenarioParameter(Parameter):
         # so that it can return the correct value in value()
         self._scenario_index = self.model.scenarios.get_scenario_index(self._scenario)
 
+    cpdef set_double_variables(self, double[:] values):
+        n = len(self._values)
+        self._values[...] = values[0:n]
+
+    cpdef double[:] get_double_variables(self):
+        return np.array(self._values, dtype=np.float64)
+
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         # This is a bit confusing.
         # scenario_indices contains the current scenario number for all


### PR DESCRIPTION
Hi @jetuk, I just implemented the methods `set_double_varibles` and `get_double_variables`. I was thinking to add `get_double_lower_bounds` and `get_double_upper_bounds` but this parameter does not have these properties (lower and upper bounds). I can add these other methods, however, do you think this parameter must have these properties? What was the initial thought (the use) with this parameter? What other methods do you think this parameter must have?

I am creating this MR to start iterating on this.