### PR TITLE
Replace interp1d in interpolation parameters

### DIFF
--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -191,8 +191,7 @@ class AbstractInterpolatedParameter(Parameter):
         the default behaviour of the interpolating instance
         """
         v = self._value_to_interpolate(ts, scenario_index)
-        val = self.interp(v)
-        return val
+        return self.interp(v)
 
 
 class InterpolatedParameter(AbstractInterpolatedParameter):

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -76,7 +76,7 @@ from .control_curves import (
 )
 from . import multi_model_parameters
 import numpy as np
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 from scipy.integrate import quad
 import pandas
 
@@ -131,24 +131,68 @@ class AbstractInterpolatedParameter(Parameter):
     def _value_to_interpolate(self, ts, scenario_index):
         raise NotImplementedError()
 
-    @property
-    def interp_kwargs(self):
-        return self._interp_kwargs
-
-    @interp_kwargs.setter
-    def interp_kwargs(self, data):
-        if "fill_value" in data and isinstance(data["fill_value"], list):
-            # SciPy's interp1d expects a tuple when defining fill values for the upper and lower bounds
-            data["fill_value"] = tuple(data["fill_value"])
-        self._interp_kwargs = data
-
     def setup(self):
         super(AbstractInterpolatedParameter, self).setup()
-        self.interp = interp1d(self.x, self.y, **self.interp_kwargs)
 
-    def value(self, ts, scenario_index):
+        degree = self._select_degree(self.interp_kwargs["kind"])
+        self.interp = make_interp_spline(self.x, self.y, degree)
+
+        AbstractInterpolatedParameter.value = self._unchecked_value
+        if "fill_value" in self.interp_kwargs:
+            # Return fill values for out of bounds args
+            self.fill_value = self.interp_kwargs["fill_value"]
+            AbstractInterpolatedParameter.value = self._filled_value
+
+        if self.interp_kwargs.get("bounds_error"):
+            # Raise ValueError on out of bounds values
+            AbstractInterpolatedParameter.value = self._checked_value
+
+    def _select_degree(self, degree_name):
+        degree_name_map = {
+            "constant": 0,
+            "linear": 1,
+            "quadratic": 2,
+            "cubic": 3
+        }
+
+        degree = degree_name_map.get(degree_name, None)
+        if not degree:
+            raise ValueError(f"Invalid degree type '{degree_name}' "
+                             f"for parameter {self.__class__.__qualname__}")
+
+        return degree
+
+    def _checked_value(self, ts, scenario_index):
+        """
+        Raises ValueError on argument outside of interpolated range
+        """
         v = self._value_to_interpolate(ts, scenario_index)
-        return self.interp(v)
+        if v < self.x[0] or v > self.x[-1]:
+            raise ValueError(f"Value {v} falls outside of interpolation bounds")
+
+        return self._unchecked_value(ts, scenario_index)
+
+    def _filled_value(self, ts, scenario_index):
+        """
+        Returns specified values for arguments outside of interpolated range
+        """
+        v = self._value_to_interpolate(ts, scenario_index)
+        if v < self.x[0]:
+            return self.fill_value[0]
+
+        if v > self.x[-1]:
+            return self.fill_value[-1]
+
+        return self._unchecked_value(ts, scenario_index)
+
+    def _unchecked_value(self, ts, scenario_index):
+        """
+        Arguments outside of the interpolated range invoke
+        the default behaviour of the interpolating instance
+        """
+        v = self._value_to_interpolate(ts, scenario_index)
+        val = self.interp(v)
+        return val
 
 
 class InterpolatedParameter(AbstractInterpolatedParameter):
@@ -200,7 +244,7 @@ class InterpolatedVolumeParameter(AbstractInterpolatedParameter):
     values : array_like or from file
         y coordinates of the data points for interpolation.
     interp_kwargs : dict
-        Dictionary of keyword arguments to pass to `scipy.interpolate.interp1d` class and used
+        Dictionary of keyword arguments to pass to base class and used
         for interpolation.
     """
 
@@ -250,7 +294,7 @@ class InterpolatedFlowParameter(AbstractInterpolatedParameter):
     values : array_like
         y coordinates of the data points for interpolation.
     interp_kwargs : dict
