### PR TITLE
fix: Add pywr.parameter imports from control_curves module.

### DIFF
--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -66,6 +66,14 @@ from ._activation_functions import (
     RectifierParameter,
     LogisticParameter,
 )  # noqa
+from .control_curves import (
+    ControlCurveParameter,
+    BaseControlCurveParameter,
+    ControlCurveInterpolatedParameter,
+    ControlCurveIndexParameter,
+    ControlCurvePiecewiseInterpolatedParameter,
+    WeightedAverageProfileParameter,
+)
 from . import multi_model_parameters
 import numpy as np
 from scipy.interpolate import interp1d


### PR DESCRIPTION
This makes control curve parameters accessible from pywr.parameters much like the other parameters.