### PR TITLE
Assert entries when creating rows in the GLPK matrix.

### DIFF
--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -256,6 +256,9 @@ cdef set_col_bnds(glp_prob *P, int i, int type, double lb, double ub):
 
 
 cdef set_mat_row(glp_prob *P, int i, int len, int* ind, double* val):
+    assert len > 0, "Attempting to set a constraint row with zero entries. This should not happen. It is likely caused" \
+                    "by invalid or unsupported network configuration, but should generally be caught earlier by Pywr. " \
+                    "If you experience this error please report it to the Pywr developers."
     IF SOLVER_DEBUG:
         cdef int j
         for j in range(len):

--- a/tests/models/virtual_storage3.json
+++ b/tests/models/virtual_storage3.json
@@ -1,0 +1,57 @@
+{
+    "metadata": {
+        "title": "Annual virtual storage with piecewise link",
+        "description": "Annual abstraction licence implemented as an annual virtual storage applied to a virtual storage node.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0
+        },
+        {
+            "name": "link1",
+            "type": "PiecewiseLink",
+            "nsteps": 2,
+            "max_flows": [10, null],
+            "costs": [-1, 0]
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "licence1",
+            "type": "AnnualVirtualStorage",
+            "max_volume": 205,
+            "initial_volume": 205,
+            "nodes": [
+                "link1"
+            ],
+            "factors": [
+                1.0
+            ],
+            "reset_day": 1,
+            "reset_month": 1
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        }
+    }
+}

--- a/tests/models/virtual_storage4.json
+++ b/tests/models/virtual_storage4.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "title": "Annual virtual storage with piecewise link",
-        "description": "Annual abstraction licence implemented as an annual virtual storage applied to a piecewise link.",
+        "description": "Annual abstraction licence implemented as an annual virtual storage applied to an aggregated node.",
         "minimum_version": "0.1"
     },
     "timestepper": {
@@ -18,10 +18,7 @@
         },
         {
             "name": "link1",
-            "type": "PiecewiseLink",
-            "nsteps": 2,
-            "max_flows": [10, null],
-            "costs": [-1, 0]
+            "type": "link"
         },
         {
             "name": "demand1",
@@ -30,12 +27,17 @@
             "cost": -10
         },
         {
+            "name": "total1",
+            "type": "aggregatednode",
+            "nodes": ["link1"]
+        },
+        {
             "name": "licence1",
             "type": "AnnualVirtualStorage",
             "max_volume": 205,
             "initial_volume": 205,
             "nodes": [
-                "link1"
+                "total1"
             ],
             "factors": [
                 1.0

--- a/tests/test_control_curves.py
+++ b/tests/test_control_curves.py
@@ -177,6 +177,11 @@ class TestPiecewiseControlCurveParameter:
         s = m.nodes['Storage']
 
         l = Link(m, 'Link')
+        # Connect the link node to the network to create a valid model
+        o = m.nodes['Output']
+        s.connect(l)
+        l.connect(o)
+
         cc = ConstantParameter(model, 0.8)
         l.cost = ControlCurveParameter(model, s, cc, [10.0, 0.0])
 
@@ -193,12 +198,15 @@ class TestPiecewiseControlCurveParameter:
             s.initial_volume = initial_volume
             m.run()
 
-
     def test_with_nonstorage_load(self, model):
         """ Test load from dict with 'storage_node' key. """
         m = model
         s = m.nodes['Storage']
         l = Link(m, 'Link')
+        # Connect the link node to the network to create a valid model
+        o = m.nodes['Output']
+        s.connect(l)
+        l.connect(o)
 
         data = {
             "type": "controlcurve",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -232,6 +232,8 @@ def test_dirty_model():
 
     # add a new node, dirty
     supply2 = Input(model, 'supply2')
+    demand2 = Output(model, 'demand2')
+    supply2.connect(demand2)
 
     # run the model, clean
     result = model.step()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -451,6 +451,19 @@ def test_annual_virtual_storage_with_dynamic_cost():
     assert_allclose(rec.data[3], 5)
 
 
+@pytest.mark.xfail(raises=AssertionError, reason="See issue #1001: https://github.com/pywr/pywr/issues/1001")
+def test_annual_virtual_storage_with_piecewise_link():
+    model = load_model('virtual_storage3.json')
+    model.run()
+    node = model.nodes["supply1"]
+    rec = node.recorders[0]
+    assert_allclose(rec.data[0], 10) # licence is not a constraint
+    assert_allclose(rec.data[19], 10)
+    assert_allclose(rec.data[20], 5) # licence is constraint
+    assert_allclose(rec.data[21], 0) # licence is exhausted
+    assert_allclose(rec.data[365], 10) # licence is refreshed
+
+
 class TestSeasonalVirtualStorage:
     def test_run(self):
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -453,15 +453,36 @@ def test_annual_virtual_storage_with_dynamic_cost():
 
 @pytest.mark.xfail(raises=AssertionError, reason="See issue #1001: https://github.com/pywr/pywr/issues/1001")
 def test_annual_virtual_storage_with_piecewise_link():
+    """Test `AnnualVirtualStorage` works with `PiecewiseLink`"""
     model = load_model('virtual_storage3.json')
+    # This should fail before #1001 is fixed properly. Once fixed the assertions about the licence and
+    # flow should be uncommented and pass.
     model.run()
-    node = model.nodes["supply1"]
-    rec = node.recorders[0]
-    assert_allclose(rec.data[0], 10) # licence is not a constraint
-    assert_allclose(rec.data[19], 10)
-    assert_allclose(rec.data[20], 5) # licence is constraint
-    assert_allclose(rec.data[21], 0) # licence is exhausted
-    assert_allclose(rec.data[365], 10) # licence is refreshed
+
+    # node = model.nodes["supply1"]
+    # rec = node.recorders[0]
+    # assert_allclose(rec.data[0], 10) # licence is not a constraint
+    # assert_allclose(rec.data[19], 10)
+    # assert_allclose(rec.data[20], 5) # licence is constraint
+    # assert_allclose(rec.data[21], 0) # licence is exhausted
+    # assert_allclose(rec.data[365], 10) # licence is refreshed
+
+
+@pytest.mark.xfail(raises=AssertionError, reason="See issue #1001: https://github.com/pywr/pywr/issues/1001")
+def test_annual_virtual_storage_with_aggregated_node():
+    """Test `AnnualVirtualStorage` works with `AggregatedNode`"""
+    model = load_model('virtual_storage4.json')
+    # This should fail before #1001 is fixed properly. Once fixed the assertions about the licence and
+    # flow should be uncommented and pass.
+    model.run()
+
+    # node = model.nodes["supply1"]
+    # rec = node.recorders[0]
+    # assert_allclose(rec.data[0], 10) # licence is not a constraint
+    # assert_allclose(rec.data[19], 10)
+    # assert_allclose(rec.data[20], 5) # licence is constraint
+    # assert_allclose(rec.data[21], 0) # licence is exhausted
+    # assert_allclose(rec.data[365], 10) # licence is refreshed
 
 
 class TestSeasonalVirtualStorage:


### PR DESCRIPTION
In response to #1001 this commit implements a check to the `glp_set_mat_row` call to ensure that there is at least one entry in the row. Zero entry rows are likely caused by invalid or unsupported model / network configuration (e.g. those reported in #1001). For the time being this change will ensure such models fail to run with an `AssertionError` instead of failing to apply expected constraints silently.

I suggest we merge this rapidly and release a bug fix ASAP.

A proper fix to enable support for a `PiecewiseLink` or other complex nodes with `VirtualStorage` is still required.

