### PR TITLE
Correct the use of keyword arguments in Model.load

### DIFF
--- a/pywr/_model.pyx
+++ b/pywr/_model.pyx
@@ -317,6 +317,7 @@ class Model(object):
         if solver_args is None:
             solver_args = {}
 
+        solver_name = solver
         if solver is None:
             if 'solver' in data:
                 solver_data = data.pop('solver')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -637,7 +637,7 @@ def test_timestep_days_in_year_methods(
     assert days_in_next_year == ts.days_in_next_year()
 
 
-class SpecifyingSolver:
+class TestSpecifyingSolver:
     @pytest.mark.parametrize("solver", ["null", "glpk", "glpk-edge"])
     def test_load_with_solver(self, solver):
         """Specify the solver from the .load method."""
@@ -663,7 +663,7 @@ class SpecifyingSolver:
             data = json.load(fh)
 
         data["solver"] = {
-            "solver": solver,
+            "name": solver,
         }
 
         model = Model.load(data)
@@ -686,7 +686,7 @@ class SpecifyingSolver:
             data = json.load(fh)
 
         data["solver"] = {
-            "solver": "glpk",
+            "name": "glpk",
         }
 
         model = Model.load(data, solver=solver)


### PR DESCRIPTION
This fixes a bug with how keyword arguments are passed between the various load methods. The bug meant that any solver passed to .load() was ignored. This fixes that and adds tests. The keyword argument overrides both the solver settings in the JSON data and PYWR_SOLVER environment variable.

Fixes #1042