### PR TITLE
Update appveyor badge to refer to master branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Pywr is a generalised network resource allocation model written in Python. It ai
 .. image:: https://travis-ci.org/pywr/pywr.svg?branch=master
    :target: https://travis-ci.org/pywr/pywr
 
-.. image:: https://ci.appveyor.com/api/projects/status/ik9u75bxfvracimh?svg=true
+.. image:: https://ci.appveyor.com/api/projects/status/ik9u75bxfvracimh/branch/master?svg=true
    :target: https://ci.appveyor.com/project/pywr-admin/pywr
 
 .. image:: https://img.shields.io/badge/chat-on%20gitter-blue.svg


### PR DESCRIPTION
The appveyor badge in the README was referring to the latest build rather than the latest master build (i.e. could be a PR). This points the badge at master.