-        Dictionary of keyword arguments to pass to `scipy.interpolate.interp1d` class and used
+        Dictionary of keyword arguments to pass to base class and used
         for interpolation.
     """
 
@@ -288,7 +332,7 @@ class InterpolatedQuadratureParameter(AbstractInterpolatedParameter):
         Lower value of the interpolated interval to integrate over. Can be `None` in which
         case the lower value of interval is zero.
     interp_kwargs : dict
-        Dictionary of keyword arguments to pass to `scipy.interpolate.interp1d` class and used
+        Dictionary of keyword arguments to pass to base class and used
         for interpolation.
 
     Example

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -60,7 +60,7 @@ import itertools
 import calendar
 import warnings
 from numpy.testing import assert_allclose
-from scipy.interpolate import Rbf, interp1d, make_interp_spline
+from scipy.interpolate import Rbf, interp1d
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -1305,7 +1305,6 @@ class TestInterpolatedParameter:
         [
             (
                 {"bounds_error": False, "fill_value": [0, 2]},
-                #{},
                 [-2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15],
             ),
             ({"kind": "quadratic"}, [5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 5]),
@@ -1322,12 +1321,9 @@ class TestInterpolatedParameter:
         data = {"parameter": "myparam", "x": x, "y": y, "interp_kwargs": interp_kwargs}
         p2 = InterpolatedParameter.load(model, data)
 
-        #if "kind" in interp_kwargs:
-        #    interp_kwargs["k"] = p2._select_degree(interp_kwargs.pop("kind"))
         if "fill_value" in interp_kwargs:
             interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
         expected_values = interp1d(x, y, **interp_kwargs)(values)
-        #expected_values = make_interp_spline(x, y, **interp_kwargs)(values)
 
         @assert_rec(model, p2)
         def expected_func(timestep, scenario_index):
@@ -1912,7 +1908,6 @@ def test_orphaned_components(simple_linear_model):
     result = model.find_orphaned_parameters()
     assert not result
     # assert that warning not raised by check
-    #with pytest.warns(None) as record:
     with warnings.catch_warnings(record=True) as record:
         model.check()
     for w in record:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -58,8 +58,9 @@ import pandas as pd
 import pytest
 import itertools
 import calendar
+import warnings
 from numpy.testing import assert_allclose
-from scipy.interpolate import Rbf, interp1d
+from scipy.interpolate import Rbf, interp1d, make_interp_spline
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -1304,6 +1305,7 @@ class TestInterpolatedParameter:
         [
             (
                 {"bounds_error": False, "fill_value": [0, 2]},
+                #{},
                 [-2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15],
             ),
             ({"kind": "quadratic"}, [5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 5]),
@@ -1320,9 +1322,12 @@ class TestInterpolatedParameter:
         data = {"parameter": "myparam", "x": x, "y": y, "interp_kwargs": interp_kwargs}
         p2 = InterpolatedParameter.load(model, data)
 
+        #if "kind" in interp_kwargs:
+        #    interp_kwargs["k"] = p2._select_degree(interp_kwargs.pop("kind"))
         if "fill_value" in interp_kwargs:
             interp_kwargs["fill_value"] = tuple(interp_kwargs["fill_value"])
         expected_values = interp1d(x, y, **interp_kwargs)(values)
+        #expected_values = make_interp_spline(x, y, **interp_kwargs)(values)
 
         @assert_rec(model, p2)
         def expected_func(timestep, scenario_index):
@@ -1907,7 +1912,8 @@ def test_orphaned_components(simple_linear_model):
     result = model.find_orphaned_parameters()
     assert not result
     # assert that warning not raised by check
-    with pytest.warns(None) as record:
+    #with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model.check()
     for w in record:
         if isinstance(w, OrphanedParameterWarning):


### PR DESCRIPTION
This request replaces the use of `scipy.interpolate.interp1d` in interpolation parameters with the `scipy.interpolate.make_interp_spline` function. Profiling indicates this gives a ~60% reduction in time per call to `.value()` for interpolating functions of the same degree and tests continue to pass.

The same set of `interp_kwargs` arguments are accepted by the `AbstractInterpolatedParameter` as previously.  The behaviours of `interp1d` in terms of the `bounds_error` and `fill_values` arguments are maintained by having the `AbstractInterpolatedParameter` process these and delegate calls to `.value()` to a method which does the minimal amount of checking consistent with the kwargs; the specified fill values are returned for arguments below or above the interpolated range, or `ValueError` is raised as specified.

The str `kind` argument is mapped to an int degree which can be passed directly to `make_interp_spline`.

A use of the deprecated `pytest.warns(None)` is removed from `tests/test_parameters.py` and replaced with the alternative descibed in [pytest docs](https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests).