### PR TITLE
Fix AggregatedStorage initial volume when defined as proportions.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -110,6 +110,8 @@ cdef class Storage(AbstractStorage):
     cdef Parameter _max_volume_param
     cdef Parameter _level_param
     cdef Parameter _area_param
+    cpdef double get_initial_volume(self) except? -1
+    cpdef double get_initial_pc(self) except? -1
     cpdef _reset_storage_only(self, bint use_initial_volume = *)
     cpdef double get_min_volume(self, ScenarioIndex scenario_index) except? -1
     cpdef double get_max_volume(self, ScenarioIndex scenario_index) except? -1

--- a/tests/test_aggregated_nodes.py
+++ b/tests/test_aggregated_nodes.py
@@ -11,8 +11,38 @@ def test_aggregated_storage(three_storage_model):
 
     agg_stg = m.nodes['Total Storage']
     stgs = [m.nodes['Storage {}'.format(num)] for num in range(3)]
-    # Check initial volume is aggregated correclty
+    # Check initial volume is aggregated correctly
     np.testing.assert_allclose(agg_stg.initial_volume, sum(s.initial_volume for s in stgs))
+
+    m.setup()
+    m.step()
+
+    # Finally check volume is summed correctly
+    np.testing.assert_allclose(agg_stg.volume, sum(s.volume for s in stgs))
+    current_pc = sum(s.volume for s in stgs) / (sum(s.max_volume for s in stgs))
+    np.testing.assert_allclose(agg_stg.current_pc, current_pc)
+    np.testing.assert_allclose(agg_stg.flow, sum(s.flow for s in stgs))
+
+    m.step()
+
+    # Finally check volume is summed correctly
+    np.testing.assert_allclose(agg_stg.volume, sum(s.volume for s in stgs))
+    current_pc = sum(s.volume for s in stgs) / (sum(s.max_volume for s in stgs))
+    np.testing.assert_allclose(agg_stg.current_pc, current_pc)
+    np.testing.assert_allclose(agg_stg.flow, sum(s.flow for s in stgs))
+
+
+def test_aggregated_storage_initial_pc(three_storage_model):
+    """Test `AggregatedStorage` correct sums multiple `Storage` with proportional initial volumes."""
+    m = three_storage_model
+
+    agg_stg = m.nodes['Total Storage']
+    stgs = [m.nodes['Storage {}'.format(num)] for num in range(3)]
+    for stg in stgs:
+        stg.initial_volume = None
+        stg.initial_volume_pc = 0.9
+    # Check initial volume is aggregated correctly
+    np.testing.assert_allclose(agg_stg.initial_volume, sum(s.initial_volume_pc * s.max_volume for s in stgs))
 
     m.setup()
     m.step()


### PR DESCRIPTION
This refactors the reset storage code to provide two helper
functions that return the initial volume in absolute and
proprtional terms. These calculations depend on how the initial
and maximum volume is defined.

The AggregatedStorage node uses one these new functions to
correctly calculate its initial volume.

Fixes #918.