### PR TITLE
Add methods to Timestep to return days in current and next year

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -36,6 +36,7 @@ cdef class Timestep:
     cdef readonly int day
     cdef readonly int month
     cdef readonly int year
+    cdef readonly int end_year
     cpdef public double days_in_current_year(self)
     cpdef public double days_in_next_year(self)
 

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -37,8 +37,8 @@ cdef class Timestep:
     cdef readonly int month
     cdef readonly int year
     cdef readonly int end_year
-    cpdef public int days_in_current_year(self)
-    cpdef public int days_in_next_year(self)
+    cpdef public double days_in_current_year(self)
+    cpdef public double days_in_next_year(self)
 
 cdef class Domain:
     cdef object name

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -37,8 +37,8 @@ cdef class Timestep:
     cdef readonly int month
     cdef readonly int year
     cdef readonly int end_year
-    cpdef public double days_in_current_year(self)
-    cpdef public double days_in_next_year(self)
+    cpdef public int days_in_current_year(self)
+    cpdef public int days_in_next_year(self)
 
 cdef class Domain:
     cdef object name

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -36,6 +36,8 @@ cdef class Timestep:
     cdef readonly int day
     cdef readonly int month
     cdef readonly int year
+    cpdef public double days_in_current_year(self)
+    cpdef public double days_in_next_year(self)
 
 cdef class Domain:
     cdef object name

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -306,14 +306,14 @@ cdef class Timestep:
     def __repr__(self):
         return "<Timestep date=\"{}\">".format(self.period.strftime("%Y-%m-%d"))
 
-    cpdef double days_in_current_year(self):
+    cpdef int days_in_current_year(self):
         """Returns the number of days of the current timestep that fall in the current year"""
         if self.year != self.end_year:
             # end time of period is in the next year
             return 366 + self.is_leap_year - self.dayofyear
-        return self.days
+        return int(self.days)
 
-    cpdef double days_in_next_year(self):
+    cpdef int days_in_next_year(self):
         """Returns the number of days of the current timestep that fall in the next year"""
         if self.year != self.end_year:
             return self.period.end_time.day_of_year

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -282,6 +282,7 @@ cdef class Timestep:
         self.month = period.month
         self.year = period.year
         self.is_leap_year = is_leap_year(self.year)
+        self.end_year = self.period.end_time.year
 
         # Calculate day of year index (zero based)
         cdef int i = self.dayofyear - 1
@@ -307,14 +308,14 @@ cdef class Timestep:
 
     cpdef double days_in_current_year(self):
         """Returns the number of days of the current timestep that fall in the current year"""
-        if self.period.start_time.year != self.period.end_time.year:
+        if self.year != self.end_year:
             # end time of period is in the next year
-            return 366 + self.period.is_leap_year - self.period.start_time.day_of_year
+            return 366 + self.is_leap_year - self.dayofyear
         return self.days
 
     cpdef double days_in_next_year(self):
         """Returns the number of days of the current timestep that fall in the next year"""
-        if self.period.start_time.year != self.period.end_time.year:
+        if self.year != self.end_year:
             return self.period.end_time.day_of_year
         return 0
 

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -305,6 +305,19 @@ cdef class Timestep:
     def __repr__(self):
         return "<Timestep date=\"{}\">".format(self.period.strftime("%Y-%m-%d"))
 
+    cpdef double days_in_current_year(self):
+        """Returns the number of days of the current timestep that fall in the current year"""
+        if self.period.start_time.year != self.period.end_time.year:
+            # end time of period is in the next year
+            return 366 + self.period.is_leap_year - self.period.start_time.day_of_year
+        return self.days
+
+    cpdef double days_in_next_year(self):
+        """Returns the number of days of the current timestep that fall in the next year"""
+        if self.period.start_time.year != self.period.end_time.year:
+            return self.period.end_time.day_of_year
+        return 0
+
 cdef class Domain:
     """ Domain class which all Node objects must have. """
     def __init__(self, name):

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -306,17 +306,23 @@ cdef class Timestep:
     def __repr__(self):
         return "<Timestep date=\"{}\">".format(self.period.strftime("%Y-%m-%d"))
 
-    cpdef int days_in_current_year(self):
+    cpdef double days_in_current_year(self):
         """Returns the number of days of the current timestep that fall in the current year"""
+        cdef double year_end, ts_start
         if self.year != self.end_year:
             # end time of period is in the next year
