### PR TITLE
Pass cutoff arg to call to nx.all_simple_paths

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -516,7 +516,7 @@ class Model(object):
         all_routes = []
         for node1 in type1_nodes:
             for node2 in type2_nodes:
-                for route in nx.all_simple_paths(self.graph, node1, node2):
+                for route in nx.all_simple_paths(self.graph, node1, node2, cutoff=max_length):
                     is_valid = True
                     # Check valid intermediate nodes
                     if valid is not None and len(route) > 2:


### PR DESCRIPTION
For a complex model I'm running this change dramatically reduces the overhead time of running the model from ~370 seconds to ~45 seconds.

It looks like a lot of the time is caused buy a few piecewise links that are very central to the network and therefore have a lot of routes associated with them. However, when using the `glpk-edge` solver only routes of 2 nodes to be assessed to get the cross-domain links. Limiting the length of routes that `all_simple_paths` searches for makes it this much faster.