### PR TITLE
Improve handling of NaN current pc in storage nodes.

### DIFF
--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -131,7 +131,7 @@ cdef class Storage(AbstractStorage):
     cdef Parameter _level_param
     cdef Parameter _area_param
     cpdef double get_initial_volume(self) except? -1
-    cpdef double get_initial_pc(self) except? -1    
+    cpdef double get_initial_pc(self) except? -1
     cpdef _reset_storage_only(self, bint use_initial_volume=*)
     cpdef double get_min_volume(self, ScenarioIndex scenario_index) except? -1
     cpdef double[:] get_all_min_volume(self, double[:] out=*)

--- a/pywr/_core.pxd
+++ b/pywr/_core.pxd
@@ -116,6 +116,7 @@ cdef class BaseInput(Node):
 cdef class AbstractStorage(AbstractNode):
     cdef public double[:] _volume
     cdef public double[:] _current_pc
+    cpdef double get_current_pc(self, ScenarioIndex scenario_index)
 
 cdef class Storage(AbstractStorage):
     cdef double _cost
@@ -130,7 +131,7 @@ cdef class Storage(AbstractStorage):
     cdef Parameter _level_param
     cdef Parameter _area_param
     cpdef double get_initial_volume(self) except? -1
-    cpdef double get_initial_pc(self) except? -1
+    cpdef double get_initial_pc(self) except? -1    
     cpdef _reset_storage_only(self, bint use_initial_volume=*)
     cpdef double get_min_volume(self, ScenarioIndex scenario_index) except? -1
     cpdef double[:] get_all_min_volume(self, double[:] out=*)

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -1018,7 +1018,7 @@ cdef class AbstractStorage(AbstractNode):
         """ Current proportion full.
          
         Note that this property is the raw internal value of the current_pc and may contain `NaN` values. Prefer
-        use of the `get_current_pc` method to return a guaranteed a finite value between 0.0 and 1.0.
+        use of the `get_current_pc` method to return a guaranteed finite value between 0.0 and 1.0.
         """
         def __get__(self, ):
             return np.asarray(self._current_pc)
@@ -1027,7 +1027,7 @@ cdef class AbstractStorage(AbstractNode):
         """Return the current proportion of full of the storage node.
         
         This method will always return a finite value between 0.0 and 1.0. If the current proportion is `NaN` 
-        (usually because max_volume is zero) it is assumed full (i.e. returns 1.0). It is preferrable to use
+        (usually because max_volume is zero) it is assumed full (i.e. returns 1.0). It is preferable to use
         this method in Parameter calculations to avoid dealing with NaN or out of range values.
         """
         cdef double current_pc = self._current_pc[scenario_index.global_id]

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -1,16 +1,13 @@
 from pywr._core cimport *
 from pywr._component cimport Component
 import itertools
+from libc.math cimport isnan
 import numpy as np
 cimport numpy as np
 import pandas as pd
 import warnings
 
 cdef double inf = float('inf')
-
-# http://stackoverflow.com/a/20031818/1300519
-cdef extern from "numpy/npy_math.h":
-    bint npy_isnan(double x)
 
 
 cdef class Scenario:
@@ -1034,7 +1031,7 @@ cdef class AbstractStorage(AbstractNode):
         this method in Parameter calculations to avoid dealing with NaN or out of range values.
         """
         cdef double current_pc = self._current_pc[scenario_index.global_id]
-        if current_pc > 1.0 or npy_isnan(current_pc):
+        if current_pc > 1.0 or isnan(current_pc):
             current_pc = 1.0
         elif current_pc < 0.0:
             current_pc = 0.0

--- a/pywr/_core.pyx
+++ b/pywr/_core.pyx
@@ -8,6 +8,11 @@ import warnings
 
 cdef double inf = float('inf')
 
+# http://stackoverflow.com/a/20031818/1300519
+cdef extern from "numpy/npy_math.h":
+    bint npy_isnan(double x)
+
+
 cdef class Scenario:
     """Represents a scenario in the model.
 
@@ -1013,9 +1018,27 @@ cdef class AbstractStorage(AbstractNode):
             return np.asarray(self._volume)
 
     property current_pc:
-        """ Current percentage full """
+        """ Current proportion full.
+         
+        Note that this property is the raw internal value of the current_pc and may contain `NaN` values. Prefer
+        use of the `get_current_pc` method to return a guaranteed a finite value between 0.0 and 1.0.
+        """
         def __get__(self, ):
             return np.asarray(self._current_pc)
+
+    cpdef double get_current_pc(self, ScenarioIndex scenario_index):
+        """Return the current proportion of full of the storage node.
+        
+        This method will always return a finite value between 0.0 and 1.0. If the current proportion is `NaN` 
+        (usually because max_volume is zero) it is assumed full (i.e. returns 1.0). It is preferrable to use
+        this method in Parameter calculations to avoid dealing with NaN or out of range values.
+        """
+        cdef double current_pc = self._current_pc[scenario_index.global_id]
+        if current_pc > 1.0 or npy_isnan(current_pc):
+            current_pc = 1.0
+        elif current_pc < 0.0:
+            current_pc = 0.0
+        return current_pc
 
     cpdef setup(self, model):
         """ Called before the first run of the model"""

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -67,7 +67,7 @@ cdef class Polynomial1DParameter(Parameter):
             x = self._parameter.__values[scenario_index.global_id]
         elif self._storage_node is not None:
             if self.use_proportional_volume:
-                x = self._storage_node._current_pc[scenario_index.global_id]
+                x = self._storage_node.get_current_pc(scenario_index)
             else:
                 x = self._storage_node._volume[scenario_index.global_id]
         elif self._other_node is not None:
@@ -151,7 +151,7 @@ cdef class Polynomial2DStorageParameter(Parameter):
 
         # Storage volume is 1st dimension
         if self.use_proportional_volume:
-            x = self._storage_node._current_pc[scenario_index.global_id]
+            x = self._storage_node.get_current_pc(scenario_index)
         else:
             x = self._storage_node._volume[scenario_index.global_id]
         # Parameter value is 2nd dimension


### PR DESCRIPTION
The current approach requires Parameter writers to handle
NaN values for current_pc. NaNs can occur when storage nodes
have zero maximum volume. This PR adds a convenience method
to get a finite and bounded current_pc for all storage nodes.
Pywr's internal parameters are updated to use this in preference
to direct access of the ._current_pc memory view.

Parameter writers should also use this new cpdef function instead
of using .current_pc directly.

There are two recorders which still use the raw ._current_pc
memory view for their data outputs. Those could be updated too.

We should also add some explicit tests for cases where using this
new internal function makes a difference.