### PR TITLE
Wrap setup and parameter functions in try: except

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -677,10 +677,14 @@ class Model(object):
                     node.setup(self)
                 except Exception as err:
                     #reraise the exception after logging some info about source of error
-                    logger.critical("An error occurred resetting node %s",node.name)
+                    logger.critical("An error occurred calling setup while resetting node %s",node.name)
                     raise
-
-            node.reset()
+            try:
+                node.reset()
+            except Exception as err:
+                #reraise the exception after logging some info about source of error
+                logger.critical("An error occurred calling reset on node %s",node.name)
+                raise
 
         components = self.flatten_component_tree(rebuild=False)
         for component in components:
@@ -689,10 +693,17 @@ class Model(object):
                     component.setup()
                 except Exception as err:
                     #reraise the exception after logging some info about source of error
-                    logger.critical("An error occurred resetting component %s",
+                    logger.critical("An error occurred calling setup while resetting component %s",
                                     component.name)
                     raise
-            component.reset()
+
+            try:
+                component.reset()
+            except Exception as err:
+                #reraise the exception after logging some info about source of error
+                logger.critical("An error occurred calling reset on component %s",
+                                component.name)
+                raise
 
         self.solver.reset()
         # reset the timers

--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -395,7 +395,16 @@ class Model(object):
                     name, component_data = components_to_load.popitem()
                 except KeyError:
                     break
-                component = load_component(model, component_data, name)
+
+                #If unable to load a node, then reraise the exception with some
+                #useful information like node name and parameter name.
+                try:
+                      component = load_component(model, component_data, name)
+                except Exception as err:
+                    logger.critical("Error loading component %s", name)
+                    #Reraise the exception
+                    raise
+
                 yield component
 
         load_components(model._recorders_to_load, load_recorder)
@@ -635,11 +644,23 @@ class Model(object):
         self.scenarios.setup()
         length_changed = self.timestepper.reset()
         for node in self.graph.nodes():
-            node.setup(self)
+            try:
+                node.setup(self)
+            except Exception as err:
+              #reraise the exception after logging some info about source of error
+              logger.critical("An error occurred setting up node during setup %s",
+                              node.name)
+              raise
 
         components = self.flatten_component_tree(rebuild=True)
         for component in components:
-            component.setup()
+            try:
+                component.setup()
+            except Exception as err:
+                #reraise the exception after logging some info about source of error
+                logger.critical("An error occurred setting up component during setup %s",
+                                component.name)
+                raise
 
         self.solver.setup(self)
         self.reset()
@@ -652,13 +673,25 @@ class Model(object):
         length_changed = self.timestepper.reset(start=start)
         for node in self.nodes:
             if length_changed:
-                node.setup(self)
+                try:
+                    node.setup(self)
+                except Exception as err:
+                    #reraise the exception after logging some info about source of error
+                    logger.critical("An error occurred resetting node %s",node.name)
+                    raise
+
             node.reset()
 
         components = self.flatten_component_tree(rebuild=False)
         for component in components:
             if length_changed:
-                component.setup()
+                try:
+                    component.setup()
+                except Exception as err:
+                    #reraise the exception after logging some info about source of error
+                    logger.critical("An error occurred resetting component %s",
+                                    component.name)
+                    raise
             component.reset()
 
         self.solver.reset()
@@ -708,7 +741,12 @@ class Model(object):
             node.finish()
         components = self.flatten_component_tree(rebuild=False)
         for component in components:
-            component.finish()
+            try:
+                component.finish()
+            except Exception as err:
+                #reraise the exception after logging some info about source of error
+                logger.critical("An error occurred finishing component %s", component.name)
+                raise
 
     def to_dataframe(self):
         """ Return a DataFrame from any Recorders with a `to_dataframe` attribute

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -3,6 +3,7 @@ import numpy as np
 cimport numpy as np
 from scipy.interpolate import Rbf
 import pandas
+import json
 import calendar
 from libc.math cimport cos, M_PI
 from libc.limits cimport INT_MIN, INT_MAX
@@ -22,15 +23,15 @@ class UnutilisedDataWarning(Warning):
 class TypeNotFoundError(KeyError):
     """
       Key Error, specifically designed for when the 'type' key is not found
-      in a dataset. This takes the data valuye and outputs a summary of it, to
+      in a dataset. This takes the data value and outputs a summary of it, to
       aid in debugging.
     """
     def __init__(self, data):
         #Try to print out some sensible amount of data without overloading
         #the terminal with data. 1000 chars should be enough to get an idea
-        #of what the data looks like. If more than 100 chars, do a pandas-style
+        #of what the data looks like. If more than 1000 chars, do a pandas-style
         #summary using ...
-        data_str = str(data)
+        data_str = json.dumps(data)
         if len(data_str) > 1000:
             data_summary = f"{data_str[:500]} ... {data_str[-500:]}"
         else:


### PR DESCRIPTION
This takes the master-specific content out of #888 so it can be merged directly to master instead of schema2. A separate MR will follow for schema2

adding contextual data to exceptions to aid in debugging.
Specifically:
1. Throw an exception when 'type' is not found on a parameter and throw
a custom exception when this occurs with a summarised version of the
erroneous data value in the message.
2. Wrap various setup functions in model.pyx in try: : except, logging
the component name in the before re-raising the exception.