### PR TITLE
skip virtual nodes when creating d3 graph data from model json

### DIFF
--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -285,18 +285,14 @@ def pywr_json_to_d3_json(model, attributes=False):
         with open(model) as d:
             model = json.load(d)
 
-    nodes = [node["name"] for node in model["nodes"]]
-
-    edges = []
-    for edge in model["edges"]:
-        sourceindex = nodes.index(edge[0])
-        targetindex = nodes.index(edge[1])
-        edges.append({'source': sourceindex, 'target': targetindex})
-
     nodes = []
     node_classes = create_node_class_trees()
 
     for node in model["nodes"]:
+
+        if node["type"].lower() in ["annualvirtualstorage", "virtualstorage"]:
+            continue
+
         json_node = {'name': node["name"], 'clss': node_classes[node["type"].lower()]}
         try:
             json_node['position'] = node['position']['schematic']
@@ -326,6 +322,14 @@ def pywr_json_to_d3_json(model, attributes=False):
                 json_node["attributes"].append(attr_dict)
 
         nodes.append(json_node)
+
+    nodes_names = [node["name"] for node in nodes]
+
+    edges = []
+    for edge in model["edges"]:
+        sourceindex = nodes_names.index(edge[0])
+        targetindex = nodes_names.index(edge[1])
+        edges.append({'source': sourceindex, 'target': targetindex})
 
     graph = {
         "nodes": nodes,

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -46,8 +46,10 @@ def test_from_json(from_json):
 
 
 def test_d3_data():
-    """ Check that the graph data returned by the pywr_json_to_d3_json and pywr_model_to_d3_json functions contains the
-    same nodes and number on links. The data won't match exactly due to differences in node ordering.
+    """Test returned by `pywr_json_to_d3_json` and `pywr_model_to_d3_json` is similar.
+
+    These return graph data from a JSON file and Model instance respectively. Here we test that each returns the
+    same node names and number on links. The data won't match exactly due to differences in node ordering.
     """
     json_path = os.path.join(os.path.dirname(__file__), "models", "demand_saving2_with_variables.json")
     model = load_model("demand_saving2_with_variables.json")

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -43,3 +43,18 @@ def test_from_json(from_json):
     demand_max_flow = get_node_attribute(demand, "max_flow")
 
     assert demand_max_flow["value"] == "demand_max_flow - AggregatedParameter"
+
+
+def test_d3_data():
+
+    json_path = os.path.join(os.path.dirname(__file__), "models", "demand_saving2_with_variables.json")
+    model = load_model("demand_saving2_with_variables.json")
+
+    d3_data_from_json = pywr_json_to_d3_json(json_path)
+    d3_data_from_model = pywr_model_to_d3_json(model)
+
+    json_nodes = {n["name"]: n for n in d3_data_from_json["nodes"]}
+    model_nodes = {n["name"]: n for n in d3_data_from_model["nodes"]}
+
+    assert json_nodes == model_nodes
+    assert len(d3_data_from_json["links"]) == len(d3_data_from_model["links"])

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -46,7 +46,9 @@ def test_from_json(from_json):
 
 
 def test_d3_data():
-
+    """ Check that the graph data returned by the pywr_json_to_d3_json and pywr_model_to_d3_json functions contains the
+    same nodes and number on links. The data won't match exactly due to differences in node ordering.
+    """
     json_path = os.path.join(os.path.dirname(__file__), "models", "demand_saving2_with_variables.json")
     model = load_model("demand_saving2_with_variables.json")
 


### PR DESCRIPTION
This makes it consistent with how the d3 data is created from a model object