### PR TITLE
feat: Add RollingMeanFlowNodeParameter

### DIFF
--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -164,5 +164,4 @@ Other parameters
    FlowDelayParameter
    StorageParameter
    DiscountFactorParameter
-
-
+   RollingMeanFlowNodeParameter

--- a/pywr/parameters/_parameters.pxd
+++ b/pywr/parameters/_parameters.pxd
@@ -227,3 +227,12 @@ cdef class FlowDelayParameter(Parameter):
 cdef class DiscountFactorParameter(Parameter):
     cdef public double rate
     cdef public int base_year
+
+
+cdef class RollingMeanFlowNodeParameter(Parameter):
+    cdef int position
+    cdef public int timesteps
+    cdef public int days
+    cdef public double initial_flow
+    cdef public AbstractNode node
+    cdef double[:, :] _memory

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -2161,6 +2161,88 @@ cdef class DiscountFactorParameter(Parameter):
 DiscountFactorParameter.register()
 
 
+cdef class RollingMeanFlowNodeParameter(Parameter):
+    """Returns the mean flow of a Node for the previous N timesteps.
+
+    Parameters
+    ----------
+    model : `pywr.core.Model`
+    node : `pywr.core.Node`
+        The node to record
+    timesteps : int
+        The number of timesteps to calculate the mean flow for
+    name : str (optional)
+        The name of the recorder
+    initial_flow : float
+        The initial value to use in the first timestep before any flows have been recorded.
+    """
+    def __init__(self, model, node, timesteps=None, days=None, initial_flow=0.0, **kwargs):
+        super(RollingMeanFlowNodeParameter, self).__init__(model, **kwargs)
+        self.node = node
+        self.initial_flow = initial_flow
+
+        if not timesteps and not days:
+            raise ValueError("Either `timesteps` or `days` must be specified.")
+        if timesteps:
+            self.timesteps = int(timesteps)
+        else:
+            self.timesteps = 0
+        if days:
+            self.days = int(days)
+        else:
+            self.days = 0
+        self._memory = None
+        self.position = 0
+
+    cpdef setup(self):
+        super(RollingMeanFlowNodeParameter, self).setup()
+        if self.days > 0:
+            try:
+                self.timesteps = self.days // self.model.timestepper.delta
+            except TypeError:
+                raise TypeError('A rolling window defined as a number of days is only valid with daily time-steps.')
+        if self.timesteps == 0:
+            raise ValueError("Timesteps property of MeanFlowRecorder is less than 1.")
+        self._memory = np.zeros([len(self.model.scenarios.combinations), self.timesteps])
+
+    cpdef reset(self):
+        super(RollingMeanFlowNodeParameter, self).reset()
+        self.position = 0
+        self._memory[:] = 0.0
+
+    cpdef double value(self, Timestep ts, ScenarioIndex scenario_index) except? -1:
+
+        cdef int n
+        # No data in memory yet
+        if ts.index == 0:
+            return self.initial_flow
+
+        # Calculate the mean flow from the memory
+        if ts.index <= self.timesteps:
+            n = ts.index
+        else:
+            n = self.timesteps
+        return np.mean(self._memory[scenario_index.global_id, :n])
+
+    cpdef after(self):
+        cdef int i
+        # save today's flow (NB - this won't change the parameter until tomorrow)
+        for i in range(0, self._memory.shape[0]):
+            self._memory[i, self.position] = self.node._flow[i]
+
+        # prepare for the next timestep
+        self.position += 1
+        if self.position >= self.timesteps:
+            self.position = 0
+
+    @classmethod
+    def load(cls, model, data):
+        node = model.nodes[data.pop("node")]
+        return cls(model, node, **data)
+
+RollingMeanFlowNodeParameter.register()
+
+
 def get_parameter_from_registry(parameter_type):
     key = parameter_type.lower()
     try:

--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -2162,17 +2162,20 @@ DiscountFactorParameter.register()
 
 
 cdef class RollingMeanFlowNodeParameter(Parameter):
-    """Returns the mean flow of a Node for the previous N timesteps.
+    """Returns the mean flow of a Node for the previous N timesteps or days.
 
     Parameters
     ----------
     model : `pywr.core.Model`
     node : `pywr.core.Node`
         The node to record
-    timesteps : int
-        The number of timesteps to calculate the mean flow for
+    timesteps : int (optional)
+        The number of timesteps to calculate the mean flow for. If `days` is provided then timesteps is ignored.
+    days : int (optional)
+        The number of days to calculate the mean flow for. This is converted into a number of timesteps
+        internally provided the timestep is a number of days.
     name : str (optional)
