### PR TITLE
Add CI steps to publish wheels and sdist to test PyPI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,16 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+      - name: Publish wheels to Test PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: ./wheelhouse/
+
+
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -93,6 +103,15 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: dist/*.tar.gz
+
+      - name: Publish sdist to Test PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: dist/
 
   build_docs:
     name: Build documentation


### PR DESCRIPTION
Publishing only happens on tagged commits. If this works as
expected we can follow-up with another commit to move to
live PyPI.

Beginning of the end for #944 