### PR TITLE
Switch to openpyxl instead of xlrd and drop Python 3.6 support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ env:
   CIBW_BEFORE_TEST_LINUX: "chmod +x {project}/.github/workflows/run-tests.sh"
   CIBW_TEST_COMMAND_LINUX: "{project}/.github/workflows/run-tests.sh {project}"
   CIBW_TEST_COMMAND_WINDOWS: "{project}\\.github\\workflows\\run-tests-windows.bat {project}"
-  # Only build on Python 3.6+
-  CIBW_BUILD: cp36-* cp37-* cp38-*
+  # Only build on Python 3.7+
+  CIBW_BUILD: cp37-* cp38-*
   # Skip 32-bit builds
   CIBW_SKIP: "*-win32 *-manylinux_i686"
   # Install GLPK

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Pywr is a tool for solving network resource allocation problems. It has many sim
 Installation
 ============
 
-Pywr should work on Python 3.6 (or later) on Windows, Linux or OS X.
+Pywr should work on Python 3.7 (or later) on Windows, Linux or OS X.
 
 See the documentation for `detailed installation instructions <https://pywr.github.io/pywr/install.html>`__.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,7 +1,7 @@
 Installing Pywr
 ===============
 
-Pywr should work on Python 3.6 (or later) on Windows, Linux or OS X.
+Pywr should work on Python 3.7 (or later) on Windows, Linux or OS X.
 
 Building Pywr from source requires a working C compiler. It has been built successfully with MSVC on Windows, GCC on Linux and clang/LLVM on OS X.
 
@@ -71,7 +71,7 @@ Binary wheel distributions of Pywr are hosted on `Pypi <https://pypi.org/project
 Installing binary packages with Anaconda
 ----------------------------------------
 
-A binary distribution of Pywr is provided for 3.6+ (64-bit) on Windows, Linux and OS X for the `Anaconda Python distribution <https://www.continuum.io/downloads>`_. Note that this release may lag behind the development version.
+A binary distribution of Pywr is provided for 3.7+ (64-bit) on Windows, Linux and OS X for the `Anaconda Python distribution <https://www.continuum.io/downloads>`_. Note that this release may lag behind the development version.
 
 You will need to install and configure Anaconda before proceeding. The `conda 30-minute test drive <http://conda.pydata.org/docs/test-drive.html>`_ is a good place to start.
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,17 @@ def setup_package():
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
         setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
-        install_requires=["pandas", "networkx", "scipy", "tables", "xlrd", "packaging", "matplotlib", "jinja2", "ipython"],
+        install_requires=[
+            "pandas",
+            "networkx",
+            "scipy",
+            "tables",
+            "openpyxl",
+            "packaging",
+            "matplotlib",
+            "jinja2",
+            "ipython"
+        ],
         extras_require={
             "docs": docs_extras,
             "test": test_extras,


### PR DESCRIPTION
Pandas 1.2 has been released and no longer supports reading xlsx files with `xlrd`. Openpyxl is the preferred default.

