### PR TITLE
update load methods of interpolation parameters so that they accept interp1d kwargs

### DIFF
--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -73,6 +73,17 @@ class AbstractInterpolatedParameter(Parameter):
     def _value_to_interpolate(self, ts, scenario_index):
         raise NotImplementedError()
 
+    @property
+    def interp_kwargs(self):
+        return self._interp_kwargs
+
+    @interp_kwargs.setter
+    def interp_kwargs(self, data):
+        if "fill_value" in data and isinstance(data["fill_value"], list):
+            # SciPy's interp1d expects a tuple when defining fill values for the upper and lower bounds
+            data["fill_value"] = tuple(data["fill_value"])
+        self._interp_kwargs = data
+
     def setup(self):
         super(AbstractInterpolatedParameter, self).setup()
         self.interp = interp1d(self.x, self.y, **self.interp_kwargs)
@@ -108,15 +119,7 @@ class InterpolatedParameter(AbstractInterpolatedParameter):
         parameter = load_parameter(model, data.pop("parameter"))
         x = np.array(data.pop("x"))
         y = np.array(data.pop("y"))
-        kind = data.pop("kind", "linear")
         interp_kwargs = data.pop("interp_kwargs", None)
-        if interp_kwargs:
-            interp_kwargs["kind"] = kind
-            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
-                # interp1d expects a tuple when defining fill values for the upper and lower bounds
-                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
-        else:
-            interp_kwargs = {"kind": kind}
         return cls(model, parameter, x, y, interp_kwargs=interp_kwargs)
 
 
@@ -163,15 +166,7 @@ class InterpolatedVolumeParameter(AbstractInterpolatedParameter):
             values = load_parameter_values(model, values)
         else:
             raise TypeError("Unexpected type for \"values\" in {}".format(cls.__name__))
-        kind = data.pop("kind", "linear")
         interp_kwargs = data.pop("interp_kwargs", None)
-        if interp_kwargs:
-            interp_kwargs["kind"] = kind
-            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
-                # interp1d expects a tuple when defining fill values for the upper and lower bounds
-                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
-        else:
-            interp_kwargs = {"kind": kind}
         return cls(model, node, volumes, values, interp_kwargs=interp_kwargs)
 
 
@@ -206,15 +201,7 @@ class InterpolatedFlowParameter(AbstractInterpolatedParameter):
         node = model._get_node_from_ref(model, data.pop("node"))
         flows = np.array(data.pop("flows"))
         values = np.array(data.pop("values"))
-        kind = data.pop("kind", "linear")
         interp_kwargs = data.pop("interp_kwargs", None)
-        if interp_kwargs:
-            interp_kwargs["kind"] = kind
-            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
-                # interp1d expects a tuple when defining fill values for the upper and lower bounds
-                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
-        else:
-            interp_kwargs = {"kind": kind}
         return cls(model, node, flows, values, interp_kwargs=interp_kwargs)
 
 
@@ -274,15 +261,7 @@ class InterpolatedQuadratureParameter(AbstractInterpolatedParameter):
         lower_parameter = load_parameter(model, data.pop("lower_parameter", None))
         x = np.array(data.pop("x"))
         y = np.array(data.pop("y"))
-        kind = data.pop("kind", "linear")
         interp_kwargs = data.pop("interp_kwargs", None)
-        if interp_kwargs:
-            interp_kwargs["kind"] = kind
-            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
-                # interp1d expects a tuple when defining fill values for the upper and lower bounds
-                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
-        else:
-            interp_kwargs = {"kind": kind}
         return cls(model, upper_parameter, x, y, lower_parameter=lower_parameter,
                    interp_kwargs=interp_kwargs)
 

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -109,7 +109,17 @@ class InterpolatedParameter(AbstractInterpolatedParameter):
         x = np.array(data.pop("x"))
         y = np.array(data.pop("y"))
         kind = data.pop("kind", "linear")
-        return cls(model, parameter, x, y, interp_kwargs={'kind': kind})
+        interp_kwargs = data.pop("interp_kwargs", None)
+        if interp_kwargs:
+            interp_kwargs["kind"] = kind
+            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
+                # interp1d expects a tuple when defining fill values for the upper and lower bounds
+                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
+        else:
+            interp_kwargs = {"kind": kind}
+        return cls(model, parameter, x, y, interp_kwargs=interp_kwargs)
+
+
 InterpolatedParameter.register()
 
 
@@ -154,7 +164,17 @@ class InterpolatedVolumeParameter(AbstractInterpolatedParameter):
         else:
             raise TypeError("Unexpected type for \"values\" in {}".format(cls.__name__))
         kind = data.pop("kind", "linear")
