### PR TITLE
Improve GLPK error handling.

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -3,11 +3,13 @@
 # GLPK solver
 echo "Running GLPK (route-based) tests in: $1";
 PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
+PYWR_SOLVER_GLPK_UNSAFE_API=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
 PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE=true PYWR_SOLVER="glpk" pytest "$1"/tests  || exit 1
 
 # GLPK Edge solver
 echo "Running GLPK (edge-based) tests in: $1";
 PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
+PYWR_SOLVER_GLPK_UNSAFE_API=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
 PYWR_SOLVER_GLPK_FIXED_COSTS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FLOWS_ONCE=true PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE=true PYWR_SOLVER="glpk-edge" pytest "$1"/tests  || exit 1
 
 # Lpsolve solver

--- a/docs/source/err_perf.rst
+++ b/docs/source/err_perf.rst
@@ -2,7 +2,7 @@ GLPK error handling and performance
 ===================================
 
 In complex models it may be possible to create combinations of nodes, custom parameter outputs and other data that
-does translate in to a sensible linear programme. GLPK's C interface by default performs little check of input values
+does not translate in to a sensible linear programme. GLPK's C interface by default performs little check of input values
 (e.g. NaNs are unchecked). Since v1.17 Pywr has enabled additional data checking and error handling by default.
 
 Version 1.17 and above
@@ -18,9 +18,10 @@ from. In general if either of these errors occur users are recommended to debug 
 an new process) the models. It is *not* recommended to attempt to catch these exceptions, recover and continue with
 a simulation.
 
-The addition of the data checking and error handling is not zero cost in terms of runtime performance. Since version
-1.17 a new compile time option has been added, `--glpk-unsafe`, which uses GLPK without any data checks or error
-handling. This should be comparable with Pywr's default behaviour prior to version 1.17.
+The addition of the data checking and error handling is not zero cost in terms of runtime performance. Benchmarks on
+random test models and real world models have shown the cost is minimal in the context of an entire simulation.
+However, since version 1.17 a new compile time option has been added, `--glpk-unsafe`, which uses GLPK without any data
+checks or error handling. This should be comparable with Pywr's default behaviour prior to version 1.17.
 
 
 Older versions

--- a/docs/source/err_perf.rst
+++ b/docs/source/err_perf.rst
@@ -1,0 +1,32 @@
+GLPK error handling and performance
+===================================
+
+In complex models it may be possible to create combinations of nodes, custom parameter outputs and other data that
+does translate in to a sensible linear programme. GLPK's C interface by default performs little check of input values
+(e.g. NaNs are unchecked). Since v1.17 Pywr has enabled additional data checking and error handling by default.
+
+Version 1.17 and above
+----------------------
+
+Since version v1.17 Pywr has included additional value checking and error handling by default. These checks will
+ensure that NaN values are caught before they reach GLPK. The error handling ensures that any internal errors within
+GLPK are caught gracefully and translated to Python exceptions. Two exceptions `GLPKError` and `GLPKInternalError`
+are raised for these cases respectively.
+
+Internal errors (i.e. `GLPKInternalError`) will invalidate the entire GLPK environment and is very difficult to recover
+from. In general if either of these errors occur users are recommended to debug their causes and re-load (ideally with
+an new process) the models. It is *not* recommended to attempt to catch these exceptions, recover and continue with
+a simulation.
+
+The addition of the data checking and error handling is not zero cost in terms of runtime performance. Since version
+1.17 a new compile time option has been added, `--glpk-unsafe`, which uses GLPK without any data checks or error
+handling. This should be comparable with Pywr's default behaviour prior to version 1.17.
+
+
+Older versions
+--------------
+
+Prior to version v1.17 checks of NaN values could be enabled using the `--enabled-debug` option at build time. Any
+errors would result in an `AssertionError` from the GLPK solver interface. Internal GLPK errors are not handled in
+earlier versions of Pywr. If an error occurs within GLPK it is very likely that this will result in a segmentation
+fault of the calling Python process.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Contents:
    tutorial.rst
    formulation.rst
    json.rst
