### PR TITLE
unpin decorator dependency in doc build as networkx now requires >5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,11 +110,9 @@ jobs:
       - name: Build docs
         # lpsolve doesn't compile on Ubuntu without building the library from source - disable for the time being.
         # This doesn't really matter for the documentation builds.
-        # Pin decorator<5 until networkx updates.
-        # https://github.com/networkx/networkx/issues/4732
         run: |
           sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc "decorator<5"
+          pip install sphinx sphinx_rtd_theme numpydoc
           python setup.py install --without-lpsolve
           cd docs
           make html


### PR DESCRIPTION
neworkx have released a fix for the original issue - https://github.com/networkx/networkx/pull/4815