### PR TITLE
New notebook graph functionality 

### DIFF
--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -51,11 +51,11 @@ class PywrSchematic:
         """
 
         if isinstance(model, Model):
-            self.graph = self.pywr_model_to_d3_json(model, attributes)
+            self.graph = pywr_model_to_d3_json(model, attributes)
             # TODO update when schema branch is merged
             self.json = None
         else:
-            self.graph = self.pywr_json_to_d3_json(model, attributes)
+            self.graph = pywr_json_to_d3_json(model, attributes)
             with open(model) as d:
                 self.json = json.load(d)
 

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -99,7 +99,7 @@ class PywrSchematic:
             node positions to a csv file.
         """
 
-        if self.json is None:
+        if self.json is None and filetype == "json":
             warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using"
                           "a pywr model object. Please use a json file path or model dict instead", stacklevel=2)
         else:

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -69,196 +69,6 @@ class PywrSchematic:
         else:
             self.css = css
 
-    def pywr_model_to_d3_json(self, model, attributes=False):
-        """
-        Convert a Pywr graph to a structure d3 can display
-
-        Parameters
-        ----------
-        model : `pywr.core.Model`
-        attributes: bool (default=False)
-            If True, attribute data for each node is extract
-        """
-        nodes = []
-        node_names = []
-        for node in model.graph.nodes():
-            if node.parent is None and node.virtual is False:
-                nodes.append(node)
-                node_names.append(node.name)
-
-        edges = []
-        for edge in model.graph.edges():
-            node_source, node_target = edge
-
-            # where a link is to/from a subnode, display a link to the parent instead
-            if node_source.parent is not None:
-                node_source = node_source.parent
-            if node_target.parent is not None:
-                node_target = node_target.parent
-
-            if node_source is node_target:
-                # link is between two subnodes
-                continue
-
-            index_source = node_names.index(node_source.name)
-            index_target = node_names.index(node_target.name)
-            edges.append({'source': index_source, 'target': index_target})
-
-        json_nodes = []
-        for n, node in enumerate(nodes):
-            node_dict = {"name": node.name}
-            classes = []
-            cls = node.__class__
-            classes.append(cls)
-            while True:
-                for base in cls.__bases__:
-                    if issubclass(base, Node) and base is not Node:
-                        classes.append(base)
-                if classes[-1] is cls:
-                    break
-                else:
-                    cls = classes[-1]
-            classes = classes[::-1]
-            node_dict["clss"] = [cls.__name__.lower() for cls in classes]
-            try:
-                node_dict["position"] = node.position["schematic"]
-            except KeyError:
-                pass
-
-            if attributes:
-                node_dict["attributes"] = self.get_node_attr(node)
-
-            json_nodes.append(node_dict)
-
-        graph = {
-            "nodes": json_nodes,
-            "links": edges}
-
-        return graph
-
-    def get_node_attr(self, node):
-        """
-        Returns a dictionary that contains node attributes as strings
-
-        Parameters
-        ----------
-        node : a pywr node object
-        """
-        attrs = inspect.getmembers(node, lambda a:not(inspect.isroutine(a)))
-        attribute_data = []
-        for att in attrs:
-
-            attr_name, attr_val = att
-            if attr_name.startswith("_"):
-                continue
-            attr_type = type(attr_val).__name__
-
-            attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
-                            "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
-                            "fully_qualified_name", "allow_isolated"]
-            if not attr_val or attr_name.lower() in attrs_to_skip:
-                continue
-
-            if isinstance(attr_val, Component):
-                attr_val = attr_val.name
-                if not attr_val:
-                    attr_val = attr_type
-                else:
-                    attr_val = attr_val + " - " + attr_type
-
-            if isinstance(attr_val, list):
-                new_vals = []
-                for val in attr_val:
-                    val_name = str(val)
-                    val_name = val_name.replace("[", "").replace("]", "")
-                    new_vals.append(val_name)
-                attr_val = "".join(new_vals)
-            else:
-                attr_val = str(attr_val)
-
-            attribute_data.append({"attribute": attr_name, "value": attr_val})
-
-        return attribute_data
-
-    def pywr_json_to_d3_json(self, model, attributes=False):
-        """
-        Converts a JSON file or a JSON-derived dict into structure that d3js can use.
-
-        Parameters
-        ----------
-        model : dict or str
-            str inputs should be a path to a json file containing the model.
-        """
-
-        if isinstance(model, str):
-            with open(model) as d:
-                model = json.load(d)
-
-        nodes = [node["name"] for node in model["nodes"]]
-
-        edges = []
-        for edge in model["edges"]:
-            sourceindex = nodes.index(edge[0])
-            targetindex = nodes.index(edge[1])
-            edges.append({'source': sourceindex, 'target': targetindex})
-
-        nodes = []
-        node_classes = self.create_node_class_trees()
-
-        for node in model["nodes"]:
-            json_node = {'name': node["name"], 'clss': node_classes[node["type"].lower()]}
-            try:
-                json_node['position'] = node['position']['schematic']
-            except KeyError:
-                pass
-
-            if attributes:
-                json_node["attributes"] = []
-                for name, val in node.items():
-
-                    if name == "type":
-                        continue
-
-                    attr_val = val
-
-                    if isinstance(val, dict):
-                        try:
-                            attr_val = get_parameter_from_registry(val["type"]).__name__
-                        except KeyError:
-                            pass
-                    elif val in model["parameters"].keys():
-                        param = model["parameters"][val]
-                        attr_type = get_parameter_from_registry(param["type"]).__name__
-                        attr_val = attr_val + " - " + attr_type
-
-                    attr_dict = {"attribute": name, "value": attr_val}
-                    json_node["attributes"].append(attr_dict)
-
-            nodes.append(json_node)
-
-        graph = {
-            "nodes": nodes,
-            "links": edges}
-
-        return graph
-
-    def create_node_class_trees(self):
-        # create class tree for each node type
-        node_class_trees = {}
-        for name, cls in NodeMeta.node_registry.items():
-            classes = [cls]
-            while True:
-                for base in cls.__bases__:
-                    if issubclass(base, Node) and base is not Node:
-                        classes.append(base)
-                if classes[-1] is cls:
-                    break
-                else:
-                    cls = classes[-1]
-            clss = [cls.__name__.lower() for cls in classes[::-1]]
-            node_class_trees[name] = clss
-        return node_class_trees
-
     def draw_graph(self):
         """Draw pywr schematic graph in a jupyter notebook"""
         js = draw_graph_template.render(
@@ -309,3 +119,197 @@ class PywrSchematic:
 
         with open(filename, "w") as f:
             f.write(html)
+
+
+def pywr_model_to_d3_json(model, attributes=False):
+    """
+    Convert a Pywr graph to a structure d3 can display
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+    attributes: bool (default=False)
+        If True, attribute data for each node is extract
+    """
+    nodes = []
+    node_names = []
+    for node in model.graph.nodes():
+        if node.parent is None and node.virtual is False:
+            nodes.append(node)
+            node_names.append(node.name)
+
+    edges = []
+    for edge in model.graph.edges():
+        node_source, node_target = edge
+
+        # where a link is to/from a subnode, display a link to the parent instead
+        if node_source.parent is not None:
+            node_source = node_source.parent
+        if node_target.parent is not None:
+            node_target = node_target.parent
+
+        if node_source is node_target:
+            # link is between two subnodes
+            continue
+
+        index_source = node_names.index(node_source.name)
+        index_target = node_names.index(node_target.name)
+        edges.append({'source': index_source, 'target': index_target})
+
+    json_nodes = []
+    for n, node in enumerate(nodes):
+        node_dict = {"name": node.name}
+        classes = []
+        cls = node.__class__
+        classes.append(cls)
+        while True:
+            for base in cls.__bases__:
+                if issubclass(base, Node) and base is not Node:
+                    classes.append(base)
+            if classes[-1] is cls:
+                break
+            else:
+                cls = classes[-1]
+        classes = classes[::-1]
+        node_dict["clss"] = [cls.__name__.lower() for cls in classes]
+        try:
+            node_dict["position"] = node.position["schematic"]
+        except KeyError:
+            pass
+
+        if attributes:
+            node_dict["attributes"] = get_node_attr(node)
+
+        json_nodes.append(node_dict)
+
+    graph = {
+        "nodes": json_nodes,
+        "links": edges}
+
+    return graph
+
+
+def get_node_attr(node):
+    """
+    Returns a dictionary that contains node attributes as strings
+
+    Parameters
+    ----------
+    node : a pywr node object
+    """
+    attrs = inspect.getmembers(node, lambda a:not(inspect.isroutine(a)))
+    attribute_data = []
+    for att in attrs:
+
+        attr_name, attr_val = att
+        if attr_name.startswith("_"):
+            continue
+        attr_type = type(attr_val).__name__
+
+        attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
+                        "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
+                        "fully_qualified_name", "allow_isolated"]
+        if not attr_val or attr_name.lower() in attrs_to_skip:
+            continue
+
+        if isinstance(attr_val, Component):
+            attr_val = attr_val.name
+            if not attr_val:
+                attr_val = attr_type
+            else:
+                attr_val = attr_val + " - " + attr_type
+
+        if isinstance(attr_val, list):
+            new_vals = []
+            for val in attr_val:
+                val_name = str(val)
+                val_name = val_name.replace("[", "").replace("]", "")
+                new_vals.append(val_name)
+            attr_val = "".join(new_vals)
+        else:
+            attr_val = str(attr_val)
+
+        attribute_data.append({"attribute": attr_name, "value": attr_val})
+
+    return attribute_data
+
+
+def pywr_json_to_d3_json(model, attributes=False):
+    """
+    Converts a JSON file or a JSON-derived dict into structure that d3js can use.
+
+    Parameters
+    ----------
+    model : dict or str
+        str inputs should be a path to a json file containing the model.
+    """
+
+    if isinstance(model, str):
+        with open(model) as d:
+            model = json.load(d)
+
+    nodes = [node["name"] for node in model["nodes"]]
+
+    edges = []
+    for edge in model["edges"]:
+        sourceindex = nodes.index(edge[0])
+        targetindex = nodes.index(edge[1])
+        edges.append({'source': sourceindex, 'target': targetindex})
+
+    nodes = []
+    node_classes = create_node_class_trees()
+
+    for node in model["nodes"]:
+        json_node = {'name': node["name"], 'clss': node_classes[node["type"].lower()]}
+        try:
+            json_node['position'] = node['position']['schematic']
+        except KeyError:
+            pass
+
+        if attributes:
+            json_node["attributes"] = []
+            for name, val in node.items():
+
+                if name == "type":
+                    continue
+
+                attr_val = val
+
+                if isinstance(val, dict):
+                    try:
+                        attr_val = get_parameter_from_registry(val["type"]).__name__
+                    except KeyError:
+                        pass
+                elif val in model["parameters"].keys():
+                    param = model["parameters"][val]
+                    attr_type = get_parameter_from_registry(param["type"]).__name__
+                    attr_val = attr_val + " - " + attr_type
+
+                attr_dict = {"attribute": name, "value": attr_val}
+                json_node["attributes"].append(attr_dict)
+
+        nodes.append(json_node)
+
+    graph = {
+        "nodes": nodes,
+        "links": edges}
+
+    return graph
+
+
+def create_node_class_trees():
+    # create class tree for each node type
+    node_class_trees = {}
+    for name, cls in NodeMeta.node_registry.items():
+        classes = [cls]
+        while True:
+            for base in cls.__bases__:
+                if issubclass(base, Node) and base is not Node:
+                    classes.append(base)
+            if classes[-1] is cls:
+                break
+            else:
+                cls = classes[-1]
+        clss = [cls.__name__.lower() for cls in classes[::-1]]
+        node_class_trees[name] = clss
+    return node_class_trees

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -21,6 +21,8 @@ with open(os.path.join(folder, "save_graph.js"), "r") as f:
     save_graph_template = Template(f.read())
 with open(os.path.join(folder, "graph.css"), "r") as f:
     draw_graph_css = f.read()
