### PR TITLE
chore: pyproject.toml and build modernisation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,9 @@ jobs:
           python-version: '3.11'
 
       - name: Build sdist
-        run: python -m build --sdist
+        run: |
+          python -m pip install build
+          python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           sudo apt-get install libglpk-dev
           pip install sphinx sphinx_rtd_theme numpydoc matplotlib "numpy"
-          python setup.py install --without-lpsolve
+          PYWR_BUILD_LPSOLVE=false python setup.py install
           cd docs
           make html
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.11'
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,8 @@ jobs:
         # lpsolve doesn't compile on Ubuntu without building the library from source - disable for the time being.
         # This doesn't really matter for the documentation builds.
         run: |
-          sudo apt-get install libglpk-dev
-          pip install sphinx sphinx_rtd_theme numpydoc matplotlib "numpy"
-          PYWR_BUILD_LPSOLVE=false python setup.py install
+          sudo apt-get install libglpk-dev          
+          PYWR_BUILD_LPSOLVE=false pip install -e .[docs]
           cd docs
           make html
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -47,17 +47,14 @@ Pywr has several external dependencies, listed below.
 Installing (in general)
 -----------------------
 
-When installing Pywr you must specific which solvers to build. This is done by passing ``--with-<solver>`` as an argument to ``setup.py``. The following command will build and install Pywr with both the GLPK and lpsolve solvers:
+When installing Pywr you can specify which solvers to build. This is done via environment variables.
+We recommend using `uv` for package management, as it is the easiest way to install the dependencies.
+The following command will build and install Pywr with only the GLPK solver:
 
 .. code-block:: shell
 
-  python setup.py install --with-glpk --with-lpsolve
+  PYWR_BUILD_LPSOLVE=false uv pip install -e .
 
-To install Pywr in-place in developer mode, use the ``develop`` command instead of ``install``. This is only useful if you plan to modify the Pywr source code and is not required for general use.
-
-.. code-block:: shell
-
-  python setup.py develop --with-glpk --with-lpsolve
 
 Installing binary wheels with pip
 ---------------------------------
@@ -92,7 +89,7 @@ It's possible to install the dependencies as Anaconda packages, but still build 
   set LIBRARY=%CONDA_PREFIX%\Library
   set LIBRARY_INC=%LIBRARY%\include
   set LIBRARY_LIB=%LIBRARY%\lib
-  python setup.py build_ext -I"%LIBRARY_INC%" -L"%LIBRARY_LIB%" --inplace --with-glpk --with-lpsolve install
+  python setup.py build_ext -I"%LIBRARY_INC%" -L"%LIBRARY_LIB%" --inplace install
 
 Installing on Windows
 ---------------------
@@ -161,13 +158,13 @@ There are a collection of unit tests for Pywr written using ``pytest``. These ca
 
 .. code-block:: shell
 
-  pytest tests
+  uv run python -m pytest tests
 
 This will run all avaialble tests using the default solver. A specific solver can be tested by specifying the `PYWR_SOLVER` environment variable:
 
 .. code-block:: shell
 
-  PYWR_SOLVER=lpsolve pytest tests
+  PYWR_SOLVER=lpsolve uv run python -m pytest tests
 
 Continuous Integration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,42 @@
+[project]
+name="pywr"
+description="Python Water Resource model"
+license = "GPL-3.0"
+readme="README.rst"
+dynamic = ["version"]
+authors = [
+  {name = "Joshua Arnott", email = "josh@snorfalorpagus.net"},
+  {name = "James Tomlinson", email = "tomo.bbe@gmail.com"},
+]
+requires-python=">=3.10"
+dependencies=[
+    "pandas",
+    "networkx",
+    "numpy",
+    "scipy",
+    "tables",
+    "openpyxl",
+    "packaging",
+]
+
+
+[project.urls]
+Documentation="https://pywr.github.io/pywr/"
+Repository="https://github.com/pywr/pywr"
+
+[project.optional-dependencies]
+docs = ["sphinx", "sphinx_rtd_theme", "numpydoc", "matplotlib"]
+notebook = ["ipython", "jinja2", "matplotlib"]
+opt = ["platypus-opt", "pygmo"]
+dev = ["pytest", "platypus-opt", "black"]
+
+
+
 [build-system]
-requires = ["setuptools>=62", "wheel", "setuptools_scm[toml]>=8.0", "cython>=3", "numpy", ]
+requires = ["setuptools", "cython>=3", "numpy",]
+build-backend = "setuptools.build_meta"
+
+
 
 # enable version inference
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = ["pytest", "platypus-opt", "black"]
 
 
 [build-system]
