### PR TITLE
fix: Overload get_xxx_flow for PiecewiseLink.

### DIFF
--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -818,6 +818,12 @@ class PiecewiseLink(Node):
         if max_flows is not None:
             self.max_flows = max_flows
 
+    def get_min_flow(self, si):
+        return sum([sl.get_min_flow(si) for sl in self.sublinks])
+
+    def get_max_flow(self, si):
+        return sum([sl.get_max_flow(si) for sl in self.sublinks])
+
     def costs():
         def fget(self):
             return [sl.cost for sl in self.sublinks]


### PR DESCRIPTION
This fix allows PiecewiseLink to return the sum of its sublinks min and max flows. While the solver won't use these methods because the outer node is not added to the LP it does allow recorders to get the total min and max flows for the entire node.

Test implemented for deficit recorder.

Fixes #1087.