+with open(os.path.join(folder, "template.html"), "r") as f:
+    html_template = Template(f.read())
 
 
 class PywrSchematic:
@@ -54,20 +56,13 @@ class PywrSchematic:
 
         self.height = height
         self.width = width
+        self.labels = labels
+        self.attributes = attributes
 
         if css is None:
-            css = draw_graph_css
-
-        self.js = Javascript(
-            data=draw_graph_template.render(
-                graph=self.graph,
-                width=self.width,
-                height=self.height,
-                labels=labels,
-                attributes=attributes,
-                css=css.replace("\n","")
-            )
-        )
+            self.css = draw_graph_css
+        else:
+            self.css = css
 
     def pywr_model_to_d3_json(self, model, attributes=False):
         """
@@ -260,7 +255,16 @@ class PywrSchematic:
         return node_class_trees
 
     def draw_graph(self):
-        display(self.js)
+        js = draw_graph_template.render(
+            graph=self.graph,
+            width=self.width,
+            height=self.height,
+            element="element",
+            labels=self.labels,
+            attributes=self.attributes,
+            css=self.css.replace("\n", "")
+        ) 
+        display(Javascript(data=js))
 
     def save_graph(self, filename="model"):
         """Save a copy of the model json with update schematic positions"""
@@ -271,10 +275,25 @@ class PywrSchematic:
             filename=json.dumps(filename)
         )))
 
-    def print_graph_positions_html(self):
-        """Print list of all node positions to console"""
-        # TODO
 
-    def to_html(self):
+    def to_html(self, filename, title="Model Schematic"):
         """Save an HTML file of schematic"""
-        # TODO
+
+        js = draw_graph_template.render(
+            graph=self.graph,
+            width=self.width,
+            height=self.height,
+            element=json.dumps(".schematic"),
+            labels=self.labels,
+            attributes=self.attributes,
+            css=""
+        ) 
+
+        html = html_template.render(
+            title=title,
+            css=self.css,
+            d3_script=js
+        )
+
+        with open(filename, "w") as f:
+            f.write(html)

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -31,7 +31,7 @@ class PywrSchematic:
         notebook or saved to an html file.
 
         It also contains a method to save the node positions of a notebook graph back to a pywr model json file. Note
-        that this method currently odoes not work if the object has be instantiated using a model object. 
+        that this method currently does not work if the object has be instantiated using a model object.
 
         Parameters
         ----------
@@ -82,38 +82,46 @@ class PywrSchematic:
         )
         display(Javascript(data=js))
 
-    def save_graph(self, filename="model.json"):
-        """Save a copy of the model json with update schematic positions"""
+    def save_graph(self, filename, save_unfixed=False, filetype="json"):
+        """Save a copy of the model json with update schematic positions.
+
+        When run in a jupyter notebook this will trigger a download.
+
+        Parameters
+        ----------
+        filename: str
+            The name of the file to save the output data to.
+        save_unfixed: bool
+            If True, then all node position are saved to output file. If False, only nodes who have had their position
+            fixed in the d3 grpah have their positions saved.
+        filetype: str
+            Should be either 'json' to save the model data with updated node positions to a json file or 'csv' to save
+            node positions to a csv file.
+        """
 
         if self.json is None:
             warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using"
-                          "a pywr model object. Please use a json file path or Python dict instead", stacklevel=2)
+                          "a pywr model object. Please use a json file path or model dict instead", stacklevel=2)
         else:
             display(Javascript(save_graph_template.render(
                 model_data=json.dumps(self.json),
                 height=self.height,
                 width=self.width,
+                save_unfixed=json.dumps(save_unfixed),
                 filename=json.dumps(filename),
-                filetype=json.dumps("model_json")
+                filetype=json.dumps(filetype)
             )))
 
-    def save_positions(self, filename="node_positions.csv"):
-        """Save a copy of the model json with update schematic positions"""
+    def to_html(self, filename="model.html", title="Model Schematic"):
+        """Save an HTML file of schematic
 