+   err_perf.rst
    Cookbook <cookbook/cookbook.rst>
    Extending Pywr <extending_pywr/index.rst>
    Python API reference <api/pywr.rst>

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -99,6 +99,12 @@ else:
                 "PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE",
                 bool,
             )
+            kwargs = _parse_env_kwarg(
+                kwargs,
+                "use_safe_api",
+                "PYWR_SOLVER_GLPK_UNSAFE_API",
+                bool,
+            )
             self._cy_solver = cy_CythonGLPKSolver(**kwargs)
 
         def setup(self, model):
@@ -215,6 +221,12 @@ else:
                 kwargs,
                 "set_fixed_factors_once",
                 "PYWR_SOLVER_GLPK_FIXED_FACTORS_ONCE",
+                bool,
+            )
+            kwargs = _parse_env_kwarg(
+                kwargs,
+                "use_safe_api",
+                "PYWR_SOLVER_GLPK_UNSAFE_API",
                 bool,
             )
             self._cy_solver = cy_CythonGLPKEdgeSolver(**kwargs)

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -101,7 +101,7 @@ else:
             )
             kwargs = _parse_env_kwarg(
                 kwargs,
-                "use_safe_api",
+                "use_unsafe_api",
                 "PYWR_SOLVER_GLPK_UNSAFE_API",
                 bool,
             )
@@ -229,7 +229,7 @@ else:
             )
             kwargs = _parse_env_kwarg(
                 kwargs,
-                "use_safe_api",
+                "use_unsafe_api",
                 "PYWR_SOLVER_GLPK_UNSAFE_API",
                 bool,
             )

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -164,6 +164,10 @@ else:
             return self._cy_solver.use_presolve
 
         @property
+        def use_unsafe_api(self):
+            return self._cy_solver.use_unsafe_api
+
+        @property
         def set_fixed_flows_once(self):
             return self._cy_solver.set_fixed_flows_once
 
@@ -267,6 +271,10 @@ else:
         @property
         def use_presolve(self):
             return self._cy_solver.use_presolve
+
+        @property
+        def use_unsafe_api(self):
+            return self._cy_solver.use_unsafe_api
 
         @property
         def set_fixed_flows_once(self):

--- a/pywr/solvers/__init__.py
+++ b/pywr/solvers/__init__.py
@@ -62,7 +62,11 @@ class Solver(object):
 
 # Attempt to import solvers. These will only be successful if they are built correctly.
 try:
-    from .cython_glpk import CythonGLPKSolver as cy_CythonGLPKSolver
+    from .cython_glpk import (
+        CythonGLPKSolver as cy_CythonGLPKSolver,
+        GLPKError,
+        GLPKInternalError,
+    )
 except ImportError:
     pass
 else:

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -248,9 +248,9 @@ cdef int term_hook(void *info, const char *s):
 
 # Unsafe interface to GLPK
 # This interface performs no checks or error handling
-cdef simplex_unsafe(glp_prob *P, glp_smcp parm):
+cdef int simplex_unsafe(glp_prob *P, glp_smcp parm):
     """Unsafe wrapped call to `glp_simplex`"""
-    glp_simplex(P, &parm)
+    return glp_simplex(P, &parm)
 
 cdef set_obj_coef_unsafe(glp_prob *P, int j, double coef):
     """Unsafe wrapped call to `glp_set_obj_coef`"""
@@ -488,10 +488,7 @@ cdef class CythonGLPKSolver(GLPKSolver):
 
         # explicitly set bounds on route and demand columns
         for col, route in enumerate(routes):
-            if self.use_unsafe_api:
-                set_col_bnds_unsafe(self.prob, self.idx_col_routes+col, GLP_LO, 0.0, DBL_MAX)
-            else:
-                set_col_bnds_safe(self.prob, self.idx_col_routes+col, GLP_LO, 0.0, DBL_MAX)
+            set_col_bnds_safe(self.prob, self.idx_col_routes+col, GLP_LO, 0.0, DBL_MAX)
 
         # constrain supply minimum and maximum flow
         self.idx_row_non_storages = glp_add_rows(self.prob, len(non_storages))

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -279,7 +279,7 @@ ELSE:
             raise GLPKInternalError("An error occurred in `glp_simplex`." + glpk_error_msg)
 
 
