### PR TITLE
Fix doc error about aggregated parameters

### DIFF
--- a/docs/source/cookbook/aggregated_parameter.rst
+++ b/docs/source/cookbook/aggregated_parameter.rst
@@ -86,7 +86,7 @@ The examples below compare the "max" aggregation function in ``AggregatedParamet
 
     {
         "type": "max",
-        "parameter": "another_parameter"
+        "parameter": "another_parameter",
         "threshold": 0.0
     }
 
@@ -98,7 +98,7 @@ An example use of these functions is to handle the net inflow timeseries for a r
 
     "inflow": {
         "type": "max",
-        "parameter": "original"
+        "parameter": "original",
         "threshold": 0.0
     }
     
@@ -107,7 +107,6 @@ An example use of these functions is to handle the net inflow timeseries for a r
         "parameter": {
             "type": "negative",
             "parameter": "original"
-            "threshold": 0.0
         }
         "threshold": 0.0
     }


### PR DESCRIPTION
Docs incorrectly include a "threshold" for a `NegativeParameter` and misses some commas in the JSON definitions.