-        if self.json is None:
-            warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using"
-                          "a pywr model object. Please use a json file path or Python dict instead", stacklevel=2)
-        else:
-            display(Javascript(save_graph_template.render(
-                model_data=json.dumps(self.json),
-                height=self.height,
-                width=self.width,
-                filename=json.dumps(filename),
-                filetype=json.dumps("csv")
-            )))
-
-    def to_html(self, filename, title="Model Schematic"):
-        """Save an HTML file of schematic"""
+        Parameters
+        ----------
+        filename: str
+            The name of the html file
+        title: str
+            The schematic title
+        """
 
         # TODO add option to get node position from graph that has already been drawn in a notebook
 
@@ -222,9 +230,9 @@ def get_node_attr(node):
             continue
         attr_type = type(attr_val).__name__
 
-        attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
-                        "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
-                        "fully_qualified_name", "allow_isolated"]
+        attrs_to_skip = ["component_attrs", "components", "color", "model", "input", "output",
+                         "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
+                         "fully_qualified_name", "allow_isolated"]
         if not attr_val or attr_name.lower() in attrs_to_skip:
             continue
 

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -100,8 +100,8 @@ class PywrSchematic:
         """
 
         if self.json is None and filetype == "json":
-            warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using"
-                          "a pywr model object. Please use a json file path or model dict instead", stacklevel=2)
+            warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using "
+                          "a pywr model object. Please use a json file path or model dict instead.", stacklevel=2)
         else:
             display(Javascript(save_graph_template.render(
                 model_data=json.dumps(self.json),

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -93,7 +93,23 @@ class PywrSchematic:
                 model_data=json.dumps(self.json),
                 height=self.height,
                 width=self.width,
-                filename=json.dumps(filename)
+                filename=json.dumps(filename),
+                filetype=json.dumps("model_json")
+            )))
+
+    def save_positions(self, filename="node_positions.csv"):
+        """Save a copy of the model json with update schematic positions"""
+
+        if self.json is None:
+            warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using"
+                          "a pywr model object. Please use a json file path or Python dict instead", stacklevel=2)
+        else:
+            display(Javascript(save_graph_template.render(
+                model_data=json.dumps(self.json),
+                height=self.height,
+                width=self.width,
+                filename=json.dumps(filename),
+                filetype=json.dumps("csv")
             )))
 
     def to_html(self, filename, title="Model Schematic"):

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -145,6 +145,15 @@ class PywrSchematic:
             f.write(html)
 
 