-        return cls(model, node, volumes, values, interp_kwargs={'kind': kind})
+        interp_kwargs = data.pop("interp_kwargs", None)
+        if interp_kwargs:
+            interp_kwargs["kind"] = kind
+            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
+                # interp1d expects a tuple when defining fill values for the upper and lower bounds
+                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
+        else:
+            interp_kwargs = {"kind": kind}
+        return cls(model, node, volumes, values, interp_kwargs=interp_kwargs)
+
+
 InterpolatedVolumeParameter.register()
 
 
@@ -187,7 +207,17 @@ class InterpolatedFlowParameter(AbstractInterpolatedParameter):
         flows = np.array(data.pop("flows"))
         values = np.array(data.pop("values"))
         kind = data.pop("kind", "linear")
-        return cls(model, node, flows, values, interp_kwargs={'kind': kind})
+        interp_kwargs = data.pop("interp_kwargs", None)
+        if interp_kwargs:
+            interp_kwargs["kind"] = kind
+            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
+                # interp1d expects a tuple when defining fill values for the upper and lower bounds
+                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
+        else:
+            interp_kwargs = {"kind": kind}
+        return cls(model, node, flows, values, interp_kwargs=interp_kwargs)
+
+
 InterpolatedFlowParameter.register()
 
 
@@ -245,8 +275,18 @@ class InterpolatedQuadratureParameter(AbstractInterpolatedParameter):
         x = np.array(data.pop("x"))
         y = np.array(data.pop("y"))
         kind = data.pop("kind", "linear")
+        interp_kwargs = data.pop("interp_kwargs", None)
+        if interp_kwargs:
+            interp_kwargs["kind"] = kind
+            if "fill_value" in interp_kwargs and isinstance(interp_kwargs["fill_value"], list):
+                # interp1d expects a tuple when defining fill values for the upper and lower bounds
+                interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
+        else:
+            interp_kwargs = {"kind": kind}
         return cls(model, upper_parameter, x, y, lower_parameter=lower_parameter,
-                   interp_kwargs={'kind': kind})
+                   interp_kwargs=interp_kwargs)
+
+
 InterpolatedQuadratureParameter.register()
 
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1085,19 +1085,37 @@ class Test1DPolynomialParameter:
         model.run()
 
 
-def test_interpolated_parameter(simple_linear_model):
-    model = simple_linear_model
-    model.timestepper.start = "1920-01-01"
-    model.timestepper.end = "1920-01-12"
+class TestInterpolatedParameter:
 
-    p1 = ArrayIndexedParameter(model, [0,1,2,3,4,5,6,7,8,9,10,11])
-    p2 = InterpolatedParameter(model, p1, [0, 5, 10, 11], [0, 5*2, 10*3, 2])
+    def test_interpolated_parameter(self, simple_linear_model):
+        model = simple_linear_model
+        model.timestepper.start = "1920-01-01"
+        model.timestepper.end = "1920-01-12"
 
-    @assert_rec(model, p2)
-    def expected_func(timestep, scenario_index):
-        values = [0, 2, 4, 6, 8, 10, 14, 18, 22, 26, 30, 2]
-        return values[timestep.index]
-    model.run()
+        p1 = ArrayIndexedParameter(model, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+        p2 = InterpolatedParameter(model, p1, [0, 5, 10, 11], [0, 5*2, 10*3, 2])
+
+        @assert_rec(model, p2)
+        def expected_func(timestep, scenario_index):
+            values = [0, 2, 4, 6, 8, 10, 14, 18, 22, 26, 30, 2]
+            return values[timestep.index]
+        model.run()
+
+    def test_interp_kwargs(self, simple_linear_model):
+        model = simple_linear_model
+        model.timestepper.start = "1920-01-01"
+        model.timestepper.end = "1920-01-12"
+
+        ArrayIndexedParameter(model, [-2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15], name="myparam")
+        interp_kwargs = {"bounds_error": False, "fill_value": [0, 2]}
+        data = {"parameter": "myparam", "x": [0, 5, 10, 11], "y": [0, 5*2, 10*3, 2], "interp_kwargs": interp_kwargs}
+        p2 = InterpolatedParameter.load(model, data)
+
+        @assert_rec(model, p2)
+        def expected_func(timestep, scenario_index):
+            values = [0, 2, 4, 6, 8, 10, 14, 18, 22, 26, 30, 2]
+            return values[timestep.index]
+        model.run()
 
 
 class TestInterpolatedQuadratureParameter:


### PR DESCRIPTION
This could be made a bit cleaner by changing the api and requiring the `kind` kwarg to be included with `interp_kwargs` rather than allowing it to still be defined separately. What do you think @jetuk 

See also #889 