-    cdef int set_obj_coef(glp_prob *P, int j, double coef) except? -1:
+    cdef int set_obj_coef(glp_prob *P, int j, double coef) except -1:
         """Wrapped call to `glp_set_obj_coef`"""
         if isnan(coef):
             raise GLPKError(f"NaN detected in objective coefficient of column {j}")
@@ -290,7 +290,7 @@ ELSE:
             raise GLPKInternalError("An error occurred in `glp_set_obj_coef`." + glpk_error_msg)
 
 
-    cdef int set_row_bnds(glp_prob *P, int i, int type, double lb, double ub) except? -1:
+    cdef int set_row_bnds(glp_prob *P, int i, int type, double lb, double ub) except -1:
         """Wrapped call to `glp_set_row_bnds`"""
         if isnan(lb):
             raise GLPKError(f"NaN detected in lower bounds of row {i}")
@@ -317,8 +317,8 @@ ELSE:
     cdef int set_mat_row(glp_prob *P, int i, int len, int* ind, double* val) except -1:
         """Wrapped call to `glp_set_mat_row`"""
         if len == 0:
-            raise GLPKError("Attempting to set a constraint row with zero entries. This should not happen. It is likely caused" \
-                            "by invalid or unsupported network configuration, but should generally be caught earlier by Pywr. " \
+            raise GLPKError("Attempting to set a constraint row with zero entries. This should not happen. It is likely caused "
+                            "by invalid or unsupported network configuration, but should generally be caught earlier by Pywr. "
                             "If you experience this error please report it to the Pywr developers.")
 
         for j in range(len):

--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -151,9 +151,9 @@ cdef class GLPKSolver:
             glp_delete_prob(self.prob)
 
     def __init__(self, use_presolve=False, time_limit=None, iteration_limit=None, message_level="error",
-                 set_fixed_flows_once=False, set_fixed_costs_once=False, set_fixed_factors_once=False, use_safe_api=False):
+                 set_fixed_flows_once=False, set_fixed_costs_once=False, set_fixed_factors_once=False, use_unsafe_api=False):
         self.use_presolve = use_presolve
-        self.use_unsafe_api = use_safe_api
+        self.use_unsafe_api = use_unsafe_api
         self.set_solver_options(time_limit, iteration_limit, message_level)
         glp_term_hook(term_hook, NULL)
         self.has_presolved = False

--- a/pywr/solvers/libglpk.pxd
+++ b/pywr/solvers/libglpk.pxd
@@ -1,3 +1,5 @@
+from libc.setjmp cimport jmp_buf
+
 cdef extern from "glpk.h":
     ctypedef struct glp_prob:
         pass
@@ -52,6 +54,7 @@ cdef extern from "glpk.h":
     void glp_erase_prob(glp_prob *P)
     void glp_delete_prob(glp_prob *P)
     void glp_free(void *ptr)
+    int glp_free_env()
 
     int glp_add_rows(glp_prob *P, int nrs)
     int glp_add_cols(glp_prob *P, int ncs)
@@ -76,6 +79,7 @@ cdef extern from "glpk.h":
     int glp_get_status(glp_prob *P)
     int glp_term_out(int flag)
     void glp_term_hook(int (*func)(void *info, const char *s), void *info)
+    void glp_error_hook(void (*func)(void *info), void *info)
 
     double glp_get_row_prim(glp_prob *P, int i)
     double glp_get_col_prim(glp_prob *P, int j)

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ def setup_package():
 
     if config["glpk_unsafe"]:
         compile_time_env["GLPK_UNSAFE"] = True
-    print(compile_time_env)
+
     setup(**metadata)
 
 
