### PR TITLE
Update constant aggregated node factors only during rest.

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -3,16 +3,12 @@
 # GLPK solver
 echo "Running GLPK (route-based) tests in: $1";
 PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
+PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
 
 # GLPK Edge solver
 echo "Running GLPK (edge-based) tests in: $1";
 PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
-PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
+PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
 
 # Lpsolve solver
 echo "Running LpSolve tests in: $1";

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -104,6 +104,7 @@ cdef class AggregatedNode(AbstractNode):
     cpdef double get_max_flow(self, ScenarioIndex scenario_index) except? -1
     cpdef double[:] get_all_max_flow(self, double[:] out=*)
     cpdef double[:] get_factors(self, ScenarioIndex scenario_index)
+    cpdef double[:] get_constant_factors(self)
     cpdef double[:] get_factors_norm(self, ScenarioIndex scenario_index)
 
 cdef class BaseInput(Node):

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -139,13 +139,18 @@ else:
             return self._cy_solver.set_fixed_costs_once
 
         @property
+        def set_fixed_factors_once(self):
+            return self._cy_solver.set_fixed_factors_once
+
+        @property
         def settings(self):
             return {
                 'use_presolve': self.use_presolve,
                 'save_routes_flows': self.save_routes_flows,
                 'retry_solve': self.retry_solve,
                 'set_fixed_flows_once': self.set_fixed_flows_once,
-                'set_fixed_costs_once': self.set_fixed_costs_once
+                'set_fixed_costs_once': self.set_fixed_costs_once,
+                'set_fixed_factors_once': self.set_fixed_factors_once
             }
     solver_registry.append(CythonGLPKSolver)
 
@@ -214,12 +219,17 @@ else:
             return self._cy_solver.set_fixed_costs_once
 
         @property
+        def set_fixed_factors_once(self):
+            return self._cy_solver.set_fixed_factors_once
+
+        @property
         def settings(self):
             return {
                 'use_presolve': self.use_presolve,
                 'retry_solve': self.retry_solve,
                 'set_fixed_flows_once': self.set_fixed_flows_once,
-                'set_fixed_costs_once': self.set_fixed_costs_once
+                'set_fixed_costs_once': self.set_fixed_costs_once,
+                'set_fixed_factors_once': self.set_fixed_factors_once
             }
     solver_registry.append(CythonGLPKEdgeSolver)
 

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -73,6 +73,7 @@ else:
             super(CythonGLPKSolver, self).__init__(*args, **kwargs)
             kwargs = _parse_env_kwarg(kwargs, 'set_fixed_flows_once', 'PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE', bool)
             kwargs = _parse_env_kwarg(kwargs, 'set_fixed_costs_once', 'PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE', bool)
+            kwargs = _parse_env_kwarg(kwargs, 'set_fixed_factors_once', 'PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE', bool)
             self._cy_solver = cy_CythonGLPKSolver(**kwargs)
 
         def setup(self, model):
@@ -165,6 +166,7 @@ else:
             super(CythonGLPKEdgeSolver, self).__init__(*args, **kwargs)
             kwargs = _parse_env_kwarg(kwargs, 'set_fixed_flows_once', 'PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE', bool)
             kwargs = _parse_env_kwarg(kwargs, 'set_fixed_costs_once', 'PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE', bool)
+            kwargs = _parse_env_kwarg(kwargs, 'set_fixed_factors_once', 'PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE', bool)
             self._cy_solver = cy_CythonGLPKEdgeSolver(**kwargs)
 
         def setup(self, model):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -800,7 +800,7 @@ cdef class CythonGLPKSolver(GLPKSolver):
         t0 = time.perf_counter()
 
         # Update constraint matrix values for aggregated nodes that have factors defined as parameters
-        for agg_node in self.aggregated_with_factors:
+        for agg_node in self.aggregated_with_dynamic_factors:
 
             factors_norm = agg_node.get_factors_norm(scenario_index)
 


### PR DESCRIPTION
This is a performance improvement that follows on from #983
by only updating aggregated node factors in the GLPK solvers
during reset instead of every timestep. It should have most
benefit for models which use many of aggregated nodes with factors
as the code both for calculating the normalised factors is
not very efficient.

A new solver option and corresponding environment variable is
added to turn this feature on. It is off by default.

Modified the CI test suite to run only with and without the
extra options. As opposed to running each option individually.