### PR TITLE
fix: use `get_value`` method when fetching threshold param value within threshold parameters

### DIFF
--- a/pywr/parameters/_thresholds.pyx
+++ b/pywr/parameters/_thresholds.pyx
@@ -96,7 +96,7 @@ cdef class AbstractThresholdParameter(IndexParameter):
 
         cdef double threshold
         if self._threshold_parameter is not None:
-            threshold = self._threshold_parameter.value(timestep, scenario_index)
+            threshold = self._threshold_parameter.get_value(scenario_index)
         else:
             threshold = self._threshold
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1697,6 +1697,38 @@ class TestThresholdParameters:
         # Storage < 10
         assert p1.index(m.timestepper.current, si) == 0
 
+    def test_threshold_parameter_with_agg_threshold(self, simple_storage_model):
+        """Test StorageThresholdParameter"""
+        m = simple_storage_model
+
+        data = {
+            "type": "storagethreshold",
+            "storage_node": "Storage",
+            "threshold": {
+                "type": "aggregated",
+                "agg_func": "min",
+                "parameters": [5.0, 15.0],
+            },
+            "predicate": ">",
+        }
+
+        p1 = load_parameter(m, data)
+
+        si = ScenarioIndex(0, np.array([0], dtype=np.int32))
+
+        m.nodes["Storage"].initial_volume = 15.0
+        m.setup()
+        # step so that value if aggregated parameter is calculated
+        m.step()
+        # Storage > 10
+        assert p1.index(m.timestepper.current, si) == 1
+
+        m.nodes["Storage"].initial_volume = 7.0
+        m.setup()
+        m.step()
+        # Storage < 10
+        assert p1.index(m.timestepper.current, si) == 0
+
     def test_node_threshold_parameter2(self, simple_linear_model):
         model = simple_linear_model
         model.nodes["Input"].max_flow = ArrayIndexedParameter(model, np.arange(0, 20))


### PR DESCRIPTION
This allows parameters that do not define a value method (e.g. `AggregatedParameter`) to be used as thresholds