### PR TITLE
Fix warnings about small aggregated node factors.

### DIFF
--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -679,7 +679,7 @@ cdef class AggregatedNode(AbstractNode):
 
         def __set__(self, values):
             values = np.array(values, np.float64)
-            if np.any(values < 1e-6):
+            if np.any(np.abs(values) < 1e-6):
                 warnings.warn("Very small factors in AggregateNode result in ill-conditioned matrix")
             self._factors = values
             self.model.dirty = True
@@ -693,7 +693,7 @@ cdef class AggregatedNode(AbstractNode):
 
         def __set__(self, values):
             values = np.array(values, np.float64)
-            if np.any(values < 1e-6):
+            if np.any(np.abs(values) < 1e-6):
                 warnings.warn("Very small flow_weights in AggregateNode result in ill-conditioned matrix")
             self._flow_weights = values
             self.model.dirty = True


### PR DESCRIPTION
Make the warning trigger when the absolute value is less than
 the threshold.