### PR TITLE
chore: Support Cython 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython<3", "numpy"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython", "numpy"]
 
 # enable version inference
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython", "numpy"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cython>=3", "numpy"]
 
 # enable version inference
 [tool.setuptools_scm]

--- a/pywr/parameters/_polynomial.pyx
+++ b/pywr/parameters/_polynomial.pyx
@@ -64,7 +64,7 @@ cdef class Polynomial1DParameter(Parameter):
 
         # Get the 'x' value to put in the polynomial
         if self._parameter is not None:
-            x = self._parameter.__values[scenario_index.global_id]
+            x = self._parameter._Parameter__values[scenario_index.global_id]
         elif self._storage_node is not None:
             if self.use_proportional_volume:
                 x = self._storage_node.get_current_pc(scenario_index)
@@ -155,7 +155,7 @@ cdef class Polynomial2DStorageParameter(Parameter):
         else:
             x = self._storage_node._volume[scenario_index.global_id]
         # Parameter value is 2nd dimension
-        y = self._parameter.__values[scenario_index.global_id]
+        y = self._parameter._Parameter__values[scenario_index.global_id]
 
         # Apply scaling and offset
         x = self.storage_scale*x + self.storage_offset

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
-        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
+        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython>=3", "numpy"],
         install_requires=[
             "pandas",
             "networkx",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def setup_package():
         author="Joshua Arnott",
         author_email="josh@snorfalorpagus.net",
         url="https://github.com/pywr/pywr",
-        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython<3", "numpy"],
+        setup_requires=["setuptools>=18.0", "setuptools_scm", "cython", "numpy"],
         install_requires=[
             "pandas",
             "networkx",


### PR DESCRIPTION
Several updates required to handle building with Cython 3.x.

- Include `noexcept` for GLPK callback functions.
- Handle name mangling of attributes using __. Cython 3 aligns more closely with Python 3 in this respect.

There should be a review of the use of `except` given the new behaviour in Cython 3, but that is not done here.