### PR TITLE
Add NormalisedGaussianKDEStorageRecorder

### DIFF
--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -62,6 +62,9 @@ cdef class NumpyArrayAbstractStorageRecorder(StorageRecorder):
 cdef class NumpyArrayStorageRecorder(NumpyArrayAbstractStorageRecorder):
     cdef public bint proportional
 
+cdef class NumpyArrayNormalisedStorageRecorder(NumpyArrayAbstractStorageRecorder):
+    cdef readonly Parameter parameter
+
 cdef class NumpyArrayLevelRecorder(NumpyArrayAbstractStorageRecorder):
     pass
 

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1126,6 +1126,55 @@ cdef class NumpyArrayStorageRecorder(NumpyArrayAbstractStorageRecorder):
 NumpyArrayStorageRecorder.register()
 
 
+cdef class NumpyArrayNormalisedStorageRecorder(NumpyArrayAbstractStorageRecorder):
+    """Recorder for timeseries information normalised relative to a control curve for a `Storage` node.
+
+    This class stores normalised storage from a specific node for each time-step of a simulation. The normalisation
+    is relative to a `Parameter` which defines a control curve. The data is normalised such that values of 1, 0 and
+    -1 align with full, at control curve and empty volumes respectively. The data is saved internally using a
+     memory view. The data can be accessed through the `data` attribute or `to_dataframe()` method.
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+    node : `pywr.core.Node`
+        Node instance to record.
+    parameter : `Parameter`
+        The control curve for normalisation.
+    temporal_agg_func : str or callable (default="mean")
+        Aggregation function used over time when computing a value per scenario. This can be used
+        to return, for example, the median flow over a simulation. For aggregation over scenarios
+        see the `agg_func` keyword argument.
+    """
+    def __init__(self, *args, **kwargs):
+        # Optional different method for aggregating across time.
+        self.parameter = kwargs.pop('parameter')
+        super().__init__(*args, **kwargs)
+        self.children.add(self.parameter)
+
+    cpdef after(self):
+        cdef int i
+        cdef Timestep ts = self.model.timestepper.current
+        cdef double[:] values = self.parameter.get_all_values()
+        cdef double vol, cc, norm_vol
+
+        for i in range(self._data.shape[1]):
+            vol = self._node._current_pc[i]
+            cc = values[i]
+
+            if vol < cc:
+                # Lower than control curve; value between -1.0 and 0.0
+                norm_vol = vol / cc - 1.0
+            else:
+                # At or above control curve; value between 0.0 and 1.0
+                norm_vol = (vol - cc) / (1.0 - cc)
+
+            self._data[ts.index, i] = norm_vol
+
+        return 0
+NumpyArrayNormalisedStorageRecorder.register()
+
+
 cdef class StorageDurationCurveRecorder(NumpyArrayStorageRecorder):
     """
     This recorder calculates a storage duration curve for each scenario.

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1142,9 +1142,9 @@ cdef class NumpyArrayNormalisedStorageRecorder(NumpyArrayAbstractStorageRecorder
     parameter : `Parameter`
         The control curve for normalisation.
     temporal_agg_func : str or callable (default="mean")
-        Aggregation function used over time when computing a value per scenario. This can be used
-        to return, for example, the median flow over a simulation. For aggregation over scenarios
-        see the `agg_func` keyword argument.
+        Aggregation function used over time when computing a value per scenario. This can be used to return, for
+        example, the minimum normalised storage reached over a simulation. For aggregation over scenarios see the
+        `agg_func` keyword argument.
     """
     def __init__(self, *args, **kwargs):
         # Optional different method for aggregating across time.

--- a/pywr/recorders/kde.py
+++ b/pywr/recorders/kde.py
@@ -2,7 +2,7 @@ from typing import Tuple
 import numpy as np
 import pandas
 from scipy import stats
-from ._recorders import NumpyArrayStorageRecorder
+from ._recorders import NumpyArrayStorageRecorder, NumpyArrayNormalisedStorageRecorder
 
 
 class GaussianKDEStorageRecorder(NumpyArrayStorageRecorder):
@@ -100,3 +100,97 @@ class GaussianKDEStorageRecorder(NumpyArrayStorageRecorder):
 
         return p, pdf
 GaussianKDEStorageRecorder.register()
