### PR TITLE
feat: Add timestep offset to DataFrameParameter and TablesArrayParameter

### DIFF
--- a/pywr/domains/river.py
+++ b/pywr/domains/river.py
@@ -132,7 +132,6 @@ class RiverSplit(MultiSplitLink):
     """
 
     def __init__(self, model, *args, nsteps=1, **kwargs):
-
         factors = kwargs.pop("factors")
         extra_slots = len(factors) - 1
 

--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -348,7 +348,6 @@ class Storage(Loadable, Drawable, Connectable, _core.Storage, metaclass=NodeMeta
     __parameter_value_attributes__ = ("initial_volume",)
 
     def __init__(self, model, name, outputs=1, inputs=1, *args, **kwargs):
-
         min_volume = pop_kwarg_parameter(kwargs, "min_volume", 0.0)
         if min_volume is None:
             min_volume = 0.0

--- a/pywr/notebook/__init__.py
+++ b/pywr/notebook/__init__.py
@@ -245,7 +245,6 @@ def get_node_attr(node):
     attrs = inspect.getmembers(node, lambda a: not (inspect.isroutine(a)))
     attribute_data = []
     for att in attrs:
-
         attr_name, attr_val = att
         if attr_name.startswith("_"):
             continue
@@ -309,7 +308,6 @@ def pywr_json_to_d3_json(model, attributes=False):
     nodes = []
     node_classes = create_node_class_trees()
     for node in model["nodes"]:
-
         if node["type"].lower() in [
             "annualvirtualstorage",
             "virtualstorage",
@@ -329,7 +327,6 @@ def pywr_json_to_d3_json(model, attributes=False):
         if attributes:
             json_node["attributes"] = []
             for name, val in node.items():
-
                 if name == "type":
                     continue
 

--- a/pywr/notebook/sankey.py
+++ b/pywr/notebook/sankey.py
@@ -24,7 +24,6 @@ def routes_to_sankey_links(
     sources = defaultdict(lambda: defaultdict(lambda: 0.0))
 
     with tables.open_file(filename, mode="r") as h5:
-
         flows = h5.get_node(where, node_name)
 
         # Apply time slice and aggregation

--- a/pywr/optimisation/pygmo.py
+++ b/pywr/optimisation/pygmo.py
@@ -57,7 +57,6 @@ class PygmoWrapper(BaseOptimisationWrapper):
         lower = []
         upper = []
         for var in self.model_variables:
-
             if var.double_size > 0:
                 lower.append(var.get_double_lower_bounds())
                 upper.append(var.get_double_upper_bounds())

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -40,6 +40,7 @@ cdef class DataFrameParameter(Parameter):
     cdef int _scenario_index
     cdef int[:] _scenario_ids
     cdef public object dataframe
+    cdef public int timestep_offset
 
 cdef class ArrayIndexedParameter(Parameter):
     cdef double[:] values
@@ -132,7 +133,7 @@ cdef class TablesArrayParameter(IndexParameter):
     cdef public object h5store
     cdef public object node
     cdef public object where
-
+    cdef public int timestep_offset
     cdef int _scenario_index
     cdef int[:] _scenario_ids
 

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -201,6 +201,8 @@ cdef class DataFrameParameter(Parameter):
     timestep_offset : int (default=0)
         Optional offset to apply to the timestep look-up. This can be used to look forward (positive value) or
         backward (negative value) in the dataset. The offset is applied to dataset after alignment and resampling.
+        If the offset takes the indexing out of the data bounds then the parameter will return the first or last
+        value available.
     """
     def __init__(self, model, dataframe, scenario=None, timestep_offset=0, **kwargs):
         super(DataFrameParameter, self).__init__(model, *kwargs)
@@ -357,6 +359,8 @@ cdef class TablesArrayParameter(IndexParameter):
         timestep_offset : int
             Optional offset to apply to the timestep look-up. This can be used to look forward (positive value) or
             backward (negative value) in the dataset. The offset is applied to dataset after alignment and resampling.
+            If the offset takes the indexing out of the data bounds then the parameter will return the first or last
+            value available.
         """
         super(TablesArrayParameter, self).__init__(model, **kwargs)
 

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -198,11 +198,15 @@ cdef class DataFrameParameter(Parameter):
     model : pywr.model.Model
     dataframe : pandas.DataFrame or pandas.Series
     scenario: pywr._core.Scenario (optional)
+    timestep_offset : int (default=0)
+        Optional offset to apply to the timestep look-up. This can be used to look forward (positive value) or
+        backward (negative value) in the dataset. The offset is applied to dataset after alignment and resampling.
     """
