### PR TITLE
Change basestring to str

### DIFF
--- a/pywr/_component.pxd
+++ b/pywr/_component.pxd
@@ -3,7 +3,7 @@
 cdef class Component:
     cdef object _name
     cdef readonly object model
-    cdef public basestring comment
+    cdef public str comment
     cdef readonly object parents
     cdef readonly object children
     cpdef setup(self)


### PR DESCRIPTION
This was only needed for Python 2 support.