### PR TITLE
Glpk v5 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,16 @@ env:
   # MUSL Linux can be re-enabled more easily when updating from manylinux2014
   CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
   # Install GLPK
-  CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve-devel
-  # build using the manylinux2014 image. Can link to system provided GLPk
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve
+  # build using the manylinux_2_34 image. Can link to system provided GLPk (v5.0)
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
   # Windows binary paths to allow linking
-  CIBW_ENVIRONMENT_WINDOWS: LIB="c://glpk//w64;c://lpsolve" INCLUDE="c://glpk//src;c://"
+  CIBW_ENVIRONMENT_WINDOWS: LIB="c://glpk//Library//bin;c://glpk//Library//lib;c://lpsolve" INCLUDE="c://glpk//Library//include;c://"
   # Use delvewheel on windows
   CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-  CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path \"c://glpk//w64;c://lpsolve\" -w {dest_dir} {wheel}"
+  CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path \"c://glpk//Library//bin;c://lpsolve\" -w {dest_dir} {wheel}"
 
 jobs:
   build_wheels:
@@ -50,13 +50,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         env:
-          WINGLPK_URL: "https://sourceforge.net/projects/winglpk/files/winglpk/GLPK-4.65/winglpk-4.65.zip/download"
+          WINGLPK_URL: "https://anaconda.org/conda-forge/glpk/5.0/download/win-64/glpk-5.0-h8ffe710_0.tar.bz2"
         run: |
-          curl -L $WINGLPK_URL --output glpk.zip
-          7z x glpk.zip -o/c/
-          mv /c/glpk-4.65 /c/glpk
-          cp /c/glpk/w64/glpk_4_65.lib /c/glpk/w64/glpk.lib
-          cp /c/glpk/w64/glpk_4_65.dll /c/glpk/w64/glpk.dll
+          curl -L $WINGLPK_URL --output glpk.tar.bz2          
+          tar -xf glpk.tar.bz2 -o/c/glpk/
 
       - name: Install LpSolve (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
         env:
           WINGLPK_URL: "https://anaconda.org/conda-forge/glpk/5.0/download/win-64/glpk-5.0-h8ffe710_0.tar.bz2"
         run: |
-          curl -L $WINGLPK_URL --output glpk.tar.bz2          
+          curl -L $WINGLPK_URL --output glpk.tar.bz2
+          mkdir /c/glpk
           tar -xf glpk.tar.bz2 -C /c/glpk/
 
       - name: Install LpSolve (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ env:
   # MUSL Linux can be re-enabled more easily when updating from manylinux2014
   CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
   # Install GLPK
-  CIBW_BEFORE_ALL_LINUX: yum install -y glpk-devel lpsolve
+  CIBW_BEFORE_ALL_LINUX: dnf install -y almalinux-release-devel && dnf install -y glpk-devel lpsolve-devel
+
   # build using the manylinux_2_34 image. Can link to system provided GLPk (v5.0)
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           WINGLPK_URL: "https://anaconda.org/conda-forge/glpk/5.0/download/win-64/glpk-5.0-h8ffe710_0.tar.bz2"
         run: |
           curl -L $WINGLPK_URL --output glpk.tar.bz2          
-          tar -xf glpk.tar.bz2 -o/c/glpk/
+          tar -xf glpk.tar.bz2 -C /c/glpk/
 
       - name: Install LpSolve (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
There's an inconsistency in GLPK version between the Linux and Windows wheels. This update ensures they are both using v5. It requires updating to the latest manylinux image and fetching the Windows GLPK binaries from Conda Forge. 