### PR TITLE
Use Python 3.9 for building the documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Build docs
         # lpsolve doesn't compile on Ubuntu without building the library from source - disable for the time being.


### PR DESCRIPTION
Python 3.7 is a bit old and not all packages will support it in future.