### PR TITLE
Add to_dataframe methods to two annual count recorders.

### DIFF
--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1873,6 +1873,19 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
         """
         return self._temporal_aggregator.aggregate_2d(self._data, axis=0, ignore_nan=self.ignore_nan)
 
+    def to_dataframe(self):
+        """ Return a `pandas.DataFrame` of the recorder data
+
+        This DataFrame contains a MultiIndex for the columns with the recorder name
+        as the first level and scenario combination names as the second level. This
+        allows for easy combination with multiple recorder's DataFrames.
+        """
+        start_year = self.model.timestepper.start.year
+        end_year = self.model.timestepper.end.year
+        index = pd.period_range(f'{start_year}-01-01', f'{end_year}-01-01', freq='A')
+        sc_index = self.model.scenarios.multiindex
+        return pd.DataFrame(data=np.array(self._data, dtype=int), index=index, columns=sc_index)
+
     property data:
         def __get__(self):
             return np.array(self._data, dtype=np.int16)
@@ -1953,6 +1966,19 @@ cdef class AnnualTotalFlowRecorder(Recorder):
     property data:
         def __get__(self):
             return np.array(self._data, dtype=np.float64)
+
+    def to_dataframe(self):
+        """ Return a `pandas.DataFrame` of the recorder data
+
+        This DataFrame contains a MultiIndex for the columns with the recorder name
+        as the first level and scenario combination names as the second level. This
+        allows for easy combination with multiple recorder's DataFrames.
+        """
+        start_year = self.model.timestepper.start.year
+        end_year = self.model.timestepper.end.year
+        index = pd.period_range(f'{start_year}-01-01', f'{end_year}-01-01', freq='A')
+        sc_index = self.model.scenarios.multiindex
+        return pd.DataFrame(data=np.array(self._data), index=index, columns=sc_index)
 
     @classmethod
     def load(cls, model, data):

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1522,6 +1522,14 @@ def test_annual_count_index_threshold_recorder(simple_storage_model, params):
                      [0, 365],
                      [0, 365]], rec.data, atol=1e-7)
 
+    df = rec.to_dataframe()
+    assert_allclose([[0, 0],
+                     [0, 0],
+                     [0, 183],
+                     [0, 365],
+                     [0, 365]], df.values, atol=1e-7)
+
+
 class TestAnnualTotalFlowRecorder:
 
     def test_annual_total_flow_recorder(self, simple_linear_model):
@@ -1539,6 +1547,8 @@ class TestAnnualTotalFlowRecorder:
         model.run()
 
         assert_allclose(3650.0, rec.data, atol=1e-7)
+        df = rec.to_dataframe()
+        assert_allclose([[3650.0]], df.values)
 
     def test_annual_total_flow_recorder_factored(self, simple_linear_model):
         """
@@ -1557,6 +1567,8 @@ class TestAnnualTotalFlowRecorder:
         model.run()
 
         assert_allclose(3650.0*3, rec_fact.data, atol=1e-7)
+        df = rec_fact.to_dataframe()
+        assert_allclose([[3650.0*3]], df.values)
 
 
 def test_total_flow_node_recorder(simple_linear_model):


### PR DESCRIPTION
`AnnualTotalFlowRecorder` and `AnnualCountIndexThresholdRecorder` store their data internally in an annual timeseries. This commit exposes that data as a pandas DataFrame.