+def draw_graph(model, width=500, height=400, labels=False, attributes=False, css=None):
+    """Display a Pywr model using D3 in Jupyter
+
+    Functionality for creating the d3 graph is now in the PywrSchematic object
+    """
+    schematic = PywrSchematic(model, width=width, height=height, labels=labels, attributes=attributes, css=css)
+    schematic.draw_graph()
+
+
 def pywr_model_to_d3_json(model, attributes=False):
     """
     Convert a Pywr graph to a structure d3 can display

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -83,7 +83,7 @@ class PywrSchematic:
         display(Javascript(data=js))
 
     def save_graph(self, filename, save_unfixed=False, filetype="json"):
-        """Save a copy of the model json with update schematic positions.
+        """Save a copy of the model JSON with update schematic positions.
 
         When run in a jupyter notebook this will trigger a download.
 
@@ -93,15 +93,19 @@ class PywrSchematic:
             The name of the file to save the output data to.
         save_unfixed: bool
             If True, then all node position are saved to output file. If False, only nodes who have had their position
-            fixed in the d3 grpah have their positions saved.
+            fixed in the d3 graph have their positions saved.
         filetype: str
-            Should be either 'json' to save the model data with updated node positions to a json file or 'csv' to save
+            Should be either 'json' to save the model data with updated node positions to a JSON file or 'csv' to save
             node positions to a csv file.
         """
 
+        if filetype not in ["json", "csv"]:
+            warnings.warn(f"Output filetype '{filetype}' not recognised. Please use either 'json' or 'csv'</p>",
+                          stacklevel=2)
+
         if self.json is None and filetype == "json":
