### PR TITLE
Move project dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          python setup.py build_ext --inplace
+          pip install -e .
           python setup.py sdist
 
       - uses: actions/upload-artifact@v2
@@ -117,7 +117,7 @@ jobs:
         run: |
           sudo apt-get install libglpk-dev
           pip install sphinx sphinx_rtd_theme numpydoc
-          python setup.py build_ext --inplace
+          pip install -e .
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install cython
+          pip install cython numpy
           python setup.py sdist
 
       - uses: actions/upload-artifact@v2
@@ -116,7 +116,7 @@ jobs:
         # This doesn't really matter for the documentation builds.
         run: |
           sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc cython
+          pip install sphinx sphinx_rtd_theme numpydoc cython numpy
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install -e .
+          pip install cython
           python setup.py sdist
 
       - uses: actions/upload-artifact@v2
@@ -116,8 +116,7 @@ jobs:
         # This doesn't really matter for the documentation builds.
         run: |
           sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc
-          pip install -e .
+          pip install sphinx sphinx_rtd_theme numpydoc cython
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,7 @@ jobs:
           python-version: '3.7'
 
       - name: Build sdist
-        run: |
-          pip install cython numpy
-          python setup.py sdist
+        run: python setup.py sdist
 
       - uses: actions/upload-artifact@v2
         with:
@@ -116,7 +114,7 @@ jobs:
         # This doesn't really matter for the documentation builds.
         run: |
           sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc cython numpy
+          pip install sphinx sphinx_rtd_theme numpydoc
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on: [push, pull_request]
 
 env:
-  CIBW_TEST_REQUIRES: pytest platypus-opt
+  CIBW_TEST_REQUIRES: pytest platypus-opt ipython jinja2 matplotlib
   CIBW_BEFORE_TEST_LINUX: "chmod +x {project}/.github/workflows/run-tests.sh"
   CIBW_TEST_COMMAND_LINUX: "{project}/.github/workflows/run-tests.sh {project}"
   CIBW_TEST_COMMAND_WINDOWS: "{project}\\.github\\workflows\\run-tests-windows.bat {project}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,9 @@ jobs:
           python-version: '3.7'
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          python setup.py build_ext --inplace
+          python setup.py sdist
 
       - uses: actions/upload-artifact@v2
         with:
@@ -115,6 +117,7 @@ jobs:
         run: |
           sudo apt-get install libglpk-dev
           pip install sphinx sphinx_rtd_theme numpydoc
+          python setup.py build_ext --inplace
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         # This doesn't really matter for the documentation builds.
         run: |
           sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc
+          pip install sphinx sphinx_rtd_theme numpydoc matplotlib
           python setup.py install --without-lpsolve
           cd docs
           make html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,21 +9,3 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython", "n
 line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
-
-
-[project]
-dependencies = [
-    "pandas",
-    "networkx",
-    "scipy",
-    "tables",
-    "openpyxl",
-    "packaging",
-]
-
-[project.optional-dependencies]
-docs = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
-tests = ["pytest"]
-dev = ["sphinx", "sphinx_rtd_theme", "numpydoc", "pytest"]
-optimisation = ["platypus-opt", "pygmo"]
-notebook = ["jupyter", "jinja2", "matplotlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,21 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython", "n
 line-length = 88
 target-version = ['py37']
 include = '\.pyi?$'
+
+
+[project]
+dependencies = [
+    "pandas",
+    "networkx",
+    "scipy",
+    "tables",
+    "openpyxl",
+    "packaging",
+]
+
+[project.optional-dependencies]
+docs = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
+tests = ["pytest"]
+dev = ["sphinx", "sphinx_rtd_theme", "numpydoc", "pytest"]
+optimisation = ["platypus-opt", "pygmo"]
+notebook = ["jupyter", "jinja2", "matplotlib"]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def setup_package():
             super().finalize_options()
 
     # Extra optional dependencies
-    docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
+    docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc", "matplotlib"]
     notebook_extras = ["ipython", "jinja2", "matplotlib"]
     opt_extras = ["platypus-opt", "pygmo"]
     test_extras = ["pytest"] + notebook_extras + opt_extras

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ def setup_package():
     test_extras = ["pytest"] + notebook_extras + opt_extras
     dev_extras = docs_extras + test_extras
 
-
     metadata = dict(
         name="pywr",
         description="Python Water Resource model",
@@ -50,6 +49,7 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
+        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
         install_requires=[
             "pandas",
             "networkx",

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,6 @@ def setup_package():
             self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 
-    # Extra optional dependencies
-    docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
-    test_extras = ["pytest"]
-    dev_extras = docs_extras + test_extras
-    opt_extras = ["platypus-opt", "pygmo"]
-
     metadata = dict(
         name="pywr",
         description="Python Water Resource model",
@@ -48,24 +42,6 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
-        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
-        install_requires=[
-            "pandas",
-            "networkx",
-            "scipy",
-            "tables",
-            "openpyxl",
-            "packaging",
-            "matplotlib",
-            "jinja2",
-            "ipython",
-        ],
-        extras_require={
-            "docs": docs_extras,
-            "test": test_extras,
-            "dev": dev_extras,
-            "optimisation": opt_extras,
-        },
         cmdclass={"build_ext": new_build_ext},
         packages=[
             "pywr",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ def setup_package():
             self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 
-
     # Extra optional dependencies
     docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
     test_extras = ["pytest"]

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,11 @@ def setup_package():
 
     # Extra optional dependencies
     docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
-    test_extras = ["pytest"]
-    dev_extras = docs_extras + test_extras
+    notebook_extras = ["ipython", "jinja2", "matplotlib"]
     opt_extras = ["platypus-opt", "pygmo"]
-    notebook_extras = ["jupyter", "jinja2", "matplotlib"]
+    test_extras = ["pytest"] + notebook_extras + opt_extras
+    dev_extras = docs_extras + test_extras
+
 
     metadata = dict(
         name="pywr",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,14 @@ def setup_package():
             self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 
+
+    # Extra optional dependencies
+    docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc"]
+    test_extras = ["pytest"]
+    dev_extras = docs_extras + test_extras
+    opt_extras = ["platypus-opt", "pygmo"]
+    notebook_extras = ["jupyter", "jinja2", "matplotlib"]
+
     metadata = dict(
         name="pywr",
         description="Python Water Resource model",
@@ -42,6 +50,21 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
+        install_requires=[
+            "pandas",
+            "networkx",
+            "scipy",
+            "tables",
+            "openpyxl",
+            "packaging",
+        ],
+        extras_require={
+            "docs": docs_extras,
+            "test": test_extras,
+            "dev": dev_extras,
+            "optimisation": opt_extras,
+            "notebook": notebook_extras,
+        },
         cmdclass={"build_ext": new_build_ext},
         packages=[
             "pywr",


### PR DESCRIPTION
Add a new optional dependency group for notebook sub-package. This
removes ipython, matplotlob and jinja2 from core dependencies.