-        The name of the recorder
+        The name of the parameter
     initial_flow : float
         The initial value to use in the first timestep before any flows have been recorded.
     """
@@ -2202,7 +2205,7 @@ cdef class RollingMeanFlowNodeParameter(Parameter):
             except TypeError:
                 raise TypeError('A rolling window defined as a number of days is only valid with daily time-steps.')
         if self.timesteps == 0:
-            raise ValueError("Timesteps property of MeanFlowRecorder is less than 1.")
+            raise ValueError("Timesteps is less than 1.")
         self._memory = np.zeros([len(self.model.scenarios.combinations), self.timesteps])
 
     cpdef reset(self):

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -41,6 +41,7 @@ from ._parameters import (
     OffsetParameter,
     RbfProfileParameter,
     UniformDrawdownProfileParameter,
+    RollingMeanFlowNodeParameter,
     load_parameter,
     load_parameter_values,
     load_dataframe,

--- a/pywr/recorders/_recorders.pyx
+++ b/pywr/recorders/_recorders.pyx
@@ -1635,8 +1635,15 @@ cdef class RollingMeanFlowNodeRecorder(NodeRecorder):
     name : str (optional)
         The name of the recorder
 
+    See also
+    --------
+    RollingMeanFlowNodeParameter
     """
     def __init__(self, model, node, timesteps=None, days=None, name=None, **kwargs):
+        warnings.warn("`RollingMeanFlowNodeRecorder` has been deprecated in favour of `RollingMeanFlowNodeParameter`."
+                      " If you need to record the value use a recorder capable of recording an arbitrary parameter"
+                      " (e.g. `NumpyArrayParameterRecorder`)", DeprecationWarning, stacklevel=2)
+
         super(RollingMeanFlowNodeRecorder, self).__init__(model, node, name=name, **kwargs)
         self.model = model
         if not timesteps and not days:
@@ -1650,6 +1657,7 @@ cdef class RollingMeanFlowNodeRecorder(NodeRecorder):
         else:
             self.days = 0
         self._data = None
+        self._memory = None
         self.position = 0
 
     cpdef setup(self):

--- a/pywr/recorders/recorders.py
+++ b/pywr/recorders/recorders.py
@@ -89,6 +89,7 @@ class AssertionRecorder(Recorder):
                 value = self._parameter.get_index(scenario_index)
             else:
                 value = self._parameter.get_value(scenario_index)
+
             try:
                 np.testing.assert_allclose(value, expected_value)
             except AssertionError:

--- a/tests/models/mean_flow_parameter.json
+++ b/tests/models/mean_flow_parameter.json
@@ -1,0 +1,73 @@
+{
+    "metadata": {
+        "title": "Mean flow parameter",
+        "description": "A test of the mean flow parameter",
+        "minimum_version": "0.1"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-01-04",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 15,
+            "cost": 1
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 10,
+            "cost": -10
+        },
+        {
+          "name": "supply2",
+          "type": "Input",
+          "max_flow": 100,
+          "cost": 0
+        },
+        {
+            "name": "demand_with_threshold",
+            "type": "Output",
+            "max_flow": {
+                "type": "parameterthreshold",
+                "parameter": "mean-flow",
+                "threshold": 2.5,
+                "values": [60.0, 50.0],
+                "predicate": "LT"
+            },
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "demand1"],
+        ["supply2", "demand_with_threshold"]
+    ],
+    "parameters": {
+        "mean-flow": {
+            "comment": "Mean flow (last 3 days) from supply1",
+            "type": "rollingMeanFlownode",
+            "node": "supply1",
+            "timesteps": 3
+        }
+
+    },
+    "recorders": {
+        "Supply": {
+            "comment": "Actual flow from supply1",
+            "type": "NumpyArrayNode",
+            "node": "supply1"
+        },
+        "Mean Flow": {
+            "comment": "Mean flow (last 3 days) from supply1",
+            "type": "NumpyArrayParameter",
+            "parameter": "mean-flow"
+        },
+        "Supply 2": {
+            "type": "NumpyArrayNode",
+            "node": "supply2"
+        }
+    }
+}

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -42,7 +42,7 @@ from pywr.parameters import (
     load_parameter,
     InterpolatedFlowParameter,
     ScenarioDailyProfileParameter,
-    RollingMeanFlowNodeParameter
+    RollingMeanFlowNodeParameter,
 )
 from pywr.recorders import AssertionRecorder, assert_rec
 from pywr.model import OrphanedParameterWarning
