### PR TITLE
fix: Do not reset AVS if simulation starts after reset day.

### DIFF
--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -624,6 +624,13 @@ class AnnualVirtualStorage(VirtualStorage):
     def before(self, ts):
         super(AnnualVirtualStorage, self).before(ts)
 
+        if ts.index == 0:
+            if ts.month > self.reset_month or (
+                ts.month == self.reset_month and ts.day > self.reset_day
+            ):
+                # Assume we reset before the model started
+                self._last_reset_year = ts.year
+
         # Reset the storage volume if necessary
         if ts.year != self._last_reset_year:
             # I.e. we're in a new year and ...


### PR DESCRIPTION
This fixes an issue where a reset would be triggered immediately if the model started after the reset day. This would prevent starting a model with a non-max initial volume after the reset day.