### PR TITLE
Update to AnnualCountIndexThresholdRecorder to include a range of days to record

### DIFF
--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -148,6 +148,8 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
     cdef public object include_from_month
     cdef public object include_to_day
     cdef public object include_to_month
+    cdef int _num_years
+    cdef int _ncomb
     cdef double[:, :] _data
     cdef double[:, :] _data_this_year
     cdef int _current_year

--- a/pywr/recorders/_recorders.pxd
+++ b/pywr/recorders/_recorders.pxd
@@ -144,8 +144,10 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
     cdef public list parameters
     cdef public int threshold
     cdef public list exclude_months
-    cdef int _num_years
-    cdef int _ncomb
+    cdef public object include_from_day
+    cdef public object include_from_month
+    cdef public object include_to_day
+    cdef public object include_to_month
     cdef double[:, :] _data
     cdef double[:, :] _data_this_year
     cdef int _current_year

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1994,7 +1994,7 @@ cdef class AnnualCountIndexThresholdRecorder(Recorder):
             include_to = 366
         else:
             include_to = pd.Timestamp(self._current_year, self.include_to_month, self.include_to_day).dayofyear
-        if include_from <= ts.dayofyear <= include_to:
+        if not (include_from <= ts.dayofyear <= include_to):
             return
 
         for scenario_index in self.model.scenarios.combinations:

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1905,8 +1905,8 @@ TimestepCountIndexParameterRecorder.register()
 
 
 cdef class AnnualCountIndexThresholdRecorder(Recorder):
-    """
-    For each scenario, count the number of times a list of parameters exceeds a threshold in each year.
+    """For each scenario, count the number of times a list of parameters exceeds a threshold in each year.
+
     If multiple parameters exceed in one timestep then it is only counted once. The recorder also allows
     for exclusion of months and for the inclusion of a range of dates within a calendar year to which
     the parameter exceedence is counted. Both the exclusion of months and the inclusion of dates can

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1831,17 +1831,17 @@ def test_annual_count_index_threshold_recorder(
 
     # We expect no failures in the first ensemble, the reservoir starts failing halfway through
     # the 3rd year
-    if exclude_months is None and include_range is None:
+    if exclude_months is None and None in include_range:
         expected_data = [[0, 0], [0, 0], [0, 183], [0, 365], [0, 365]]
-    elif isinstance(include_range, list):
+    elif None not in include_range:
         # Ignore counts between the 1st April and 15th Aug inclusive
         assert include_range == [4, 1, 8, 15]
         expected_data = [
             [0, 0],
             [0, 0],
-            [0, 183 + 31 + 15],
-            [0, 365 - 31 - 30 - 31 - 30 - 16],
-            [0, 365 - 31 - 30 - 31 - 30 - 16],
+            [0, 30 + 15],
+            [0, 30 + 31 + 30 + 31 + 15],
+            [0, 30 + 31 + 30 + 31 + 15],
         ]
     else:
         # Ignore counts for Jan, Feb and Dec
@@ -1857,7 +1857,6 @@ def test_annual_count_index_threshold_recorder(
             [0, 365 - 31 - 28 - 31],
             [0, 365 - 31 - 28 - 31],
         ]
-
     assert_allclose(expected_data, rec.data, atol=1e-7)
     df = rec.to_dataframe()
     assert_allclose(expected_data, df.values, atol=1e-7)

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -717,7 +717,10 @@ def test_numpy_parameter_recorder(simple_linear_model):
     model.timestepper.end = pandas.to_datetime("2016-12-31")
     otpt = model.nodes["Output"]
 
-    p = DailyProfileParameter(model, np.arange(366, dtype=np.float64),)
+    p = DailyProfileParameter(
+        model,
+        np.arange(366, dtype=np.float64),
+    )
     p.name = "daily profile"
     model.nodes["Input"].max_flow = p
     otpt.cost = -2.0
@@ -748,7 +751,10 @@ def test_numpy_daily_profile_parameter_recorder(simple_linear_model):
     model.timestepper.end = pandas.to_datetime("2017-12-31")
     otpt = model.nodes["Output"]
 
-    p = DailyProfileParameter(model, np.arange(366, dtype=np.float64),)
+    p = DailyProfileParameter(
+        model,
+        np.arange(366, dtype=np.float64),
+    )
     p.name = "daily profile"
     model.nodes["Input"].max_flow = p
     otpt.cost = -2.0
@@ -1299,7 +1305,15 @@ class TestTablesRecorder:
         with tables.open_file(str(h5file), "w") as h5f:
             nodes = ["Output", "Input", "Sum"]
             where = "/agroup"
-            rec = TablesRecorder(model, h5f, nodes=nodes, parameters=[p,], where=where,)
+            rec = TablesRecorder(
+                model,
+                h5f,
+                nodes=nodes,
+                parameters=[
+                    p,
+                ],
+                where=where,
+            )
 
             model.run()
 
@@ -1904,7 +1918,11 @@ class TestAnnualTotalFlowRecorder:
         assert_allclose([[3650.0 * 3]], df.values)
 
     @pytest.mark.parametrize(
-        "end_date, expected", [("2013-01-04", [30.0, 40.0]), ("2012-12-31", [30.0]),],
+        "end_date, expected",
+        [
+            ("2013-01-04", [30.0, 40.0]),
+            ("2012-12-31", [30.0]),
+        ],
     )
     def test_annual_total_flow_recorder_year_end(
         self, simple_linear_model, end_date, expected
@@ -1971,7 +1989,7 @@ def test_mean_flow_node_recorder(simple_linear_model):
 
 
 def custom_test_func(array, axis=None):
-    return np.sum(array ** 2, axis=axis)
+    return np.sum(array**2, axis=axis)
 
 
 class TestAggregatedRecorder:
@@ -2437,7 +2455,10 @@ class TestEventRecorder:
         elif minimum_length < 4:
             assert len(evt_rec.events) == 1
             assert_equal(
-                [3,], [e.duration for e in evt_rec.events],
+                [
+                    3,
+                ],
+                [e.duration for e in evt_rec.events],
             )
         else:
             assert len(evt_rec.events) == 0
@@ -2588,7 +2609,9 @@ class TestHydroPowerRecorder:
         np.testing.assert_allclose(rec.data[1, 0], 1000 * 9.81 * 8 * 0 * 1e-6)
         np.testing.assert_allclose(rec_total.values()[0], 1000 * 9.81 * 8 * 20 * 1e-6)
 
-    def test_load_from_json(self,):
+    def test_load_from_json(
+        self,
+    ):
         """Test example hydropower model loads and runs."""
         model = load_model("hydropower_example.json")
 


### PR DESCRIPTION
Updates to the recorder add four new arguments to specify start and end dates in a year where an Annual count is to be recorded.