-            return 366 + self.is_leap_year - self.dayofyear
-        return int(self.days)
+            year_end = pd.Timestamp(f"{self.end_year}-01-01").value
+            ts_start = self.period.start_time.value
+            return (year_end - ts_start) / 8.64e+13
+        return self.days
 
-    cpdef int days_in_next_year(self):
+    cpdef double days_in_next_year(self):
         """Returns the number of days of the current timestep that fall in the next year"""
+        cdef double year_end, ts_end
         if self.year != self.end_year:
-            return self.period.end_time.day_of_year
+            year_end = pd.Timestamp(f"{self.end_year}-01-01").value
+            ts_end = self.period.end_time.value
+            return (ts_end - year_end) / 8.64e+13
         return 0
 
 cdef class Domain:

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -2070,16 +2070,16 @@ cdef class AnnualTotalFlowRecorder(Recorder):
         cdef Timestep ts = self.model.timestepper.current
         cdef int idx = ts.year - self._start_year
         cdef AbstractNode node
-        cdef double[:] flow = np.zeros(self._ncomb, np.float64)
         cdef double days_in_current_year = ts.days_in_current_year()
+        cdef double days_in_next_year = ts.days_in_next_year()
+        cdef double ts_days = ts.days
 
         for i in range(self._ncomb):
             for j, node in enumerate(self.nodes):
-                self._data[idx, i] += node._flow[i] * ts.days_in_current_year() * self._factors[j]
-                if days_in_current_year != ts.days:
+                self._data[idx, i] += node._flow[i] * days_in_current_year * self._factors[j]
+                if days_in_current_year != ts.days and idx+1 < self._data.shape[0]:
                     # Timestep cross into the next year.
-                    if idx+1 < self._data.shape[0]:
-                        self._data[idx + 1, i] += node._flow[i] * ts.days_in_next_year() * self._factors[j]
+                    self._data[idx + 1, i] += node._flow[i] * days_in_next_year * self._factors[j]
 
     cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -2071,10 +2071,15 @@ cdef class AnnualTotalFlowRecorder(Recorder):
         cdef int idx = ts.year - self._start_year
         cdef AbstractNode node
         cdef double[:] flow = np.zeros(self._ncomb, np.float64)
+        cdef double days_in_current_year = ts.days_in_current_year()
 
         for i in range(self._ncomb):
             for j, node in enumerate(self.nodes):