-            warnings.warn("Node positions cannot be saved to json if PywrSchematic object has been instantiated using "
-                          "a pywr model object. Please use a json file path or model dict instead.", stacklevel=2)
+            warnings.warn("Node positions cannot be saved to JSON if PywrSchematic object has been instantiated using "
+                          "a pywr model object. Please use a JSON file path or model dict instead.", stacklevel=2)
         else:
             display(Javascript(save_graph_template.render(
                 model_data=json.dumps(self.json),

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -17,245 +17,264 @@ from .figures import *
 folder = os.path.dirname(__file__)
 with open(os.path.join(folder, "draw_graph.js"), "r") as f:
     draw_graph_template = Template(f.read())
+with open(os.path.join(folder, "save_graph.js"), "r") as f:
+    save_graph_template = Template(f.read())
 with open(os.path.join(folder, "graph.css"), "r") as f:
     draw_graph_css = f.read()
 
-def pywr_model_to_d3_json(model, attributes=False):
-    """
-    Convert a Pywr graph to a structure d3 can display
 
-    Parameters
-    ----------
-    model : `pywr.core.Model`
-    attributes: bool (default=False)
-        If True, attribute data for each node is extract
-    """
-    nodes = []
-    node_names = []
-    for node in model.graph.nodes():
-        if node.parent is None and node.virtual is False:
-            nodes.append(node)
-            node_names.append(node.name)
+class PywrSchematic:
 
-    edges = []
-    for edge in model.graph.edges():
-        node_source, node_target = edge
+    def __init__(self, model, width=500, height=400, labels=False, attributes=False, css=None):
+        """Display a Pywr model using D3 in Jupyter
 
-        # where a link is to/from a subnode, display a link to the parent instead
-        if node_source.parent is not None:
-            node_source = node_source.parent
-        if node_target.parent is not None:
-            node_target = node_target.parent
+        Parameters
+        ----------
+        model : pywr.core.Model or json-dict that describes a model
+            The model to display
+        width : int
+            The width of the svg canvas to draw the graph on
+        height : int
+            The height of the svg canvas to draw the graph on
+        labels : bool
+            If True, each graph node is labelled with its name. If false, the node names are displayed
+            during mouseover events
+        attributes : bool
+            If True, a table of node attributes is displayed during mouseover events
+        css : string
+            Stylesheet data to use instead of default
+        """
 
-        if node_source is node_target:
-            # link is between two subnodes
-            continue
-
-        index_source = node_names.index(node_source.name)
-        index_target = node_names.index(node_target.name)
-        edges.append({'source': index_source, 'target': index_target})
-
-    json_nodes = []
-    for n, node in enumerate(nodes):
-        node_dict = {"name": node.name}
-        classes = []
-        cls = node.__class__
-        classes.append(cls)
-        while True:
-            for base in cls.__bases__:
-                if issubclass(base, Node) and base is not Node:
-                    classes.append(base)
-            if classes[-1] is cls:
-                break
-            else:
-                cls = classes[-1]
-        classes = classes[::-1]
-        node_dict["clss"] = [cls.__name__.lower() for cls in classes]
-        try:
-            node_dict["position"] = node.position["schematic"]
-        except KeyError:
-            pass
-
-        if attributes:
-            node_dict["attributes"] = get_node_attr(node)
-
-        json_nodes.append(node_dict)
-
-    graph = {
-        "nodes": json_nodes,
-        "links": edges}
-
-
-    return graph
-
-def get_node_attr(node):
-    """
-    Returns a dictionary that contains node attributes as strings
-
-    Parameters
-    ----------
-    node : a pywr node object
-    """
-    attrs = inspect.getmembers(node, lambda a:not(inspect.isroutine(a)))
-    attribute_data = []
-    for att in attrs:
-
-        attr_name, attr_val = att
-        if attr_name.startswith("_"):
-            continue
-        attr_type = type(attr_val).__name__
-
-        attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
-                         "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
-                         "fully_qualified_name", "allow_isolated"]
-        if not attr_val or attr_name.lower() in attrs_to_skip:
-            continue
-
-        if isinstance(attr_val, Component):
-            attr_val = attr_val.name
-            if not attr_val:
-                attr_val = attr_type
-            else:
-                attr_val = attr_val + " - " + attr_type
-
-        if isinstance(attr_val, list):
-            new_vals = []
-            for val in attr_val:
-                val_name = str(val)
-                val_name = val_name.replace("[", "").replace("]", "")
-                new_vals.append(val_name)
-            attr_val = "".join(new_vals)
+        if isinstance(model, Model):
+            self.graph = self.pywr_model_to_d3_json(model, attributes)
         else:
-            attr_val = str(attr_val)
+            self.graph = self.pywr_json_to_d3_json(model, attributes)
+            with open(model) as d:
+                self.json = json.load(d)
 
-        attribute_data.append({"attribute": attr_name, "value": attr_val})
+        self.height = height
+        self.width = width
 
-    return attribute_data
+        if css is None:
+            css = draw_graph_css
 
+        self.js = Javascript(
+            data=draw_graph_template.render(
+                graph=self.graph,
+                width=self.width,
+                height=self.height,
+                labels=labels,
+                attributes=attributes,
+                css=css.replace("\n","")
+            )
+        )
 
-def pywr_json_to_d3_json(model, attributes=False):
-    """
-    Converts a JSON file or a JSON-derived dict into structure that d3js can use.
+    def pywr_model_to_d3_json(self, model, attributes=False):
+        """
+        Convert a Pywr graph to a structure d3 can display
 
-    Parameters
-    ----------
-    model : dict or str
-        str inputs should be a path to a json file containing the model.
-    """
+        Parameters
+        ----------
+        model : `pywr.core.Model`
+        attributes: bool (default=False)
+            If True, attribute data for each node is extract
+        """
+        nodes = []
+        node_names = []
+        for node in model.graph.nodes():
+            if node.parent is None and node.virtual is False:
+                nodes.append(node)
+                node_names.append(node.name)
 
-    if isinstance(model, str):
-        with open(model) as d:
-            model = json.load(d)
+        edges = []
+        for edge in model.graph.edges():
+            node_source, node_target = edge
 
-    nodes = [node["name"] for node in model["nodes"]]
+            # where a link is to/from a subnode, display a link to the parent instead
+            if node_source.parent is not None:
+                node_source = node_source.parent
+            if node_target.parent is not None:
+                node_target = node_target.parent
 
-    edges = []
-    for edge in model["edges"]:
-        sourceindex = nodes.index(edge[0])
-        targetindex = nodes.index(edge[1])
-        edges.append({'source': sourceindex, 'target': targetindex})
+            if node_source is node_target:
+                # link is between two subnodes
+                continue
 
-    nodes = []
-    node_classes = create_node_class_trees()
+            index_source = node_names.index(node_source.name)
+            index_target = node_names.index(node_target.name)
+            edges.append({'source': index_source, 'target': index_target})
 
-    for node in model["nodes"]:
-        json_node = {'name': node["name"], 'clss': node_classes[node["type"].lower()]}
-        try:
-            json_node['position'] = node['position']['schematic']
-        except KeyError:
-            pass
+        json_nodes = []
+        for n, node in enumerate(nodes):
+            node_dict = {"name": node.name}
+            classes = []
+            cls = node.__class__
+            classes.append(cls)
+            while True:
+                for base in cls.__bases__:
+                    if issubclass(base, Node) and base is not Node:
+                        classes.append(base)
+                if classes[-1] is cls:
+                    break
+                else:
+                    cls = classes[-1]
+            classes = classes[::-1]
+            node_dict["clss"] = [cls.__name__.lower() for cls in classes]
+            try:
+                node_dict["position"] = node.position["schematic"]
+            except KeyError:
+                pass
 
-        if attributes:
-            json_node["attributes"] = []
-            for name, val in node.items():
+            if attributes:
+                node_dict["attributes"] = self.get_node_attr(node)
 
-                if name == "type":
-                    continue
+            json_nodes.append(node_dict)
 
-                attr_val = val
+        graph = {
+            "nodes": json_nodes,
+            "links": edges}
 
-                if isinstance(val, dict):
-                    try:
-                        attr_val = get_parameter_from_registry(val["type"]).__name__
-                    except KeyError:
-                        pass
-                elif val in model["parameters"].keys():
-                    param = model["parameters"][val]
-                    attr_type = get_parameter_from_registry(param["type"]).__name__
+        return graph
+
+    def get_node_attr(self, node):
+        """
+        Returns a dictionary that contains node attributes as strings
+
+        Parameters
+        ----------
+        node : a pywr node object
+        """
+        attrs = inspect.getmembers(node, lambda a:not(inspect.isroutine(a)))
+        attribute_data = []
+        for att in attrs:
+
+            attr_name, attr_val = att
+            if attr_name.startswith("_"):
+                continue
+            attr_type = type(attr_val).__name__
+
+            attrs_to_skip = ["component_attrs", "components", "color", "model",  "input", "output",
+                            "inputs", "outputs", "sub_domain", "sub_output", "sublinks", "visible",
+                            "fully_qualified_name", "allow_isolated"]
+            if not attr_val or attr_name.lower() in attrs_to_skip:
+                continue
+
+            if isinstance(attr_val, Component):
+                attr_val = attr_val.name
+                if not attr_val:
+                    attr_val = attr_type
+                else:
                     attr_val = attr_val + " - " + attr_type
 
-                attr_dict = {"attribute": name, "value": attr_val}
-                json_node["attributes"].append(attr_dict)
-
-        nodes.append(json_node)
-
-    graph = {
-        "nodes": nodes,
-        "links": edges}
-
-    return graph
-
-
-def create_node_class_trees():
-    # create class tree for each node type
-    node_class_trees = {}
-    for name, cls in NodeMeta.node_registry.items():
-        classes = [cls]
-        while True:
-            for base in cls.__bases__:
-                if issubclass(base, Node) and base is not Node:
-                    classes.append(base)
-            if classes[-1] is cls:
-                break
+            if isinstance(attr_val, list):
+                new_vals = []
+                for val in attr_val:
+                    val_name = str(val)
+                    val_name = val_name.replace("[", "").replace("]", "")
+                    new_vals.append(val_name)
+                attr_val = "".join(new_vals)
             else:
-                cls = classes[-1]
-        clss = [cls.__name__.lower() for cls in classes[::-1]]
-        node_class_trees[name] = clss
-    return node_class_trees
+                attr_val = str(attr_val)
 
+            attribute_data.append({"attribute": attr_name, "value": attr_val})
 
-def draw_graph(model, width=500, height=400, labels=False, attributes=False, css=None):
-    """Display a Pywr model using D3 in Jupyter
+        return attribute_data
 
-    Parameters
-    ----------
-    model : pywr.core.Model or json-dict that describes a model
-        The model to display
-    width : int
-        The width of the svg canvas to draw the graph on
-    height : int
-        The height of the svg canvas to draw the graph on
-    labels : bool
-        If True, each graph node is labelled with its name. If false, the node names are displayed
-        during mouseover events
-    attributes : bool
-        If True, a table of node attributes is displayed during mouseover events
-    css : string
-        Stylesheet data to use instead of default
-    """
-    js = _draw_graph(model, width, height, labels, attributes, css)
-    display(js)
+    def pywr_json_to_d3_json(self, model, attributes=False):
+        """
+        Converts a JSON file or a JSON-derived dict into structure that d3js can use.
 
+        Parameters
+        ----------
+        model : dict or str
+            str inputs should be a path to a json file containing the model.
+        """
 
-def _draw_graph(model, width=500, height=400, labels=False, attributes=False, css=None):
-    """Creates Javascript/D3 code for graph"""
-    if isinstance(model, Model):
-        graph = pywr_model_to_d3_json(model, attributes)
-    else:
-        graph = pywr_json_to_d3_json(model, attributes)
+        if isinstance(model, str):
+            with open(model) as d:
+                model = json.load(d)
 
-    if css is None:
-        css = draw_graph_css
+        nodes = [node["name"] for node in model["nodes"]]
 
-    js = Javascript(
-        data=draw_graph_template.render(
-            graph=graph,
-            width=width,
-            height=height,
-            labels=labels,
-            attributes=attributes,
-            css=css.replace("\n","")
-        )
-    )
+        edges = []
+        for edge in model["edges"]:
+            sourceindex = nodes.index(edge[0])
+            targetindex = nodes.index(edge[1])
+            edges.append({'source': sourceindex, 'target': targetindex})
 
-    return js
+        nodes = []
+        node_classes = self.create_node_class_trees()
+
+        for node in model["nodes"]:
+            json_node = {'name': node["name"], 'clss': node_classes[node["type"].lower()]}
+            try:
+                json_node['position'] = node['position']['schematic']
+            except KeyError:
+                pass
+
+            if attributes:
+                json_node["attributes"] = []
+                for name, val in node.items():
+
+                    if name == "type":
+                        continue
+
+                    attr_val = val
+
+                    if isinstance(val, dict):
+                        try:
+                            attr_val = get_parameter_from_registry(val["type"]).__name__
+                        except KeyError:
+                            pass
+                    elif val in model["parameters"].keys():
+                        param = model["parameters"][val]
+                        attr_type = get_parameter_from_registry(param["type"]).__name__
+                        attr_val = attr_val + " - " + attr_type
+
+                    attr_dict = {"attribute": name, "value": attr_val}
+                    json_node["attributes"].append(attr_dict)
+
+            nodes.append(json_node)
+
+        graph = {
+            "nodes": nodes,
+            "links": edges}
+
+        return graph
+
+    def create_node_class_trees(self):
+        # create class tree for each node type
+        node_class_trees = {}
+        for name, cls in NodeMeta.node_registry.items():
+            classes = [cls]
+            while True:
+                for base in cls.__bases__:
+                    if issubclass(base, Node) and base is not Node:
+                        classes.append(base)
+                if classes[-1] is cls:
+                    break
+                else:
+                    cls = classes[-1]
+            clss = [cls.__name__.lower() for cls in classes[::-1]]
+            node_class_trees[name] = clss
+        return node_class_trees
+
+    def draw_graph(self):
+        display(self.js)
+
+    def save_graph(self, filename="model"):
+        """Save a copy of the model json with update schematic positions"""
+        display(Javascript(save_graph_template.render(
+            model_data=json.dumps(self.json),
+            height=self.height,
+            width=self.width,
+            filename=json.dumps(filename)
+        )))
+
+    def print_graph_positions_html(self):
+        """Print list of all node positions to console"""
+        # TODO
+
+    def to_html(self):
+        """Save an HTML file of schematic"""
+        # TODO

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -11,7 +11,7 @@ require(["d3"], function(d3) {
     const style = d3.selectAll(element).append("style");
     style.html("{{ css }}");
 
-    const div = d3.selectAll(element).append("div");
+    const div = d3.selectAll(element).append("div").classed("pywr_schematic", true);
 
     const width = {{ width }},
         height = {{ height }};
@@ -38,12 +38,12 @@ require(["d3"], function(d3) {
         .range([0, height])
         .domain([100, -100]); // map-style, +ve is up
 
-    // set initial node positions 
+    // set initial node positions
     for (let i = 0; i < nodes.length; i++) {
         let n = nodes[i];
         if (n.position != undefined) {
-            n.x = posX(n.position[0]);
-            n.y = posY(n.position[1]);
+            n.fx = posX(n.position[0]);
+            n.fy = posY(n.position[1]);
             n.fixed = true;
         } else {
             n.fixed = false;
@@ -92,6 +92,7 @@ require(["d3"], function(d3) {
         
         function dragended(d) {
         if (!d3.event.active) simulation.alphaTarget(0);
+        d.fixed = true;
         }
         
         return d3.drag()

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -8,10 +8,10 @@ require(["d3"], function(d3) {
     const links = graph.links.map(d => Object.create(d));
     const nodes = graph.nodes.map(d => Object.create(d));
 
-    const style = d3.selectAll(element).append("style");
+    const style = d3.selectAll({{ element }}).append("style");
     style.html("{{ css }}");
 
-    const div = d3.selectAll(element).append("div").classed("pywr_schematic", true);
+    const div = d3.selectAll({{ element }}).append("div").classed("pywr_schematic", true);
 
     const width = {{ width }},
         height = {{ height }};
@@ -163,7 +163,7 @@ require(["d3"], function(d3) {
             
             d3.select(".table-tooltip").remove();
 
-            const table  = d3.selectAll(element)
+            const table  = d3.selectAll({{ element }})
                         .append("table")
                         .classed("table-tooltip", true);
 

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -137,6 +137,12 @@ require(["d3"], function(d3) {
 
     function tick() {
 
+        node.attr("transform", function(d) {
+            d.x = Math.max(node_size, Math.min(width - node_size, d.x))
+            d.y = Math.max(node_size, Math.min(height - node_size, d.y));
+            return "translate(" + d.x + "," + d.y + ")";
+        });
+
         link.attr("d", function(d) {
             let deltaX = d.target.x - d.source.x,
                 deltaY = d.target.y - d.source.y,
@@ -150,10 +156,6 @@ require(["d3"], function(d3) {
                 targetX = d.target.x - (targetPadding * normX),
                 targetY = d.target.y - (targetPadding * normY);
             return "M" + sourceX + "," + sourceY + "L" + targetX + "," + targetY;
-        });
-
-        node.attr("transform", function(d) {
-            return "translate(" + d.x + "," + d.y + ")";
         });
     }
     simulation.on("tick", tick);

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -203,4 +203,7 @@ require(["d3"], function(d3) {
             d3.select(".table-tooltip").transition().delay(2000).remove();
         });
     {% endif %}
-})
+
+}, function(err) {
+    element.append("<p style='color:red'>d3 failed to load:" + err + "</p>");   
+});

--- a/pywr/notebook/draw_graph.js
+++ b/pywr/notebook/draw_graph.js
@@ -138,6 +138,7 @@ require(["d3"], function(d3) {
     function tick() {
 
         node.attr("transform", function(d) {
+            // ensure nodes do not go beyond svg bounds
             d.x = Math.max(node_size, Math.min(width - node_size, d.x))
             d.y = Math.max(node_size, Math.min(height - node_size, d.y));
             return "translate(" + d.x + "," + d.y + ")";

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -4,14 +4,17 @@ require.config({paths: {d3: 'https://d3js.org/d3.v5.min'}});
   
 require(["d3"], function(d3) {
 
-    const model_data = {{ model_data }};
+    const model_data = {{ model_data }},
+    filetype = {{ filetype }},
+    filename = {{ filename }},
+    save_unfixed = {{ save_unfixed }};
 
     const width = {{ width }},
         height = {{ height }};
 
     const nodes = d3.select(".pywr_schematic").selectAll(".node").data();
 
-    const node_data_obj = {}
+    const node_data_obj = {};
     nodes.forEach(element => {
         node_data_obj[element.name] = element
     });
@@ -23,35 +26,43 @@ require(["d3"], function(d3) {
     const posY = d3.scaleLinear() 
                    .range([100, -100])
                    .domain([0, height]);
-    
-    const filename = {{ filename }};
 
-    if ({{filetype}} == "model_json"){
-        for (let i = 0; i < model_data.nodes.length; i++){
-            let node_name = model_data.nodes[i].name;
-            let node_data = node_data_obj[node_name]
-            if (node_data.fixed){
+    const output_data = ["Node name,Fixed,x,y"];
+    // loop through model nodes and get postions
+    for (let i = 0; i < model_data.nodes.length; i++){
+        
+        let node_name = model_data.nodes[i].name;
+        let node_data = node_data_obj[node_name];
+
+        if (!(node_data.fixed) && !(save_unfixed)) {
+            // If node is unfixed and unfixed node positions are not being saved move to next node
+            continue
+        }
+
+        if (filetype == "json"){
+            if ("position" in model_data["nodes"][i]){
+                // ensure that any geographic position are not overwritten
+                model_data["nodes"][i]["position"]["schematic"] = [posX(node_data.x), posY(node_data.y)]
+            } else {
                 model_data["nodes"][i]["position"] = {"schematic": [posX(node_data.x), posY(node_data.y)]}
             }
-        }
-        download(filename, JSON.stringify(model_data));
-    } else {
-        let output_data = ["Node name,Fixed,x,y"];
-        for (let i = 0; i < model_data.nodes.length; i++){
-            let node_name = model_data.nodes[i].name;
-            let node_data = node_data_obj[node_name]
+        } else if (filetype == "csv") {
             let position_data = [
                 node_name,
                 node_data.fixed,
                 posX(node_data.x),
                 posY(node_data.y),
-            ]
-            output_data.push(position_data.join(","))
+            ];
+            output_data.push(position_data.join(","));
         }
-        download(filename, output_data.join("\n"));
+        // TODO append error message if filetype not recognised
     }
 
-    
+    if (filetype == "json"){
+        download(filename, JSON.stringify(model_data));
+    } else if (filetype == "csv"){
+        download(filename, output_data.join("\n"));
+    }
       
 });
 

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -48,8 +48,7 @@ require(["d3"], function(d3) {
                 posY(node_data.y),
             ];
             output_data.push(position_data.join(","));
-        }
-        // TODO append error message if filetype not recognised
+        } 
     }
 
     if (filetype == "json"){
@@ -58,6 +57,8 @@ require(["d3"], function(d3) {
         download(filename, output_data.join("\n"));
     }
       
+}, function(err) {
+    element.append("<p style='color:red'>d3.js failed to load:" + err + "</p>");
 });
 
 function download(filename, text) {

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -14,11 +14,6 @@ require(["d3"], function(d3) {
 
     const nodes = d3.select(".pywr_schematic").selectAll(".node").data();
 
-    const node_data_obj = {};
-    nodes.forEach(element => {
-        node_data_obj[element.name] = element
-    });
-
     // scales to convert back to values between -100 and 100
     const posX = d3.scaleLinear()
                     .range([-100, 100])
@@ -29,10 +24,9 @@ require(["d3"], function(d3) {
 
     const output_data = ["Node name,Fixed,x,y"];
     // loop through model nodes and get postions
-    for (let i = 0; i < model_data.nodes.length; i++){
+    for (let i = 0; i < nodes.length; i++){
         
-        let node_name = model_data.nodes[i].name;
-        let node_data = node_data_obj[node_name];
+        let node_data = nodes[i];
 
         if (!(node_data.fixed) && !(save_unfixed)) {
             // If node is unfixed and unfixed node positions are not being saved move to next node
@@ -48,7 +42,7 @@ require(["d3"], function(d3) {
             }
         } else if (filetype == "csv") {
             let position_data = [
-                node_name,
+                node_data.name,
                 node_data.fixed,
                 posX(node_data.x),
                 posY(node_data.y),

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -1,0 +1,53 @@
+
+
+require.config({paths: {d3: 'https://d3js.org/d3.v5.min'}});
+  
+require(["d3"], function(d3) {
+
+    const model_data = {{ model_data }};
+
+    const width = {{ width }},
+        height = {{ height }};
+
+    const nodes = d3.select(".pywr_schematic").selectAll(".node").data();
+
+    const node_data_obj = {}
+    nodes.forEach(element => {
+        node_data_obj[element.name] = element
+    });
+
+    // scales to convert back to values between -100 and 100
+    const posX = d3.scaleLinear()
+                    .range([-100, 100])
+                    .domain([0, width]);
+    const posY = d3.scaleLinear() 
+                   .range([100, -100])
+                   .domain([0, height]);
+    
+    for (let i = 0; i < model_data.nodes.length; i++){
+        let node_name = model_data.nodes[i].name;
+        let node_data = node_data_obj[node_name]
+        if (node_data.fixed){
+            model_data["nodes"][i]["position"] = {"schematic": [posX(node_data.x), posY(node_data.y)]}
+        }
+    }
+
+    const filename = {{ filename }}
+    download(filename + ".json", JSON.stringify(model_data))   
+});
+
+function download(filename, text) {
+    let pom = document.createElement('a');
+    pom.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    pom.setAttribute('download', filename);
+
+    if (document.createEvent) {
+        let event = document.createEvent('MouseEvents');
+        event.initEvent('click', true, true);
+        pom.dispatchEvent(event);
+    }
+    else {
+        pom.click();
+    }
+}
+

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -33,7 +33,7 @@ require(["d3"], function(d3) {
     }
 
     const filename = {{ filename }}
-    download(filename + ".json", JSON.stringify(model_data))   
+    download(filename, JSON.stringify(model_data))   
 });
 
 function download(filename, text) {

--- a/pywr/notebook/save_graph.js
+++ b/pywr/notebook/save_graph.js
@@ -24,16 +24,35 @@ require(["d3"], function(d3) {
                    .range([100, -100])
                    .domain([0, height]);
     
-    for (let i = 0; i < model_data.nodes.length; i++){
-        let node_name = model_data.nodes[i].name;
-        let node_data = node_data_obj[node_name]
-        if (node_data.fixed){
-            model_data["nodes"][i]["position"] = {"schematic": [posX(node_data.x), posY(node_data.y)]}
+    const filename = {{ filename }};
+
+    if ({{filetype}} == "model_json"){
+        for (let i = 0; i < model_data.nodes.length; i++){
+            let node_name = model_data.nodes[i].name;
+            let node_data = node_data_obj[node_name]
+            if (node_data.fixed){
+                model_data["nodes"][i]["position"] = {"schematic": [posX(node_data.x), posY(node_data.y)]}
+            }
         }
+        download(filename, JSON.stringify(model_data));
+    } else {
+        let output_data = ["Node name,Fixed,x,y"];
+        for (let i = 0; i < model_data.nodes.length; i++){
+            let node_name = model_data.nodes[i].name;
+            let node_data = node_data_obj[node_name]
+            let position_data = [
+                node_name,
+                node_data.fixed,
+                posX(node_data.x),
+                posY(node_data.y),
+            ]
+            output_data.push(position_data.join(","))
+        }
+        download(filename, output_data.join("\n"));
     }
 
-    const filename = {{ filename }}
-    download(filename, JSON.stringify(model_data))   
+    
+      
 });
 
 function download(filename, text) {

--- a/pywr/notebook/template.html
+++ b/pywr/notebook/template.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+    {{ css }}
+
+    .title{
+        text-align: center;
+    }
+
+    .pywr_schematic{
+        margin: 0 auto;
+        outline: 1px solid black;
+    }
+
+    .table-tooltip{
+        margin: 0 auto;
+        margin-top: 10px;
+        font: 12px sans-serif;
+    }    
+</style>
+<body>
+     <h1 class="title">{{ title }}</h1>
+    <div class="schematic"></div>
+<script src=https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js></script> 
+<script>
+    {{ d3_script }}
+</script>
+</body>

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ def long_description():
 
 def package_data():
     pkg_data = {
-        "pywr.notebook": ["*.js", "*.css"],
+        "pywr.notebook": ["*.js", "*.css", "*.html"],
         'pywr': ['*.pxd'],
         'pywr.parameters': ['*.pxd'],
         'pywr.recorders': ['*.pxd'],


### PR DESCRIPTION
I’ve moved the notebook `draw_graph` function into a class and added a method to the class that will read the graph and save the positions of any node moved by a user into a new model json file. This hopefully deals with the frustration of spending ages moving nodes around to make a model graph readable only to lose this work when the notebook is reloaded. I’ve also added a method that will save the d3 graph into an html file, which should make it easier to share.

Still needs some work but any initial comments @pywr/pushers ? 
