### PR TITLE
Fixed documentation links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,13 +20,13 @@ Overview
 
 Pywr is a tool for solving network resource allocation problems at discrete timesteps using a linear programming approach. It's principal application is in resource allocation in water supply networks, although other uses are conceivable. A network is represented as a directional graph using `NetworkX <https://networkx.github.io/>`__. Nodes in the network can be given constraints (e.g. minimum/maximum flows) and costs, and can be connected as required. Parameters in the model can vary time according to boundary conditions (e.g. an inflow timeseries) or based on states in the model (e.g. the current volume of a reservoir).
 
-Models can be developed using the Python API, either in a script or interactively using `IPython <https://ipython.org/>`__/`Jupyter <https://jupyter.org/>`__. Alternatively, models can be defined in a rich `JSON-based document format <https://pywr.github.io/pywr/master/json.html>`__.
+Models can be developed using the Python API, either in a script or interactively using `IPython <https://ipython.org/>`__/`Jupyter <https://jupyter.org/>`__. Alternatively, models can be defined in a rich `JSON-based document format <https://pywr.github.io/pywr/json.html>`__.
 
 .. image:: https://raw.githubusercontent.com/pywr/pywr/master/docs/source/_static/pywr_d3.png
    :width: 250px
    :height: 190px
 
-New users are encouraged to read the `Pywr Tutorial <https://pywr.github.io/pywr/master/tutorial.html>`__.
+New users are encouraged to read the `Pywr Tutorial <https://pywr.github.io/pywr/tutorial.html>`__.
 
 Design goals
 ============
@@ -42,9 +42,9 @@ Installation
 
 Pywr should work on Python 3.6 (or later) on Windows, Linux or OS X.
 
-See the documentation for `detailed installation instructions <https://pywr.github.io/pywr/master/install.html>`__.
+See the documentation for `detailed installation instructions <https://pywr.github.io/pywr/install.html>`__.
 
-Provided that you have the required `dependencies <https://pywr.github.io/pywr/master/install.html#dependencies>`__ already installed, it's as simple as:
+Provided that you have the required `dependencies <https://pywr.github.io/pywr/install.html#dependencies>`__ already installed, it's as simple as:
 
 .. code-block:: console
 


### PR DESCRIPTION
These links must have changed when we moved the documentation build system.