### PR TITLE
chore: Pin Cython<3 until support is resolved.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython", "numpy"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython<3", "numpy"]
 
 # enable version inference
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
-        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
+        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython<3", "numpy"],
         install_requires=[
             "pandas",
             "networkx",


### PR DESCRIPTION
Cython v3 was released a couple of days ago. There are some build and runtime issues caused by the update. These will need resolving. In the meanwhile pin to the older version so we can keep releasing. 