-    def __init__(self, model, dataframe, scenario=None, **kwargs):
+    def __init__(self, model, dataframe, scenario=None, timestep_offset=0, **kwargs):
         super(DataFrameParameter, self).__init__(model, *kwargs)
         self.dataframe = dataframe
         self.scenario = scenario
+        self.timestep_offset = timestep_offset
 
     cpdef setup(self):
         cdef Py_ssize_t i
@@ -252,7 +256,7 @@ cdef class DataFrameParameter(Parameter):
 
     cpdef double value(self, Timestep timestep, ScenarioIndex scenario_index) except? -1:
         cdef double value
-        cdef Py_ssize_t i = timestep.index
+        cdef Py_ssize_t i = min(max(timestep.index + self.timestep_offset, 0), self._values.shape[0] - 1)
         cdef Py_ssize_t j
 
         if self.scenario is not None:
@@ -331,7 +335,7 @@ ArrayIndexedScenarioParameter.register()
 
 
 cdef class TablesArrayParameter(IndexParameter):
-    def __init__(self, model, h5file, node, where='/', scenario=None, **kwargs):
+    def __init__(self, model, h5file, node, where='/', scenario=None, timestep_offset=0, **kwargs):
         """
         This Parameter reads array data from a PyTables HDF database.
 
@@ -350,6 +354,9 @@ cdef class TablesArrayParameter(IndexParameter):
             Path to read the node from.
         scenario : Scenario
             Scenario to use as the second index in the array.
+        timestep_offset : int
+            Optional offset to apply to the timestep look-up. This can be used to look forward (positive value) or
+            backward (negative value) in the dataset. The offset is applied to dataset after alignment and resampling.
         """
         super(TablesArrayParameter, self).__init__(model, **kwargs)
 
@@ -358,6 +365,7 @@ cdef class TablesArrayParameter(IndexParameter):
         self.node = node
         self.where = where
         self.scenario = scenario
+        self.timestep_offset = timestep_offset
 
         # Private attributes, initialised during setup()
         self._values_dbl = None  # Stores the loaded data if float
@@ -446,10 +454,12 @@ cdef class TablesArrayParameter(IndexParameter):
                 self._values_int = node.read().astype(np.int32)
 
     cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef Py_ssize_t i = ts.index
+        cdef Py_ssize_t i
         cdef Py_ssize_t j
         if self._values_dbl is None:
             return float(self.index(ts, scenario_index))
+
+        i = min(max(ts.index + self.timestep_offset, 0), self._values_dbl.shape[0] - 1)
         # Support 1D and 2D indexing when scenario is or is not given.
         if self._scenario_index == -1:
             return self._values_dbl[i, 0]
@@ -460,10 +470,12 @@ cdef class TablesArrayParameter(IndexParameter):
             return self._values_dbl[i, j]
 
     cpdef int index(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
-        cdef Py_ssize_t i = ts.index
+        cdef Py_ssize_t i
         cdef Py_ssize_t j
         if self._values_int is None:
             return int(self.value(ts, scenario_index))
+
+        i = min(max(ts.index + self.timestep_offset, 0), self._values_int.shape[0] - 1)
         # Support 1D and 2D indexing when scenario is or is not given.
         if self._scenario_index == -1:
             return self._values_int[i, 0]

--- a/pywr/profiler.py
+++ b/pywr/profiler.py
@@ -50,7 +50,6 @@ class Profiler:
         self._last_max_rss = memory_usage()
 
     def checkpoint(self, phase: str, class_name: str, name: str):
-
         max_rss = memory_usage()
         perf_counter = time.perf_counter()
 

--- a/pywr/recorders/recorders.py
+++ b/pywr/recorders/recorders.py
@@ -407,7 +407,6 @@ class TablesRecorder(Recorder):
         else:
             nodes = []
             for n in self.nodes:
-
                 try:
                     where, node = n
                 except (TypeError, ValueError):

--- a/tests/test_activation_parameters.py
+++ b/tests/test_activation_parameters.py
@@ -70,7 +70,6 @@ class TestBinaryStepParameter:
         ],
     )
     def test_bounds(self, simple_linear_model, lb, ub):
-
         m = simple_linear_model
 
         data = {
@@ -151,7 +150,6 @@ class TestRectifierParameter:
         ],
     )
     def test_bounds(self, simple_linear_model, lb, ub):
-
         m = simple_linear_model
 
         data = {
@@ -225,7 +223,6 @@ class TestLogisticParameter:
         ],
     )
     def test_bounds(self, simple_linear_model, lb, ub):
-
         m = simple_linear_model
 
         data = {

--- a/tests/test_agg_constraints.py
+++ b/tests/test_agg_constraints.py
@@ -334,7 +334,6 @@ def test_multipiecewise_constraint(model, flow):
                                                                               been implemented for glpk solvers",
 )
 def test_dynamic_factors(model):
-
     model.timestepper.end = Timestamp("2016-01-03")
 
     A = Input(model, "A", max_flow=10.0)
@@ -379,7 +378,6 @@ def test_dynamic_factors(model):
                                                                               been implemented for glpk solvers",
 )
 def test_dynamic_factors_load(model):
-
     model.timestepper.end = Timestamp("2016-01-03")
 
     A = Input(model, "A", max_flow=10.0)

--- a/tests/test_df_resampling.py
+++ b/tests/test_df_resampling.py
@@ -200,7 +200,6 @@ class TestUpSampling:
         pd.testing.assert_frame_equal(input_resampled, expected_df)
 
     def test_annual_to_daily(self):
-
         input_df = make_df("A", "2010-01-01", "2020-01-01")
         model_index = make_model_index("D", "2010-01-01", "2020-01-01")
 
@@ -213,7 +212,6 @@ class TestUpSampling:
         pd.testing.assert_frame_equal(input_resampled, expected_df)
 
     def test_annual_to_monthly(self):
-
         input_df = make_df("A", "2010-01-01", "2020-01-01")
         model_index = make_model_index("M", "2010-01-01", "2020-01-01")
 

--- a/tests/test_multi_models.py
+++ b/tests/test_multi_models.py
@@ -24,7 +24,6 @@ from pywr.recorders import (
 
 
 def make_simple_model(num: int) -> Model:
-
     m = Model()
     inpt = Input(m, name=f"input-{num}", max_flow=5 + num)
     lnk = Link(m, name=f"link-{num}")
@@ -36,7 +35,6 @@ def make_simple_model(num: int) -> Model:
 
 
 def test_run_two_independent_models():
-
     multi_model = MultiModel()
 
     for i in range(2):
@@ -54,7 +52,6 @@ def test_run_two_independent_models():
 
 
 def test_setup_profile_two_independent_models(tmp_path):
-
     multi_model = MultiModel()
 
     for i in range(2):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -468,7 +468,6 @@ def test_daily_profile_leap_day(model):
 
 class TestScenarioDailyProfileParameter:
     def test_scenario_daily_profile(self, simple_linear_model):
-
         model = simple_linear_model
         scenario = Scenario(model, "A", 2)
         values = np.array(
@@ -509,7 +508,6 @@ class TestScenarioDailyProfileParameter:
 
 
 def test_scenario_weekly_profile(simple_linear_model):
-
     model = simple_linear_model
     scenario = Scenario(model, "A", 2)
 
@@ -557,7 +555,6 @@ class TestAnnualHarmonicSeriesParameter:
     """Tests for `AnnualHarmonicSeriesParameter`"""
 
     def test_single_harmonic(self, model):
-
         p1 = AnnualHarmonicSeriesParameter(model, 0.5, [0.25], [np.pi / 4])
         si = ScenarioIndex(0, np.array([0], dtype=np.int32))
 
@@ -583,7 +580,6 @@ class TestAnnualHarmonicSeriesParameter:
             np.testing.assert_allclose(p1.value(ts, si), expected)
 
     def test_load(self, model):
-
         data = {
             "type": "annualharmonicseries",
             "mean": 0.5,
@@ -787,7 +783,6 @@ class TestAggregatedIndexParameter:
 
 
 def test_parameter_child_variables(model):
-
     p1 = Parameter(model)
     # Default parameter
     assert len(p1.parents) == 0
@@ -953,7 +948,6 @@ def test_parameter_df_subsample():
 
 
 def test_parameter_df_json_load(model, tmpdir):
-
     # Daily time-step
     index = pd.date_range("2015-01-01", periods=365, freq="D", name="date")
     df = pd.DataFrame(np.random.rand(365), index=index, columns=["data"])
@@ -972,7 +966,6 @@ def test_parameter_df_json_load(model, tmpdir):
 
 
 def test_parameter_df_embed_load(model):
-
     # Daily time-step
     index = pd.date_range("2015-01-01", periods=365, freq="D", name="date")
     df = pd.DataFrame(np.random.rand(365), index=index, columns=["data"])
@@ -991,6 +984,32 @@ def test_parameter_df_embed_load(model):
 
     p = load_parameter(model, data)
     p.setup()
+
+
+@pytest.mark.parametrize("timestep_offset", [0, 1, -1, 2])
+def test_df_timestep_offset(timestep_offset):
+    """Check `timestep_offset` works as expected for `DataFrameParameter`"""
+    model = load_model("timeseries1.json")
+
+    # check first day initalised
+    assert model.timestepper.start == datetime.datetime(2015, 1, 1)
+
+    # check results
+    demand1 = model.nodes["demand1"]
+    catchment1 = model.nodes["catchment1"]
+    # Modify the timestep offset
+    catchment1.max_flow.timestep_offset = timestep_offset
+
+    expected_array = [23.92, 22.14, 22.57, 24.97, 27.59]
+    if timestep_offset > 0:
+        expected_array = expected_array[timestep_offset:]
+    elif timestep_offset < 0:
+        expected_array = [23.92] * abs(timestep_offset) + expected_array
+
+    for expected in expected_array:
+        result = model.step()
+        assert_allclose(catchment1.flow, expected, atol=1e-7)
+        assert_allclose(demand1.flow, min(expected, 23.0), atol=1e-7)
 
 
 def test_simple_json_parameter_reference():
@@ -1217,7 +1236,6 @@ class Test1DPolynomialParameter:
         # Test with proportional storage
         @assert_rec(model, p2, name="proportionalassertion")
         def expected_func(timestep, scenario_index):
-
             return 0.5 + np.pi * x / stg.max_volume
 
         model.setup()
@@ -1716,7 +1734,6 @@ class TestThresholdParameters:
         model.run()
 
     def test_multiple_threshold_index_parameter(self, simple_linear_model):
-
         model = simple_linear_model
         model.nodes["Input"].max_flow = ArrayIndexedParameter(model, np.arange(0, 20))
         model.nodes["Output"].cost = -10.0
@@ -1746,7 +1763,6 @@ class TestThresholdParameters:
         model.run()
 
     def test_multiple_threshold_parameter_index_parameter(self, simple_linear_model):
-
         model = simple_linear_model
         model.nodes["Input"].max_flow = ArrayIndexedParameter(
             model, np.arange(0, 20), name="max_flow"

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -685,7 +685,6 @@ def test_numpy_array_level_recorder(simple_storage_model):
 
 
 def test_numpy_array_area_recorder(simple_storage_model):
-
     model = simple_storage_model
 
     storage = model.nodes["Storage"]
@@ -903,7 +902,6 @@ class TestTotalParameterRecorder:
 
     @pytest.mark.parametrize("integrate", [None, True, False])
     def test_from_json(self, daily_profile_model, integrate):
-
         model = daily_profile_model
 
         data = {
@@ -938,7 +936,6 @@ class TestMeanParameterRecorder:
         assert_allclose(rec.values(), expected)
 
     def test_from_json(self, daily_profile_model):
-
         model = daily_profile_model
 
         data = {
@@ -1337,7 +1334,6 @@ class TestTablesRecorder:
         import tables
 
         with tables.open_file(str(h5file), "w") as h5f:
-
             nodes = [
                 ("/outputs/demand", "Demand"),
                 ("/storage/reservoir", "Reservoir"),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -104,7 +104,6 @@ def test_run_reservoir2():
 
 
 def test_empty_storage_min_flow():
-
     model = Model()
     storage = Storage(
         model, "storage", initial_volume=100, max_volume=100, inputs=1, outputs=0
@@ -678,7 +677,6 @@ def test_annual_virtual_storage_with_aggregated_node():
 
 class TestSeasonalVirtualStorage:
     def test_run(self):
-
         model = load_model("seasonal_virtual_storage.json")
         model.run()
         supply_df = model.recorders["supply1"].to_dataframe()

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -211,7 +211,6 @@ def test_scenarios_from_json(json_file):
 
 
 def test_timeseries_with_scenarios():
-
     model = load_model("timeseries2.json")
 
     model.setup()


### PR DESCRIPTION
This adds a new feature to allow offsetting the timeseries provided by DataFrameParameter and TablesArrayParameter. This would allow the user to look-up future or past values if required.

Some minor black formatting updates too.