-                self._data[idx, i] += node._flow[i] * self._factors[j]
+                self._data[idx, i] += node._flow[i] * ts.days_in_current_year() * self._factors[j]
+                if days_in_current_year != ts.days:
+                    # Timestep cross into the next year.
+                    if idx+1 < self._data.shape[0]:
+                        self._data[idx + 1, i] += node._flow[i] * ts.days_in_next_year() * self._factors[j]
 
     cpdef double[:] values(self) except *:
         """Compute a value for each scenario using `temporal_agg_func`.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -584,7 +584,3 @@ def test_timestep_days_in_year_methods(simple_linear_model, freq, start_date, da
 
     assert days_in_current_year == ts.days_in_current_year()
     assert days_in_next_year == ts.days_in_next_year()
-
-    simple_linear_model.step()
-
-    #assert ts.days() == ts.days_in_current_year()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -564,3 +564,27 @@ def test_timestep_greater_than_zero_days():
     with pytest.raises(ValueError):
         # Test setting days <= 0 raises an error
         Timestep(pandas.Period('2019-01-01', freq='D'), 0, 0)
+
+
+@pytest.mark.parametrize("freq, start_date, days_in_current_year, days_in_next_year", [("1D", "2012-12-31", 1, 0),
+                                                                                       ("1D", "2011-12-31", 1, 0),
+                                                                                       ("3D", "2012-12-31", 1, 2),
+                                                                                       (7, "2012-12-29", 3, 4),])
+def test_timestep_days_in_year_methods(simple_linear_model, freq, start_date, days_in_current_year, days_in_next_year):
+    """Test the `days_in_current_year` and `days_in_next_year` methods of the timestep object"""
+
+    simple_linear_model.timestepper.start = start_date
+    simple_linear_model.timestepper.end = "2013-01-30"
+    simple_linear_model.timestepper.delta = freq
+
+    simple_linear_model.setup()
+    simple_linear_model.step()
+
+    ts = simple_linear_model.timestepper.current
+
+    assert days_in_current_year == ts.days_in_current_year()
+    assert days_in_next_year == ts.days_in_next_year()
+
+    simple_linear_model.step()
+
+    #assert ts.days() == ts.days_in_current_year()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -566,13 +566,17 @@ def test_timestep_greater_than_zero_days():
         Timestep(pandas.Period('2019-01-01', freq='D'), 0, 0)
 
 
-@pytest.mark.parametrize("freq, start_date, days_in_current_year, days_in_next_year", [("1D", "2012-12-31", 1, 0),
+@pytest.mark.parametrize("freq, start_date, days_in_current_year, days_in_next_year", [
+                                                                                       ("1D", "2012-12-31", 1, 0),
                                                                                        ("1D", "2011-12-31", 1, 0),
-                                                                                       ("3D", "2012-12-31", 1, 2),
-                                                                                       (7, "2012-12-29", 3, 4),])
+                                                                                       ("3D", "2012-12-30", 2, 1),
+                                                                                       (7, "2012-12-29", 3, 4),
+                                                                                       ("60h", "2012-12-31", 1, 1.5),
+                                                                                       ("15h", "2012-12-31", 0.625, 0),
+                                                                                       ("39h", "2012-12-31", 1, 0.625)
+                                                                                      ])
 def test_timestep_days_in_year_methods(simple_linear_model, freq, start_date, days_in_current_year, days_in_next_year):
     """Test the `days_in_current_year` and `days_in_next_year` methods of the timestep object"""
-
     simple_linear_model.timestepper.start = start_date
     simple_linear_model.timestepper.end = "2013-01-30"
     simple_linear_model.timestepper.delta = freq
@@ -581,6 +585,5 @@ def test_timestep_days_in_year_methods(simple_linear_model, freq, start_date, da
     simple_linear_model.step()
 
     ts = simple_linear_model.timestepper.current
-
     assert days_in_current_year == ts.days_in_current_year()
     assert days_in_next_year == ts.days_in_next_year()

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1680,7 +1680,14 @@ class TestAnnualTotalFlowRecorder:
     @pytest.mark.parametrize("end_date, expected", [("2013-01-04", [30.0, 40.0]), ("2012-12-31", [30.0]),])
     def test_annual_total_flow_recorder_year_end(self, simple_linear_model, end_date, expected):
         """
-        Test AnnualTotalFlowRecorder when timestep crosses year end
+        Test AnnualTotalFlowRecorder when timestep crosses year end.
+
+        The two parameterisations of this test run a single timestep of 7 days that crosses into the next year. In the
+        first, the model end date is set to the end of the timestep, so flow for the recorder is assigned to each year
+        according to the numbers of days of the timestep that are in each year (3 in the current, 4 in the next). In the
+        second parameterisation, the model end date is set to the end of year, so flow for the recorder is only assigned
+        for the first 3 days of the timestep that are in the current year. The subsequent 4 days of the timestep are not
+        recorded because they are beyond the model end date.
         """
         model = simple_linear_model
         simple_linear_model.timestepper.start = "2012-12-29"

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1677,6 +1677,26 @@ class TestAnnualTotalFlowRecorder:
         df = rec_fact.to_dataframe()
         assert_allclose([[3650.0*3]], df.values)
 
+    @pytest.mark.parametrize("end_date, expected", [("2013-01-04", [30.0, 40.0]), ("2012-12-31", [30.0]),])
+    def test_annual_total_flow_recorder_year_end(self, simple_linear_model, end_date, expected):
+        """
+        Test AnnualTotalFlowRecorder when timestep crosses year end
+        """
+        model = simple_linear_model
+        simple_linear_model.timestepper.start = "2012-12-29"
+        simple_linear_model.timestepper.end = end_date
+        simple_linear_model.timestepper.delta = "7D"
+
+        otpt = model.nodes['Output']
+        otpt.max_flow = 30.0
+        model.nodes['Input'].max_flow = 10.0
+        otpt.cost = -2
+        rec = AnnualTotalFlowRecorder(model, 'Total Flow', [otpt])
+
+        model.run()
+
+        assert_allclose(expected, rec.data.flatten())
+
 
 def test_total_flow_node_recorder(simple_linear_model):
     """


### PR DESCRIPTION
These methods can be used by annual recorder to make sure that the correct proportion of flow is allocated to correct year when the timestep delta is greater than 1 day