### PR TITLE
Build & test Python 3.10 wheels.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ env:
   # Only build on Python 3.7+
   CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
   # Skip 32-bit builds
-  # Skip 3.9 & 3.10 on Windows because of missing PyTables wheels
-  CIBW_SKIP: "*-win32 *-manylinux_i686 cp39-win_amd64 cp310-win_amd64"
+  CIBW_SKIP: "*-win32 *-manylinux_i686"
   # Install GLPK
   CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve-devel
   # build using the manylinux2014 image. Can link to system provided GLPk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,11 @@ env:
   CIBW_TEST_COMMAND_WINDOWS: "{project}\\.github\\workflows\\run-tests-windows.bat {project}"
   # Only build on Python 3.7+
   CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-  # Skip 32-bit builds
-  CIBW_SKIP: "*-win32 *-manylinux_i686"
+  # Skip 32-bit builds and MUSL Linux builds
+  # MUSL Linux can be re-enabled more easily when updating from manylinux2014
+  CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
   # Install GLPK
-  CIBW_BEFORE_ALL_LINUX: dnf install -y glpk-devel lpsolve-devel
+  CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve-devel
   # build using the manylinux2014 image. Can link to system provided GLPk
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ env:
   CIBW_TEST_COMMAND_LINUX: "{project}/.github/workflows/run-tests.sh {project}"
   CIBW_TEST_COMMAND_WINDOWS: "{project}\\.github\\workflows\\run-tests-windows.bat {project}"
   # Only build on Python 3.7+
-  CIBW_BUILD: cp37-* cp38-* cp39-*
+  CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
   # Skip 32-bit builds
-  # Skip 3.9 on Windows because of missing PyTables wheels
-  CIBW_SKIP: "*-win32 *-manylinux_i686 cp39-win_amd64"
+  # Skip 3.9 & 3.10 on Windows because of missing PyTables wheels
+  CIBW_SKIP: "*-win32 *-manylinux_i686 cp39-win_amd64 cp310-win_amd64"
   # Install GLPK
   CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve-devel
   # build using the manylinux2014 image. Can link to system provided GLPk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.4
+          python -m pip install cibuildwheel
 
       - name: Install WinGLPK (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   # Skip 32-bit builds
   CIBW_SKIP: "*-win32 *-manylinux_i686"
   # Install GLPK
-  CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve-devel
+  CIBW_BEFORE_ALL_LINUX: dnf install -y glpk-devel lpsolve-devel
   # build using the manylinux2014 image. Can link to system provided GLPk
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014


### PR DESCRIPTION
This might not work just yet due to our dependencies, but we can re-run the pipeline until it does.