### PR TITLE
feat: Add metadata to TablesRecorder arrays.

### DIFF
--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1113,13 +1113,15 @@ class TestTablesRecorder:
         import tables
 
         with tables.open_file(str(h5file), "w") as h5f:
-            rec = TablesRecorder(model, h5f)
+            _rec = TablesRecorder(model, h5f)
 
             model.run()
 
             for node_name in model.nodes.keys():
                 ca = h5f.get_node("/", node_name)
                 assert ca.shape == (365, 1)
+                assert ca._v_attrs['pywr-attribute'] == 'flow'
+                assert 'pywr-type' in ca._v_attrs
                 if node_name == "Sum":
                     np.testing.assert_allclose(ca, 20.0)
                 else:

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1120,8 +1120,8 @@ class TestTablesRecorder:
             for node_name in model.nodes.keys():
                 ca = h5f.get_node("/", node_name)
                 assert ca.shape == (365, 1)
-                assert ca._v_attrs['pywr-attribute'] == 'flow'
-                assert 'pywr-type' in ca._v_attrs
+                assert ca._v_attrs["pywr-attribute"] == "flow"
+                assert "pywr-type" in ca._v_attrs
                 if node_name == "Sum":
                     np.testing.assert_allclose(ca, 20.0)
                 else:


### PR DESCRIPTION
Add metadata to the CArray nodes created in the HDF5 file by TablesRecorder. Metadata saves the type of attribute and the class name of the source of the data.