### PR TITLE
Update constant Parameters in reset rather than every timestep.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -75,8 +75,14 @@ cdef class Node(AbstractNode):
     cdef Parameter _max_flow_param
 
     cdef Parameter _conversion_factor_param
+
+    cpdef double get_fixed_min_flow(self)
+    cpdef double get_constant_min_flow(self)
     cpdef double get_min_flow(self, ScenarioIndex scenario_index) except? -1
     cpdef double[:] get_all_min_flow(self, double[:] out=*)
+
+    cpdef double get_fixed_max_flow(self)
+    cpdef double get_constant_max_flow(self)
     cpdef double get_max_flow(self, ScenarioIndex scenario_index) except? -1
     cpdef double[:] get_all_max_flow(self, double[:] out=*)
 

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -572,13 +572,13 @@ cdef class Node(AbstractNode):
                 self._min_flow = value
 
     cpdef double get_fixed_min_flow(self):
-        """Returns min_flow if `has_fixed_flows` is True otherwise returns NaN."""
+        """Returns min_flow value if it is a fixed value otherwise returns NaN."""
         if self.has_fixed_flows:
             return self._min_flow
         return float('nan')
 
     cpdef double get_constant_min_flow(self):
-        """Returns min_flow if `has_constant_flows` is True otherwise returns NaN."""
+        """Returns min_flow value if it is a constant parameter or fixed value otherwise returns NaN."""
         if self._min_flow_param is None:
             return self._min_flow
         elif self._min_flow_param.is_constant:
@@ -635,13 +635,13 @@ cdef class Node(AbstractNode):
                    (self._min_flow_param is None or self._min_flow_param.is_constant)
 
     cpdef double get_fixed_max_flow(self):
-        """Returns max_flow if `has_fixed_flows` is True otherwise returns NaN."""
+        """Returns max_flow value if it is fixed value otherwise returns NaN."""
         if self.has_fixed_flows:
             return self._max_flow
         return float('nan')
 
     cpdef double get_constant_max_flow(self):
-        """Returns max_flow if `has_constant_flows` is True otherwise returns NaN."""
+        """Returns max_flow value if it is a constant parameter or fixed value otherwise returns NaN."""
         if self._max_flow_param is None:
             return self._max_flow
         elif self._max_flow_param.is_constant:

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -571,6 +571,20 @@ cdef class Node(AbstractNode):
                 self._min_flow_param = None
                 self._min_flow = value
 
+    cpdef double get_fixed_min_flow(self):
+        """Returns min_flow if `has_fixed_flows` is True otherwise returns NaN."""
+        if self.has_fixed_flows:
+            return self._min_flow
+        return float('nan')
+
+    cpdef double get_constant_min_flow(self):
+        """Returns min_flow if `has_constant_flows` is True otherwise returns NaN."""
+        if self._min_flow_param is None:
+            return self._min_flow
+        elif self._min_flow_param.is_constant:
+            return self._min_flow_param.get_constant_value()
+        return float('nan')
+
     cpdef double get_min_flow(self, ScenarioIndex scenario_index) except? -1:
         """Get the minimum flow at a given timestep
         """
@@ -613,6 +627,26 @@ cdef class Node(AbstractNode):
         """Returns true if both min_flow and max_flow are not Parameters."""
         def __get__(self):
             return self._max_flow_param is None and self._min_flow_param is None
+
+    property has_constant_flows:
+        """Returns true if both min_flow and max_flow are literal constants or "constant" Parameters."""
+        def __get__(self):
+            return (self._max_flow_param is None or self._max_flow_param.is_constant) and \
+                   (self._min_flow_param is None or self._min_flow_param.is_constant)
+
+    cpdef double get_fixed_max_flow(self):
+        """Returns max_flow if `has_fixed_flows` is True otherwise returns NaN."""
+        if self.has_fixed_flows:
+            return self._max_flow
+        return float('nan')
+
+    cpdef double get_constant_max_flow(self):
+        """Returns max_flow if `has_constant_flows` is True otherwise returns NaN."""
+        if self._max_flow_param is None:
+            return self._max_flow
+        elif self._max_flow_param.is_constant:
+            return self._max_flow_param.get_constant_value()
+        return float('nan')
 
     cpdef double get_max_flow(self, ScenarioIndex scenario_index) except? -1:
         """Get the maximum flow at a given timestep

--- a/pywr/parameters/_activation_functions.pyx
+++ b/pywr/parameters/_activation_functions.pyx
@@ -24,12 +24,17 @@ cdef class BinaryStepParameter(Parameter):
         self.integer_size = 0
         self._lower_bounds = lower_bounds
         self._upper_bounds = upper_bounds
+        self.is_constant = True
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         if self._value <= 0.0:
             return 0.0
         else:
             return self.output
+
+    cpdef double get_constant_value(self):
+        # This is fine because value doesn't depend on timestep or scenario
+        return self.value(None, None)
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]
@@ -69,12 +74,17 @@ cdef class RectifierParameter(Parameter):
         self.integer_size = 0
         self._lower_bounds = lower_bounds
         self._upper_bounds = upper_bounds
+        self.is_constant = True
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         if self._value <= 0.0:
             return 0.0
         else:
             return self.max_output * self._value / self._upper_bounds
+
+    cpdef double get_constant_value(self):
+        # This is fine because value doesn't depend on timestep or scenario
+        return self.value(None, None)
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]
@@ -117,9 +127,14 @@ cdef class LogisticParameter(Parameter):
         self.integer_size = 0
         self._lower_bounds = lower_bounds
         self._upper_bounds = upper_bounds
+        self.is_constant = True
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         return self.max_output / (1 + np.exp(-self.growth_rate*self._value))
+
+    cpdef double get_constant_value(self):
+        # This is fine because value doesn't depend on timestep or scenario
+        return self.value(None, None)
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]

--- a/pywr/parameters/_activation_functions.pyx
+++ b/pywr/parameters/_activation_functions.pyx
@@ -26,15 +26,15 @@ cdef class BinaryStepParameter(Parameter):
         self._upper_bounds = upper_bounds
         self.is_constant = True
 
-    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+    cpdef double get_constant_value(self):
         if self._value <= 0.0:
             return 0.0
         else:
             return self.output
 
-    cpdef double get_constant_value(self):
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         # This is fine because value doesn't depend on timestep or scenario
-        return self.value(None, None)
+        return self.get_constant_value()
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]
@@ -76,15 +76,15 @@ cdef class RectifierParameter(Parameter):
         self._upper_bounds = upper_bounds
         self.is_constant = True
 
-    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+    cpdef double get_constant_value(self):
         if self._value <= 0.0:
             return 0.0
         else:
             return self.max_output * self._value / self._upper_bounds
 
-    cpdef double get_constant_value(self):
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         # This is fine because value doesn't depend on timestep or scenario
-        return self.value(None, None)
+        return self.get_constant_value()
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]
@@ -129,12 +129,12 @@ cdef class LogisticParameter(Parameter):
         self._upper_bounds = upper_bounds
         self.is_constant = True
 
-    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+    cpdef double get_constant_value(self):
         return self.max_output / (1 + np.exp(-self.growth_rate*self._value))
 
-    cpdef double get_constant_value(self):
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
         # This is fine because value doesn't depend on timestep or scenario
-        return self.value(None, None)
+        return self.get_constant_value()
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -7,12 +7,14 @@ cdef class Parameter(Component):
     cdef public int integer_size
     cdef int _size
     cdef public bint is_variable
+    cdef readonly bint is_constant
     cdef AbstractNode _node
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1
     cdef double[:] __values
     cdef calc_values(self, Timestep ts)
     cpdef double get_value(self, ScenarioIndex scenario_index)
     cpdef double[:] get_all_values(self)
+    cpdef double get_constant_value(self)
 
     # New variable API
     cpdef set_double_variables(self, double[:] values)

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -46,6 +46,7 @@ cdef class Parameter(Component):
         self.is_variable = is_variable
         self.double_size = 0
         self.integer_size = 0
+        self.is_constant = False
 
     @classmethod
     def register(cls):
@@ -79,6 +80,13 @@ cdef class Parameter(Component):
 
     cpdef double[:] get_all_values(self):
         return self.__values
+
+    cpdef double get_constant_value(self):
+        """Return a constant value.
+        
+        This method should only be implemented and called if `is_constant` is True. 
+        """
+        raise NotImplementedError()
 
     cpdef set_double_variables(self, double[:] values):
         raise NotImplementedError()
@@ -144,6 +152,7 @@ cdef class ConstantParameter(Parameter):
         self.offset = offset
         self.double_size = 1
         self.integer_size = 0
+        self.is_constant = True
         self._lower_bounds = np.ones(self.double_size) * lower_bounds
         self._upper_bounds = np.ones(self.double_size) * upper_bounds
 
@@ -152,6 +161,9 @@ cdef class ConstantParameter(Parameter):
         self.__values[...] = self.offset + self._value * self.scale
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+        return self._value
+
+    cpdef double get_constant_value(self):
         return self._value
 
     cpdef set_double_variables(self, double[:] values):

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -158,13 +158,13 @@ cdef class ConstantParameter(Parameter):
 
     cdef calc_values(self, Timestep timestep):
         # constant parameter can just set the entire array to one value
-        self.__values[...] = self.offset + self._value * self.scale
+        self.__values[...] = self.get_constant_value()
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        return self._value
+        return self.get_constant_value()
 
     cpdef double get_constant_value(self):
-        return self._value
+        return self.offset + self._value * self.scale
 
     cpdef set_double_variables(self, double[:] values):
         self._value = values[0]

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -354,7 +354,7 @@ cdef class CythonGLPKSolver(GLPKSolver):
         nodes_with_dynamic_cost = []  # Only these nodes' costs are updated each timestep
         non_storages = []
         non_storages_with_dynamic_bounds = []  # These nodes' constraints are updated each timestep
-        non_storages_with_constant_bounds = []  # These nodes' constraints are updated each timestep
+        non_storages_with_constant_bounds = []  # These nodes' constraints are updated only at reset
         storages = []
         virtual_storages = []
         aggregated_with_factors = []
@@ -1007,8 +1007,8 @@ cdef class CythonGLPKEdgeSolver(GLPKSolver):
         nodes_with_dynamic_cost = []
         link_nodes = []
         non_storages = []
-        non_storages_with_dynamic_bounds = []
-        non_storages_with_constant_bounds = []
+        non_storages_with_dynamic_bounds = []  # These nodes' constraints are updated each timestep
+        non_storages_with_constant_bounds = []  # These nodes' constraints are updated only at reset
         storages = []
         virtual_storages = []
         aggregated_with_factors = []

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -353,8 +353,8 @@ cdef class CythonGLPKSolver(GLPKSolver):
 
         nodes_with_dynamic_cost = []  # Only these nodes' costs are updated each timestep
         non_storages = []
-        non_storages_with_dynamic_bounds = []
-        non_storages_with_constant_bounds = []  # Only these nodes' constraints are updated each timestep
+        non_storages_with_dynamic_bounds = []  # These nodes' constraints are updated each timestep
+        non_storages_with_constant_bounds = []  # These nodes' constraints are updated each timestep
         storages = []
         virtual_storages = []
         aggregated_with_factors = []

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -1110,8 +1110,8 @@ cdef class CythonGLPKEdgeSolver(GLPKSolver):
             free(ind)
             free(val)
 
-            # Now test whether this node has fixed flow constraints
-            if self.set_fixed_flows_once and node.has_fixed_flows:
+            # Now test whether this node has constant flow constraints
+            if self.set_fixed_flows_once and node.has_constant_flows:
                 non_storages_with_constant_bounds.append(node)
             else:
                 non_storages_with_dynamic_bounds.append(node)
@@ -1333,10 +1333,10 @@ cdef class CythonGLPKEdgeSolver(GLPKSolver):
         # update non-storage constraints with constant bounds
         for node in self.non_storages_with_constant_bounds:
             row = node.__data.row
-            min_flow = inf_to_dbl_max(node.get_min_flow(None))
+            min_flow = inf_to_dbl_max(node.get_constant_min_flow())
             if abs(min_flow) < 1e-8:
                 min_flow = 0.0
-            max_flow = inf_to_dbl_max(node.get_max_flow(None))
+            max_flow = inf_to_dbl_max(node.get_constant_max_flow())
             if abs(max_flow) < 1e-8:
                 max_flow = 0.0
 

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -275,7 +275,8 @@ cdef class CythonGLPKSolver(GLPKSolver):
 
     cdef public list routes
     cdef list non_storages
-    cdef list non_storages_to_update
+    cdef list non_storages_with_dynamic_bounds
+    cdef list non_storages_with_constant_bounds
     cdef list nodes_with_dynamic_cost
     cdef list storages
     cdef list virtual_storages
@@ -352,7 +353,8 @@ cdef class CythonGLPKSolver(GLPKSolver):
 
         nodes_with_dynamic_cost = []  # Only these nodes' costs are updated each timestep
         non_storages = []
-        non_storages_to_update = []  # Only these nodes' constraints are updated each timestep
+        non_storages_with_dynamic_bounds = []
+        non_storages_with_constant_bounds = []  # Only these nodes' constraints are updated each timestep
         storages = []
         virtual_storages = []
         aggregated_with_factors = []
@@ -452,23 +454,16 @@ cdef class CythonGLPKSolver(GLPKSolver):
                 ind[1+n] = 1+c
                 val[1+n] = 1
             set_mat_row(self.prob, self.idx_row_non_storages+row, len(cols), ind, val)
-
-            # Now test whether this node has fixed flow constraints
-            if self.set_fixed_flows_once and node.has_fixed_flows:
-                min_flow = inf_to_dbl_max(node.get_min_flow(None))
-                if abs(min_flow) < 1e-8:
-                    min_flow = 0.0
-                max_flow = inf_to_dbl_max(node.get_max_flow(None))
-                if abs(max_flow) < 1e-8:
-                    max_flow = 0.0
-
-                set_row_bnds(self.prob, self.idx_row_non_storages+row, constraint_type(min_flow, max_flow), min_flow, max_flow)
-            else:
-                set_row_bnds(self.prob, self.idx_row_non_storages+row, GLP_FX, 0.0, 0.0)
-                non_storages_to_update.append(node)
+            set_row_bnds(self.prob, self.idx_row_non_storages + row, GLP_FX, 0.0, 0.0)
 
             free(ind)
             free(val)
+
+            # Now test whether this node has fixed flow constraints
+            if self.set_fixed_flows_once and node.has_constant_flows:
+                non_storages_with_constant_bounds.append(node)
+            else:
+                non_storages_with_dynamic_bounds.append(node)
 
             # Add constraint for cross-domain routes
             # i.e. those from a demand to a supply
@@ -621,7 +616,8 @@ cdef class CythonGLPKSolver(GLPKSolver):
 
         self.routes = routes
         self.non_storages = non_storages
-        self.non_storages_to_update = non_storages_to_update
+        self.non_storages_with_constant_bounds = non_storages_with_constant_bounds
+        self.non_storages_with_dynamic_bounds = non_storages_with_dynamic_bounds
         self.nodes_with_dynamic_cost = nodes_with_dynamic_cost
         self.storages = storages
         self.virtual_storages = virtual_storages
@@ -650,6 +646,31 @@ cdef class CythonGLPKSolver(GLPKSolver):
     def reset(self):
         # Resetting this triggers a crashing of a new basis in each scenario
         self.is_first_solve = True
+        self._update_nonstorage_constant_bounds()
+
+    cdef _update_nonstorage_constant_bounds(self):
+        """Update the bounds of non-storage where they are constants.
+
+        These bounds do not need updating every time-step.
+        """
+        cdef Node node
+        cdef double min_flow
+        cdef double max_flow
+        cdef int row
+        if self.non_storages_with_constant_bounds is None:
+            return
+        # update non-storage constraints with constant bounds
+        for node in self.non_storages_with_constant_bounds:
+            row = node.__data.row
+            min_flow = inf_to_dbl_max(node.get_constant_min_flow())
+            if abs(min_flow) < 1e-8:
+                min_flow = 0.0
+            max_flow = inf_to_dbl_max(node.get_constant_max_flow())
+            if abs(max_flow) < 1e-8:
+                max_flow = 0.0
+
+            set_row_bnds(self.prob, self.idx_row_non_storages + row, constraint_type(min_flow, max_flow),
+                         min_flow, max_flow)
 
     cpdef object solve(self, model):
         GLPKSolver.solve(self, model)
@@ -700,7 +721,7 @@ cdef class CythonGLPKSolver(GLPKSolver):
         cdef list routes = self.routes
         nroutes = len(routes)
         cdef list non_storages = self.non_storages
-        cdef list non_storages_to_update = self.non_storages_to_update
+        cdef list non_storages_with_dynamic_bounds = self.non_storages_with_dynamic_bounds
         cdef list storages = self.storages
         cdef list virtual_storages = self.virtual_storages
         cdef list aggregated = self.aggregated
@@ -756,7 +777,7 @@ cdef class CythonGLPKSolver(GLPKSolver):
         t0 = time.perf_counter()
 
         # update non-storage properties
-        for node in non_storages_to_update:
+        for node in non_storages_with_dynamic_bounds:
             row = node.__data.row
             min_flow = inf_to_dbl_max(node.get_min_flow(scenario_index))
             if abs(min_flow) < 1e-8:


### PR DESCRIPTION
This builds upon #912 by applying similar logic but to parameters whose values do not change with time or scenario. A new attribute `is_constant` is added to the `Parameter` class which indicates if this is true. If it is true then new methods provide access to the constant value without need for a timestep or scenario index. 

New attributes and methods on the `Node` class then allow the solver to determine if flows are fixed (doubles) or constant (doubles or parameters with `is_constant`). The solver then sets the constant values during reset instead of setup. This means that constant parameters can be used for optimisation and still have their updated values applied to a new model run (i.e. one that does reset and not setup).

It passes all the tests, but I haven't done a wider test or a speed test.