### PR TITLE
feat: Fallback to loading from values or tables.

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -2291,8 +2291,8 @@ def load_parameter(model, data, parameter_name=None):
         try:
              parameter_type = data['type']
         except KeyError:
-            #raise custom exception that makes the error a bit easier to interpret
-            raise TypeNotFoundError(data)
+            # Not a parameter, try to load values
+            return float(load_parameter_values(model, data))
 
         try:
             parameter_name = data["name"]

--- a/tests/models/loss_link_table.csv
+++ b/tests/models/loss_link_table.csv
@@ -1,0 +1,2 @@
+node,loss_factor
+link1,0.2

--- a/tests/models/loss_link_table.json
+++ b/tests/models/loss_link_table.json
@@ -1,0 +1,60 @@
+{
+    "metadata": {
+        "title": "Simple 1",
+        "description": "A very simple example with a loss link which reads loss_factor from a table.",
+        "minimum_version": "1.11.0"
+    },
+    "timestepper": {
+        "start": "2015-01-01",
+        "end": "2015-12-31",
+        "timestep": 1
+    },
+    "nodes": [
+        {
+            "name": "supply1",
+            "type": "Input",
+            "max_flow": 100,
+            "cost": 0.1
+        },
+        {
+            "name": "link1",
+            "type": "LossLink",
+            "max_flow": 10,
+            "loss_factor": {
+                "table": "loss_factors",
+                "index": "link1"
+            }
+        },
+        {
+            "name": "demand1",
+            "type": "Output",
+            "max_flow": 20,
+            "cost": -10
+        }
+    ],
+    "edges": [
+        ["supply1", "link1"],
+        ["link1", "demand1"]
+    ],
+    "tables": {
+        "loss_factors": {
+            "url": "loss_link_table.csv",
+            "index_col": 0,
+            "header": 0
+        }
+    },
+    "recorders": {
+        "supply1": {
+            "type": "numpyarraynoderecorder",
+            "node": "supply1"
+        },
+        "link1": {
+            "type": "numpyarraynoderecorder",
+            "node": "link1"
+        },
+        "demand1": {
+            "type": "numpyarraynoderecorder",
+            "node": "demand1"
+        }
+    }
+}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1012,6 +1012,27 @@ def test_loss_link_node(loss_factor, loss_factor_type):
     assert_allclose(demand1.flow, expected_demand)
 
 
+def test_loss_link_node_table():
+    """Test LossLink node with a table for `loss_factor`."""
+    model = load_model("loss_link_table.json")
+
+    supply1 = model.nodes["supply1"]
+    link1 = model.nodes["link1"]
+    demand1 = model.nodes["demand1"]
+
+    model.check()
+    model.run()
+
+    expected_supply = 10 * (1 + 0.2)
+    expected_demand = 10
+
+    # Supply must provide 20% more flow because of the loss in link1
+    assert_allclose(supply1.flow, expected_supply)
+    # link1 records the net flow after losses
+    assert_allclose(link1.flow, expected_demand)
+    assert_allclose(demand1.flow, expected_demand)
+
+
 def test_loss_link_node_loss_factor_parameter():
     """Test LossLink node with a parameter for `loss_factor`."""
     model = load_model("loss_link_parameter.json")


### PR DESCRIPTION
Try to load parameter as values (i.e. from a table or values entry) if there is no "type" entry. This should allow more flexible definitions of models where tabular data can be used where a parameter is required. Previously only a literal constant or Parameter definition were allowed.