@@ -230,7 +230,7 @@ def parse_optional_arguments():
     if "--glpk-unsafe" in sys.argv:
         config["glpk_unsafe"] = True
         sys.argv.remove("--glpk-unsafe")
-    print(config)
+
     return config
 
 

--- a/setup.py
+++ b/setup.py
@@ -220,8 +220,11 @@ def parse_optional_arguments():
 
     if "--enable-debug" in sys.argv:
         import warnings
-        warnings.warn("--enable-debug has been deprecated. Its functionality is now enabled by default. To disable"
-                      "GLPK error handling please use the `--glpk-unsafe` option.")
+
+        warnings.warn(
+            "--enable-debug has been deprecated. Its functionality is now enabled by default. To disable"
+            "GLPK error handling please use the `--glpk-unsafe` option."
+        )
         sys.argv.remove("--enable-debug")
 
     if "--glpk-unsafe" in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,7 @@ def setup_package():
     }
 
     define_macros = []
-
-    compile_time_env = {
-        "GLPK_UNSAFE": False,
-    }
+    compile_time_env = {}
 
     annotate = False
 
@@ -143,9 +140,6 @@ def setup_package():
             ]
         )
 
-    if config["glpk_unsafe"]:
-        compile_time_env["GLPK_UNSAFE"] = True
-
     setup(**metadata)
 
 
@@ -174,7 +168,6 @@ def parse_optional_arguments():
         "annotate": False,
         "profile": False,
         "trace": False,
-        "glpk_unsafe": False,
     }
 
     if "--with-glpk" in sys.argv:
@@ -223,13 +216,9 @@ def parse_optional_arguments():
 
         warnings.warn(
             "--enable-debug has been deprecated. Its functionality is now enabled by default. To disable"
-            "GLPK error handling please use the `--glpk-unsafe` option."
+            "GLPK error handling please use the `use_unsafe_api` option in the GLPK solvers."
         )
         sys.argv.remove("--enable-debug")
-
-    if "--glpk-unsafe" in sys.argv:
-        config["glpk_unsafe"] = True
-        sys.argv.remove("--glpk-unsafe")
 
     return config
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def setup_package():
     define_macros = []
 
     compile_time_env = {
-        "SOLVER_DEBUG": False,
+        "GLPK_UNSAFE": False,
     }
 
     annotate = False
@@ -143,9 +143,9 @@ def setup_package():
             ]
         )
 
-    if config["debug"]:
-        compile_time_env["SOLVER_DEBUG"] = True
-
+    if config["glpk_unsafe"]:
+        compile_time_env["GLPK_UNSAFE"] = True
+    print(compile_time_env)
     setup(**metadata)
 
 
@@ -174,7 +174,7 @@ def parse_optional_arguments():
         "annotate": False,
         "profile": False,
         "trace": False,
-        "debug": False,
+        "glpk_unsafe": False,
     }
 
     if "--with-glpk" in sys.argv:
@@ -219,9 +219,15 @@ def parse_optional_arguments():
         )
 
     if "--enable-debug" in sys.argv:
-        config["debug"] = True
+        import warnings
+        warnings.warn("--enable-debug has been deprecated. Its functionality is now enabled by default. To disable"
+                      "GLPK error handling please use the `--glpk-unsafe` option.")
         sys.argv.remove("--enable-debug")
 
+    if "--glpk-unsafe" in sys.argv:
+        config["glpk_unsafe"] = True
+        sys.argv.remove("--glpk-unsafe")
+    print(config)
     return config
 
 

