### PR TITLE
Add an optional tags dictionary to Component

### DIFF
--- a/pywr/_component.pxd
+++ b/pywr/_component.pxd
@@ -4,6 +4,7 @@ cdef class Component:
     cdef object _name
     cdef readonly object model
     cdef public str comment
+    cdef public dict tags
     cdef readonly object parents
     cdef readonly object children
     cpdef setup(self)

--- a/pywr/_component.pyx
+++ b/pywr/_component.pyx
@@ -67,15 +67,25 @@ cdef class Component:
      called in the correct order. E.g. that a `before` method in
      one component that is a parent of another is called first.
 
+    Parameters
+    ==========
+    name : str or None
+        The name of the component.
+    comment : str or None
+        An optional comment for the component.
+    tags : dict (default=None)
+        An optional container of key-value pairs that the user can set to help group and identify components.
+
     See also
     --------
     pywr.Model
 
     """
-    def __init__(self, model, name=None, comment=None):
+    def __init__(self, model, name=None, comment=None, tags=None):
         self.model = model
         self.name = name
         self.comment = comment
+        self.tags = tags
         model.component_graph.add_edge(ROOT_NODE, self)
         self.parents = GraphInterface(self)
         self.children = GraphInterface(self)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -43,11 +43,12 @@ class TestConstantParameter:
         scA = Scenario(model, 'Scenario A', size=2)
         scB = Scenario(model, 'Scenario B', size=5)
 
-        p = ConstantParameter(model, np.pi, name='pi', comment='Mmmmm Pi!')
+        p = ConstantParameter(model, np.pi, name='pi', comment='Mmmmm Pi!', tags={'key': 'value'})
 
         assert not p.is_variable
         assert p.double_size == 1
         assert p.integer_size == 0
+        assert p.tags == {'key': 'value'}
 
         model.setup()
         ts = model.timestepper.current


### PR DESCRIPTION
Parameters and Recorders can now optionally take a dict of tags. The component just stores these in a public attribute. It will
be useful for various tools to provide and save metadata about components. E.g. for filtering and grouping.

This PR doesn't use this metadata anywhere. It should be possible to add tags to the `TablesRecorder` parameter arrays as metadata.