### PR TITLE
Change the signature of recorder aggregation functions to catch exceptions.

### DIFF
--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -17,8 +17,8 @@ cdef class Recorder(Component):
     cdef public double epsilon
     cdef public bint ignore_nan
     cdef public Aggregator _scenario_aggregator
-    cpdef double aggregated_value(self) except? -1
-    cpdef double[:] values(self)
+    cpdef double aggregated_value(self) except *
+    cpdef double[:] values(self) except *
 
 cdef class AggregatedRecorder(Recorder):
     cdef object recorder_agg_func

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -244,11 +244,11 @@ cdef class Recorder(Component):
     def __repr__(self):
         return '<{} "{}">'.format(self.__class__.__name__, self.name)
 
-    cpdef double aggregated_value(self) except? -1:
+    cpdef double aggregated_value(self) except *:
         cdef double[:] values = self.values()
         return self._scenario_aggregator.aggregate_1d(values)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         raise NotImplementedError()
 
     @classmethod
@@ -312,7 +312,7 @@ cdef class AggregatedRecorder(Recorder):
         for rec in self.recorders:
             self.children.add(rec)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         cdef Recorder recorder
         cdef double[:] value, value2
         assert(len(self.recorders))
@@ -377,7 +377,7 @@ cdef class NodeRecorder(Recorder):
         self._node = node
         node._recorders.append(self)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return self._node._flow
 
     property node:
@@ -398,7 +398,7 @@ cdef class StorageRecorder(Recorder):
         self._node = node
         node._recorders.append(self)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return self._node._volume
 
     property node:
@@ -541,7 +541,7 @@ cdef class NumpyArrayNodeRecorder(NodeRecorder):
         def __get__(self, ):
             return np.array(self._data)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
@@ -727,7 +727,7 @@ cdef class FlowDurationCurveRecorder(NumpyArrayNodeRecorder):
         def __get__(self, ):
             return np.array(self._fdc)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._fdc, axis=0, ignore_nan=self.ignore_nan)
@@ -904,7 +904,7 @@ cdef class FlowDurationCurveDeviationRecorder(FlowDurationCurveRecorder):
             return np.array(self._fdc_deviations)
 
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._fdc_deviations, axis=0, ignore_nan=self.ignore_nan)
@@ -957,7 +957,7 @@ cdef class NumpyArrayAbstractStorageRecorder(StorageRecorder):
         def __get__(self, ):
             return np.array(self._data)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
@@ -1054,7 +1054,7 @@ cdef class StorageDurationCurveRecorder(NumpyArrayStorageRecorder):
         def __get__(self, ):
             return np.array(self._sdc)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._sdc, axis=0, ignore_nan=self.ignore_nan)
@@ -1176,7 +1176,7 @@ cdef class NumpyArrayParameterRecorder(ParameterRecorder):
         def __get__(self, ):
             return np.array(self._data)
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
@@ -1423,7 +1423,7 @@ cdef class BaseConstantNodeRecorder(NodeRecorder):
     cpdef after(self):
         raise NotImplementedError()
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return self._values
 
 
@@ -1526,7 +1526,7 @@ cdef class BaseConstantStorageRecorder(StorageRecorder):
     cpdef after(self):
         raise NotImplementedError()
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return self._values
 BaseConstantStorageRecorder.register()
 
@@ -1599,7 +1599,7 @@ cdef class TimestepCountIndexParameterRecorder(IndexParameterRecorder):
                 # threshold achieved, increment count
                 self._count[scenario_index.global_id] += 1
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return np.asarray(self._count).astype(np.float64)
 TimestepCountIndexParameterRecorder.register()
 
@@ -1652,7 +1652,7 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
         cdef int idx = self._current_year - self._start_year
         cdef int p
         cdef Py_ssize_t i
-        cdef double value
+        cdef int value
         cdef ScenarioIndex scenario_index
         cdef IndexParameter parameter
 
@@ -1680,7 +1680,7 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
         for i in range(self._ncomb):
             self._data[idx, i] = np.sum(self._data_this_year[:, i])
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
@@ -1757,7 +1757,7 @@ cdef class AnnualTotalFlowRecorder(Recorder):
             for j, node in enumerate(self.nodes):
                 self._data[idx, i] += node._flow[i] * self._factors[j]
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
@@ -1826,7 +1826,7 @@ cdef class AnnualCountIndexParameterRecorder(IndexParameterRecorder):
             if self._current_max[i] >= self.threshold:
                 self._count[i] += 1
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return np.asarray(self._count).astype(np.float64)
 AnnualCountIndexParameterRecorder.register()
 
@@ -1890,7 +1890,7 @@ cdef class BaseConstantParameterRecorder(ParameterRecorder):
     cpdef after(self):
         raise NotImplementedError()
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return self._values
 
 

--- a/pywr/recorders/_thresholds.pyx
+++ b/pywr/recorders/_thresholds.pyx
@@ -65,7 +65,7 @@ cdef class StorageThresholdRecorder(StorageRecorder):
     cpdef reset(self):
         self._state[...] = 0
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return np.array(self._state, dtype=np.float)
 
     cpdef after(self):
@@ -110,7 +110,7 @@ cdef class NodeThresholdRecorder(NodeRecorder):
     cpdef reset(self):
         self._state[...] = 0
 
-    cpdef double[:] values(self):
+    cpdef double[:] values(self) except *:
         return np.array(self._state, dtype=np.float)
 
     cpdef after(self):


### PR DESCRIPTION
Update the Cython function signature to `except *` so that exception checking is always done. This is helpful if there are errors during the computation of metrics during optimisation. 