--- a/tests/models/aggregated_with_two_nodes_same_route.json
+++ b/tests/models/aggregated_with_two_nodes_same_route.json
@@ -1,0 +1,54 @@
+{
+    "metadata": {
+        "title": "Test of aggregated node constraints",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2016-01-01",
+        "end": "2016-01-02",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "A",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "B",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "C",
+            "type": "input",
+            "max_flow": 50
+        },
+        {
+            "name": "X",
+            "type": "link",
+            "max_flow": 50
+        },
+        {
+            "name": "Z",
+            "type": "output",
+            "max_flow": 100,
+            "cost": -100
+        },
+        {
+            "name": "agg",
+            "type": "AggregatedNode",
+            "nodes": ["A", "B", "C", "X"],
+            "factors": [1.0, 1.0, 1.0, 1.0],
+            "flow_weights": [1.0, 1.0, 1.0, 1.0],
+            "max_flow": 30.0,
+            "min_flow": 5.0
+        }
+    ],
+    "edges": [
+        ["A", "X"],
+        ["X", "Z"],
+        ["B", "Z"],
+        ["C", "Z"]
+    ]
+}

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -1,3 +1,4 @@
+import pywr.solvers
 from pywr.core import (
     Model,
     Input,
@@ -221,6 +222,37 @@ def test_aggregated_constraint_json():
 
     assert_allclose(agg.max_flow, 30.0)
     assert_allclose(agg.min_flow, 5.0)
+
+    model.run()
+
+
+@pytest.mark.skipif(
+    Model().solver.name != "glpk", reason="Only valid for GLPK route based solver."
+)
+def test_aggregated_constraint_with_two_nodes_in_same_route_json():
+    """Test the case where an aggregated node contains two nodes in the same route.
+
+    In the route based solver this is not currently possible.
+    """
+    model = load_model("aggregated_with_two_nodes_same_route.json")
+
+    agg = model.nodes["agg"]
+    assert agg.nodes == [
+        model.nodes["A"],
+        model.nodes["B"],
+        model.nodes["C"],
+        model.nodes["X"],
+    ]
+
+    for f, v in zip(agg.factors, [1.0, 1.0, 1.0, 1.0]):
+        assert isinstance(f, ConstantParameter)
+        assert_allclose(f.get_double_variables(), v)
+
+    assert_allclose(agg.max_flow, 30.0)
+    assert_allclose(agg.min_flow, 5.0)
+
+    with pytest.raises(pywr.solvers.GLPKInternalError):
+        model.run()
 
 
 @pytest.mark.parametrize("flow", (100.0, 200.0, 300.0))

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -227,7 +227,8 @@ def test_aggregated_constraint_json():
 
 
 @pytest.mark.skipif(
-    Model().solver.name != "glpk", reason="Only valid for GLPK route based solver."
+    Model().solver.name != "glpk" or Model().solver.use_unsafe_api,
+    reason="Only valid for GLPK route based solver using safe API.",
 )
 def test_aggregated_constraint_with_two_nodes_in_same_route_json():
     """Test the case where an aggregated node contains two nodes in the same route.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -929,7 +929,9 @@ class NanParameter(Parameter):
 
 
 class TestGlpkErrorHandling:
-    @pytest.mark.skipif(Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve.")
+    @pytest.mark.skipif(
+        Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve."
+    )
     def test_nan_constraint_error(self):
         """Test a NaN in a row constraint causes an error"""
         # parse the JSON into a model
@@ -944,7 +946,9 @@ class TestGlpkErrorHandling:
         with pytest.raises(pywr.solvers.GLPKError):
             model.run()
 
-    @pytest.mark.skipif(Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve.")
+    @pytest.mark.skipif(
+        Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve."
+    )
     def test_nan_cost_error(self):
         """Test a NaN in a node cost causes an error"""
         # parse the JSON into a model

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,6 +3,8 @@
 
 import os
 import datetime
+
+import numpy as np
 import pytest
 import pandas
 from numpy.testing import assert_allclose
@@ -14,6 +16,7 @@ import pywr.solvers
 import pywr.parameters.licenses
 import pywr.domains.river
 from pywr.recorders import assert_rec
+from pywr.parameters import Parameter
 from helpers import load_model
 
 import pywr.parameters
@@ -495,7 +498,7 @@ def test_annual_virtual_storage_with_dynamic_cost():
 
 
 @pytest.mark.xfail(
-    raises=AssertionError,
+    raises=pywr.solvers.GLPKError,
     reason="See issue #1001: https://github.com/pywr/pywr/issues/1001",
 )
 def test_annual_virtual_storage_with_piecewise_link():
@@ -515,7 +518,7 @@ def test_annual_virtual_storage_with_piecewise_link():
 
 
 @pytest.mark.xfail(
-    raises=AssertionError,
+    raises=pywr.solvers.GLPKError,
     reason="See issue #1001: https://github.com/pywr/pywr/issues/1001",
 )
 def test_annual_virtual_storage_with_aggregated_node():
@@ -916,3 +919,40 @@ def test_select_glpk_presolve(use_presolve):
         model = load_model(data=data)
         assert model.solver.name.lower() == solver_name
         assert model.solver._cy_solver.use_presolve == (use_presolve == "true")
+
+
+class NanParameter(Parameter):
+    """A parameter that returns a NaN for testing error handling"""
+
+    def value(self, ts, si):
+        return np.NAN
+
+
+class TestGlpkErrorHandling:
+    def test_nan_constraint_error(self):
+        """Test a NaN in a row constraint causes an error"""
+        # parse the JSON into a model
+        model = load_model("simple1.json")
+
+        nan_param = NanParameter(model)
+        inpt = model.nodes["supply1"]
+        inpt.max_flow = nan_param
+
+        model.setup()
+
+        with pytest.raises(pywr.solvers.GLPKError):
+            model.run()
+
+    def test_nan_cost_error(self):
+        """Test a NaN in a node cost causes an error"""
+        # parse the JSON into a model
+        model = load_model("simple1.json")
+
+        nan_param = NanParameter(model)
+        inpt = model.nodes["supply1"]
+        inpt.cost = nan_param
+
+        model.setup()
+
+        with pytest.raises(pywr.solvers.GLPKError):
+            model.run()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -929,6 +929,7 @@ class NanParameter(Parameter):
 
 
 class TestGlpkErrorHandling:
+    @pytest.mark.skipif(Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve.")
     def test_nan_constraint_error(self):
         """Test a NaN in a row constraint causes an error"""
         # parse the JSON into a model
@@ -943,6 +944,7 @@ class TestGlpkErrorHandling:
         with pytest.raises(pywr.solvers.GLPKError):
             model.run()
 
+    @pytest.mark.skipif(Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve.")
     def test_nan_cost_error(self):
         """Test a NaN in a node cost causes an error"""
         # parse the JSON into a model

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -930,7 +930,8 @@ class NanParameter(Parameter):
 
 class TestGlpkErrorHandling:
     @pytest.mark.skipif(
-        Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve."
+        Model().solver.name == "lpsolve" or Model().solver.use_unsafe_api,
+        reason="NaN not checked for lpsolve or unsafe GLPK API.",
     )
     def test_nan_constraint_error(self):
         """Test a NaN in a row constraint causes an error"""
@@ -947,7 +948,8 @@ class TestGlpkErrorHandling:
             model.run()
 
     @pytest.mark.skipif(
-        Model().solver.name == "lpsolve", reason="NaN not checked for lpsolve."
+        Model().solver.name == "lpsolve" or Model().solver.use_unsafe_api,
+        reason="NaN not checked for lpsolve or unsafe GLPK API.",
     )
     def test_nan_cost_error(self):
         """Test a NaN in a node cost causes an error"""


### PR DESCRIPTION
This picks up some work from #759 and the work done in #762 to
improve the error handling in GLPK. Best to read the new page
in the documentation that's been added about this. The TLDR
is that this adds NaN checks and GLPK error handling to Pywr
by default at the cost of some performance. The older
behaviour can be created with `--glpk-unsafe` compile time flag.

There are two new tests that cause seg faults with the unsafe
interface (i.e. current behaviour). Raising exceptions is better
from a handling point of view for users wrapping models in
multi-processing, etc.

Queries:
 - Should the unsafe interface be a runtime option instead of
a compile time option?
- Is changing the default error handling behaviour a good idea?

Useful reference: https://en.wikibooks.org/wiki/GLPK/Error_handling