### PR TITLE
Expose run statistics to optimisation wrappers

### DIFF
--- a/pywr/optimisation/platypus.py
+++ b/pywr/optimisation/platypus.py
@@ -106,7 +106,7 @@ class PlatypusWrapper(BaseOptimisationWrapper):
                 ints = np.round(np.array(x[-var.integer_size:])).astype(np.int32)
                 var.set_integer_variables(ints)
 
-        run_stats = self.model.run()
+        self.run_stats = self.model.run()
 
         objectives = []
         for r in self.model_objectives:
@@ -124,7 +124,8 @@ class PlatypusWrapper(BaseOptimisationWrapper):
                 constraints.append(x)
 
         # Return values to the solution
-        logger.info(f'Evaluation completed in {run_stats.time_taken:.2f} seconds ({run_stats.speed:.2f} ts/s).')
+        logger.info(f'Evaluation completed in {self.run_stats.time_taken:.2f} seconds '
+                    f'({self.run_stats.speed:.2f} ts/s).')
         if len(constraints) > 0:
             return objectives, constraints
         else:

--- a/pywr/optimisation/platypus.py
+++ b/pywr/optimisation/platypus.py
@@ -124,7 +124,7 @@ class PlatypusWrapper(BaseOptimisationWrapper):
                 constraints.append(x)
 
         # Return values to the solution
-        logger.info('Evaluation complete!')
+        logger.info(f'Evaluation completed in {run_stats.time_taken:.2f} seconds ({run_stats.speed:.2f} ts/s).')
         if len(constraints) > 0:
             return objectives, constraints
         else:

--- a/pywr/optimisation/pygmo.py
+++ b/pywr/optimisation/pygmo.py
@@ -44,7 +44,7 @@ class PygmoWrapper(BaseOptimisationWrapper):
                 raise RuntimeError(f'The bounds if constraint "{r.name}" could not be identified correctly.')
 
         # Return values to the solution
-        logger.info('Evaluation complete!')
+        logger.info(f'Evaluation completed in {run_stats.time_taken:.2f} seconds ({run_stats.speed:.2f} ts/s).')
         return objectives + eq_constraints + ineq_constraints
 
     def get_bounds(self):

--- a/pywr/optimisation/pygmo.py
+++ b/pywr/optimisation/pygmo.py
@@ -15,7 +15,7 @@ class PygmoWrapper(BaseOptimisationWrapper):
             var.set_double_variables(np.array(solution[j]).copy())
 
         self.model.reset()
-        run_stats = self.model.run()
+        self.run_stats = self.model.run()
 
         objectives = []
         for r in self.model_objectives:
@@ -44,7 +44,8 @@ class PygmoWrapper(BaseOptimisationWrapper):
                 raise RuntimeError(f'The bounds if constraint "{r.name}" could not be identified correctly.')
 
         # Return values to the solution
-        logger.info(f'Evaluation completed in {run_stats.time_taken:.2f} seconds ({run_stats.speed:.2f} ts/s).')
+        logger.info(f'Evaluation completed in {self.run_stats.time_taken:.2f} seconds '
+                    f'({self.run_stats.speed:.2f} ts/s).')
         return objectives + eq_constraints + ineq_constraints
 
     def get_bounds(self):


### PR DESCRIPTION
Log the run time and speed during optimisation, and also save the `ModelResult` on to the wrapper so it can be inspected if required.