+
+
+class NormalisedGaussianKDEStorageRecorder(NumpyArrayNormalisedStorageRecorder):
+    """A recorder that fits a KDE to a normalised time-series of volume.
+
+    This recorder is an extension to `NumpyArrayNormalisedStorageRecorder` which, at the end of a simulation,
+    uses kernel density estimation (KDE) to estimate the probability density function of the storage time-series.
+    It returns the probability of being at or below zero of the normalised values in the `aggregated_value()` method
+    (i.e. used for optimisation). The recorder flattens data from all scenarios before computing the KDE. Therefore,
+    a single PDF is produced and returned via `.to_dataframe()`.
+
+    The user can specify an optional resampling (e.g. to create annual minimum time-series) prior to fitting
+    the KDE. By default the KDE is reflected at the normalised storage bounds (-1.0 and 1.0) to represent the
+    boundedness of the distribution. This can be disabled if required.
+
+    Parameters
+    ==========
+    resample_freq : str or None
+        If not None the resampling frequency used by prior to distribution fitting.
+    resample_func : str or None
+        If not None the resampling function used prior to distribution fitting.
+    num_pdf : int
+        Number of points in the PDF estimate. Defaults to 101.
+    use_reflection : bool
+        Whether to reflect the PDF at the upper and lower normalised bounds (i.e. -1.0 and 1.0 volume) to account for
+        the boundedness of the distribution. Defaults to true.
+    """
+    def __init__(self, *args, **kwargs):
+        self.resample_freq = kwargs.pop('resample_freq', None)
+        self.resample_func = kwargs.pop('resample_func', None)
+        self.use_reflection = kwargs.pop('use_reflection', True)
+        self.num_pdf = kwargs.pop('num_pdf', 101)
+
+        super().__init__(*args, **kwargs)
+        self._probability_of_target_volume = None
+        self._pdf = None
+
+    def reset(self):
+        super().reset()
+        self._probability_of_target_volume = None
+        self._pdf = None
+
+    def finish(self):
+        super().finish()
+
+        df = super().to_dataframe()
+        # Apply resampling if defined
+        if self.resample_func is not None and self.resample_freq is not None:
+            df = df.resample(self.resample_freq).agg(self.resample_func)
+
+        x = np.linspace(0.0, 1.0, self.num_pdf)
+
+        # Compute the probability for the target volume
+        p, pdf = self._estimate_pdf_and_target_probability(df.values.flatten(), x)
+
+        self._probability_of_target_volume = p
+        self._pdf = pandas.DataFrame(data=pdf, index=x)
+
+    def values(self):
+        """Return the estimated PDF values."""
+        return self._pdf.values
+
+    def to_dataframe(self):
+        """ Return a `pandas.DataFrame` of the estimated PDF.
+        """
+        return self._pdf
+
+    def aggregated_value(self):
+        return self._probability_of_target_volume
+
+    def _estimate_pdf_and_target_probability(self, values, x) -> Tuple[float, np.ndarray]:
+        """Return a probability of being at below `self.target_volume_pc` and a estimate of the PDF
+
+        This method can (if `self.use_reflection` is truthy) reflect the PDF at the lower and upper boundaries
+        to stop the PDF leaking in to infeasible space.
+        """
+        # Fit a Gaussian KDE
+        kernel = stats.gaussian_kde(values)
+        p = kernel.integrate_box_1d(-1.0, 0.0)
+        pdf = kernel(x)
+
+        if self.use_reflection:
+            # Reflection at the lower boundary
+            kernel_lb = stats.gaussian_kde(-2.0 - values)
+            p += kernel_lb.integrate_box_1d(-1.0, 0.0)
+            pdf += kernel_lb(x)
+
+            # Reflection at the upper boundary
+            kernel_ub = stats.gaussian_kde(2.0 - values)
+            p += kernel_ub.integrate_box_1d(-1.0, 0.0)
+            pdf += kernel_ub(x)
+
+        return p, pdf
+NormalisedGaussianKDEStorageRecorder.register()


### PR DESCRIPTION
Works in a similar way to `GaussianKDEStorageRecorder`, but derives from a new array recorder. `NormalisedGaussianKDEStorageRecorder` keeps an array of storage that is normalised between -1 and 1 where the 0 value is at a control curve. The new KDE recorder estimates a probability of being at or below zero in the normalised series.