### PR TITLE
Add IPython to install dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def setup_package():
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
         setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy",],
-        install_requires=["pandas", "networkx", "scipy", "tables", "xlrd", "packaging", "matplotlib", "jinja2",],
+        install_requires=["pandas", "networkx", "scipy", "tables", "xlrd", "packaging", "matplotlib", "jinja2", "ipython"],
         extras_require={"test": ["pytest"]},
         cmdclass={"build_ext": new_build_ext},
         packages=[

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,15 +1,6 @@
 import pytest
 from numpy.testing import assert_array_equal
-
-try:
-    import IPython
-    import jinja2
-    import matplotlib
-    matplotlib.use("tkagg")
-except ImportError:
-    pytestmark = pytest.mark.skip("IPython + jinja2 + matplotlib required to test pywr.notebook")
-else:
-    from pywr.notebook import pywr_model_to_d3_json, pywr_json_to_d3_json
+from pywr.notebook import pywr_model_to_d3_json, pywr_json_to_d3_json
 from pywr.model import Model
 import os
 


### PR DESCRIPTION
This should reactivate the `tests/test_notebook.py` module.