-requires = ["setuptools", "cython>=3", "numpy",]
+requires = ["setuptools", "setuptools-scm>=8", "cython>=3", "numpy"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name="pywr"
 description="Python Water Resource model"
-license = "GPL-3.0-only"
 readme="README.rst"
 dynamic = ["version"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name="pywr"
 description="Python Water Resource model"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 readme="README.rst"
 dynamic = ["version"]
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 
 def setup_package():
+    print("Building pywr with Cython extensions")
     compiler_directives = {
         "language_level": 3,
         "embedsignature": True,
@@ -34,60 +35,11 @@ def setup_package():
             self.include_dirs.append(numpy.get_include())
             super().finalize_options()
 
-    # Extra optional dependencies
-    docs_extras = ["sphinx", "sphinx_rtd_theme", "numpydoc", "matplotlib"]
-    notebook_extras = ["ipython", "jinja2", "matplotlib"]
-    opt_extras = ["platypus-opt", "pygmo"]
-    test_extras = ["pytest"] + notebook_extras + opt_extras
-    dev_extras = docs_extras + test_extras
-
     metadata = dict(
         name="pywr",
-        description="Python Water Resource model",
-        long_description=long_description(),
-        long_description_content_type="text/x-rst",
-        author="Joshua Arnott",
-        author_email="josh@snorfalorpagus.net",
-        url="https://github.com/pywr/pywr",
-        setup_requires=[
-            "setuptools>=62",
-            "setuptools_scm[toml]>=8.0",
-            "cython>=3",
-            "numpy",
-        ],
-        install_requires=[
-            "pandas",
-            "networkx",
-            "numpy",
-            "scipy",
-            "tables",
-            "openpyxl",
-            "packaging",
-        ],
-        extras_require={
-            "docs": docs_extras,
-            "test": test_extras,
-            "dev": dev_extras,
-            "optimisation": opt_extras,
-            "notebook": notebook_extras,
-        },
-        cmdclass={"build_ext": new_build_ext},
-        packages=[
-            "pywr",
-            "pywr.solvers",
-            "pywr.domains",
-            "pywr.parameters",
-            "pywr.recorders",
-            "pywr.notebook",
-            "pywr.optimisation",
-            "pywr.utils",
-        ],
-        package_data=package_data(),
-        requires_python=">=3.10",
-        use_scm_version=True,
     )
 
-    metadata["ext_modules"] = ext_modules = [
+    ext_modules = [
         Extension("pywr._core", ["pywr/_core.pyx"]),
         Extension("pywr._model", ["pywr/_model.pyx"]),
         Extension("pywr._component", ["pywr/_component.pyx"]),
@@ -131,6 +83,9 @@ def setup_package():
                 define_macros=lpsolve_macros,
             )
         )
+
+    metadata["ext_modules"] = ext_modules
+    metadata["cmdclass"] = {"build_ext": new_build_ext}
 
     annotate = config["annotate"]
 
@@ -176,55 +131,35 @@ def parse_optional_arguments():
         "trace": False,
     }
 
-    if "--with-glpk" in sys.argv:
-        config["glpk"] = True
-        sys.argv.remove("--with-glpk")
-    elif "PYWR_BUILD_GLPK" in os.environ:
+    if "PYWR_BUILD_GLPK" in os.environ:
         config["glpk"] = os.environ["PYWR_BUILD_GLPK"].lower() in (
             "true",
             "1",
         )
-    elif "--without-glpk" in sys.argv:
-        config["glpk"] = False
-        sys.argv.remove("--without-glpk")
 
-    if "--with-lpsolve" in sys.argv:
-        config["lpsolve"] = True
-        sys.argv.remove("--with-lpsolve")
-    elif "PYWR_BUILD_LPSOLVE" in os.environ:
+    if "PYWR_BUILD_LPSOLVE" in os.environ:
         config["lpsolve"] = os.environ["PYWR_BUILD_LPSOLVE"].lower() in (
             "true",
             "1",
         )
-    elif "--without-lpsolve" in sys.argv:
-        config["lpsolve"] = False
-        sys.argv.remove("--without-lpsolve")
 
-    if "--annotate" in sys.argv:
-        config["annotate"] = True
-        sys.argv.remove("--annotate")
-
-    if "--enable-profiling" in sys.argv:
-        config["profile"] = True
-        sys.argv.remove("--enable-profiling")
-
-    if "--enable-trace" in sys.argv:
-        config["trace"] = True
-        sys.argv.remove("--enable-trace")
-    elif "PYWR_BUILD_TRACE" in os.environ:
-        config["trace"] = os.environ["PYWR_BUILD_TRACE"].lower() in (
+    if "PYWR_BUILD_ANNOTATE" in os.environ:
+        config["annotate"] = os.environ["PYWR_BUILD_ANNOTATE"].lower() in (
             "true",
             "1",
         )
 
-    if "--enable-debug" in sys.argv:
-        import warnings
-
-        warnings.warn(
-            "--enable-debug has been deprecated. Its functionality is now enabled by default. To disable"
-            "GLPK error handling please use the `use_unsafe_api` option in the GLPK solvers."
+    if "PYWR_BUILD_PROFILE" in os.environ:
+        config["profile"] = os.environ["PYWR_BUILD_PROFILE"].lower() in (
+            "true",
+            "1",
         )
-        sys.argv.remove("--enable-debug")
+
+    if "PYWR_BUILD_TRACE" in os.environ:
+        config["trace"] = os.environ["PYWR_BUILD_TRACE"].lower() in (
+            "true",
+            "1",
+        )
 
     return config
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,16 @@ def setup_package():
 
     metadata = dict(
         name="pywr",
+        packages=[
+            "pywr",
+            "pywr.solvers",
+            "pywr.domains",
+            "pywr.parameters",
+            "pywr.recorders",
+            "pywr.notebook",
+            "pywr.optimisation",
+            "pywr.utils",
+        ],
     )
 
     ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 
 def setup_package():
-    print("Building pywr with Cython extensions")
     compiler_directives = {
         "language_level": 3,
         "embedsignature": True,


### PR DESCRIPTION
Modernisation of the build process and project metadata.

- Move more metadata to pyproject.toml (from setup.py).
- Specify the build-system and backend.
- Remove parsing command line arguments in build (this is not supported). Allow existing CLI arguments to be passed as environmental variables instead.
- Update CI accordingly.
- Update installation instructions.