### PR TITLE
Improve solver error messages for invalid networks.

### DIFF
--- a/pywr/solvers/cython_glpk.pyx
+++ b/pywr/solvers/cython_glpk.pyx
@@ -524,6 +524,10 @@ cdef class CythonGLPKSolver(GLPKSolver):
             else:
                 # Other nodes apply their flow constraints to all routes passing through them
                 cols = [n for n, route in enumerate(routes) if node in route]
+
+            if len(cols) == 0:
+                raise ModelStructureError(f'{node.__class__.__name__} node "{node.name}" is not part of any routes.')
+
             ind = <int*>malloc((1+len(cols)) * sizeof(int))
             val = <double*>malloc((1+len(cols)) * sizeof(double))
             for n, c in enumerate(cols):
@@ -1306,6 +1310,9 @@ cdef class CythonGLPKEdgeSolver(GLPKSolver):
             else:
                 # Other nodes apply their flow constraints to all routes passing through them
                 cols = node.__data.out_edges
+
+            if len(cols) == 0:
+                raise ModelStructureError(f'{node.__class__.__name__} node "{node.name}" does not have any valid connections.')
 
             ind = <int*>malloc((1+len(cols)) * sizeof(int))
             val = <double*>malloc((1+len(cols)) * sizeof(double))

--- a/pywr/solvers/cython_lpsolve.pyx
+++ b/pywr/solvers/cython_lpsolve.pyx
@@ -261,6 +261,9 @@ cdef class CythonLPSolveSolver:
             else:
                 cols = [n for n, route in enumerate(routes) if supply in route]
 
+            if len(cols) == 0:
+                raise ModelStructureError(f'{supply.__class__.__name__} node "{supply.name}" is not part of any routes.')
+
             ind = <int*>malloc(len(cols) * sizeof(int))
             val = <double*>malloc(len(cols) * sizeof(double))
             for n, c in enumerate(cols):
@@ -283,6 +286,10 @@ cdef class CythonLPSolveSolver:
         cross_domain_col = 0
         for col, demand in enumerate(demands):
             cols = [n for n, route in enumerate(routes) if route[-1] is demand]
+
+            if len(cols) == 0:
+                raise ModelStructureError(f'{demand.__class__.__name__} node "{demand.name}" is not part of any routes.')
+
             ind = <int*>malloc((1+len(cols)) * sizeof(int))
             val = <double*>malloc((1+len(cols)) * sizeof(double))
             for n, c in enumerate(cols):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ from pywr.core import Model, Timestep
 import pandas
 
 
-def load_model(filename=None, data=None, solver=None, model_klass=None):
+def load_model(filename=None, data=None, solver=None, model_klass=None, check=True):
     """Load a test model and check it"""
     if data is None:
         path = os.path.join(os.path.dirname(__file__), "models")
@@ -18,7 +18,8 @@ def load_model(filename=None, data=None, solver=None, model_klass=None):
         model_klass = Model
 
     model = model_klass.loads(data, path=path, solver=solver)
-    model.check()
+    if check:
+        model.check()
     return model
 
 

--- a/tests/models/simple1_broken.json
+++ b/tests/models/simple1_broken.json
@@ -1,0 +1,32 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"]
+    ]
+}

--- a/tests/models/simple1_semi_broken.json
+++ b/tests/models/simple1_semi_broken.json
@@ -1,0 +1,43 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example.",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link1",
+            "type": "Link"
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+            "name": "supply2",
+            "type": "Input",
+            "max_flow": 15
+        },
+        {
+            "name": "link2",
+            "type": "Link"
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"],
+        ["supply2", "link2"]
+    ]
+}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -839,6 +839,17 @@ def test_run_empty():
         model.run()
 
 
+@pytest.mark.parametrize(
+    "filename", ["simple1_broken.json", "simple1_semi_broken.json"]
+)
+def test_broken_model(filename):
+    """Model with no valid routes should not work."""
+    # Load, but don't trigger a `Model.check()` to make sure that the solver gives a useful error message
+    model = load_model(filename, check=False)
+    with pytest.raises(ModelStructureError):
+        model.run()
+
+
 def test_run():
     model = load_model("simple1.json")
 


### PR DESCRIPTION
If the user doesn't run `Model.check()` then the error from the solver is quite cryptic if their are missing connections between nodes. This change raises a `ModelStructureError` with a message containing the relevant node name which should help debugging some common mistakes.