### PR TITLE
Fixed index conversion to datetime index

### DIFF
--- a/pywr/dataframe_tools.py
+++ b/pywr/dataframe_tools.py
@@ -273,7 +273,11 @@ def read_dataframe(model, data):
         df = pandas.read_hdf(url, key=key, **data)
     elif filetype == "dict":
         parse_dates = data.pop("parse_dates", False)
+        index = data.pop("index") if "index" in data else None
+
         df = pandas.DataFrame.from_dict(df_data, **data)
+        if index:
+            df.index = index
         if parse_dates:
             df.index = pandas.DatetimeIndex(df.index)
 


### PR DESCRIPTION
When the data is given as dictionary to build the `DataFrame` in `read_dataframe`, the conversion to datetime index using `pandas.DatetimeIndex` creates invalid dates as the index values are integer numbers. I added a new option called `index` to set the index first. For example:

```python
pywr_dict=  {
      "type": "DataFrameParameter",
      "parse_dates": True,
      "index": ["2000-1-1", "2000-1-2"],
      "data": {
          "values": [12,13, 14],
      },
}

df = read_dataframe(model, data=pywr_dict)
```