@@ -2263,10 +2263,10 @@ class TestDiscountFactorParameter:
 
 class TestRollingMeanFlowNodeParameter:
     @pytest.mark.parametrize(
-        "initial_flow", [0.0, 2.0],
+        "initial_flow",
+        [0.0, 2.0],
     )
     def test_mean_flow_recorder(self, model, initial_flow):
-
         model.timestepper.start = pd.to_datetime("2016-01-01")
         model.timestepper.end = pd.to_datetime("2016-01-04")
 
@@ -2274,7 +2274,9 @@ class TestRollingMeanFlowNodeParameter:
         otpt = Output(model, "output")
         inpt.connect(otpt)
 
-        p_mean = RollingMeanFlowNodeParameter(model, node=inpt, timesteps=3, initial_flow=initial_flow)
+        p_mean = RollingMeanFlowNodeParameter(
+            model, node=inpt, timesteps=3, initial_flow=initial_flow
+        )
 
         _scenario = Scenario(model, "dummy", size=2)
 
@@ -2289,6 +2291,7 @@ class TestRollingMeanFlowNodeParameter:
             (2.0 + 3.0 + 4.0) / 3,
             (3.0 + 4.0 + 5.0) / 3,  # zeroth day forgotten
         ]
+
         @assert_rec(model, p_mean)
         def expected_func(timestep, scenario_index):
             return expected[timestep.index]

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -42,6 +42,7 @@ from pywr.parameters import (
     load_parameter,
     InterpolatedFlowParameter,
     ScenarioDailyProfileParameter,
+    RollingMeanFlowNodeParameter
 )
 from pywr.recorders import AssertionRecorder, assert_rec
 from pywr.model import OrphanedParameterWarning
@@ -2258,3 +2259,70 @@ class TestDiscountFactorParameter:
             return 1 / pow(1.035, year - 2015)
 
         model.run()
+
+
+class TestRollingMeanFlowNodeParameter:
+    @pytest.mark.parametrize(
+        "initial_flow", [0.0, 2.0],
+    )
+    def test_mean_flow_recorder(self, model, initial_flow):
+
+        model.timestepper.start = pd.to_datetime("2016-01-01")
+        model.timestepper.end = pd.to_datetime("2016-01-04")
+
+        inpt = Input(model, "input")
+        otpt = Output(model, "output")
+        inpt.connect(otpt)
+
+        p_mean = RollingMeanFlowNodeParameter(model, node=inpt, timesteps=3, initial_flow=initial_flow)
+
+        _scenario = Scenario(model, "dummy", size=2)
+
+        inpt.max_flow = inpt.min_flow = FunctionParameter(
+            model, inpt, lambda model, t, si: 2 + t.index
+        )
+
+        expected = [
+            initial_flow,
+            2.0,
+            (2.0 + 3.0) / 2,
+            (2.0 + 3.0 + 4.0) / 3,
+            (3.0 + 4.0 + 5.0) / 3,  # zeroth day forgotten
+        ]
+        @assert_rec(model, p_mean)
+        def expected_func(timestep, scenario_index):
+            return expected[timestep.index]
+
+        model.run()
+
+    def test_mean_flow_recorder_days(self, model):
+        model.timestepper.delta = 7
+
+        inpt = Input(model, "input")
+        otpt = Output(model, "output")
+        inpt.connect(otpt)
+
+        p_mean = RollingMeanFlowNodeParameter(model, node=inpt, days=31)
+
+        model.run()
+        assert p_mean.timesteps == 4
+
+    def test_mean_flow_recorder_json(self, model):
+        model = load_model("mean_flow_parameter.json")
+
+        supply1 = model.nodes["supply1"]
+        supply1.max_flow = supply1.min_flow = FunctionParameter(
+            model, supply1, lambda model, t, si: 2 + t.index
+        )
+
+        assert len(model.recorders) == 3
+
+        rec_flow = model.recorders["Supply"]
+        rec_mean = model.recorders["Mean Flow"]
+        rec_check = model.recorders["Supply 2"]
+
+        model.run()
+
+        assert_allclose(rec_flow.data[:, 0], [2.0, 3.0, 4.0, 5.0])
+        assert_allclose(rec_mean.data[:, 0], [0.0, 2.0, 2.5, 3.0])
+        assert_allclose(rec_check.data[:, 0], [50.0, 50.0, 60.0, 60.0])


### PR DESCRIPTION
Add a new parameter that computes the rolling mean flow of the previous N timesteps. This is the parameter equivalent of `RollingMeanFlowNodeRecorder`. This recorder has been marked as deprecated. Users should prefer this new parameter to the older recorder.