### PR TITLE
Add a threshold when checking GLPK constraints bounds equality.

### DIFF
--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -61,7 +61,7 @@ message_levels = {
 # Inline helper functions
 # =======================
 cdef inline int constraint_type(double a, double b):
-    if a == b:
+    if abs(a - b) < 1e-8:
         return GLP_FX
     elif b == DBL_MAX:
         if a == -DBL_MAX:


### PR DESCRIPTION
Use a small threshold in the difference between upper bounds and lower bounds for a constraint to qualify as GLP_FX. This is a practical consideration where exact floating point equality might not be true in all cases.

May help with #728.

My only comment on this is whether this threshold should be a configurable setting in the GLPK solvers.