### PR TITLE
No loss link in AnnualVirtualStorage

### DIFF
--- a/pywr/nodes.py
+++ b/pywr/nodes.py
@@ -615,6 +615,12 @@ class AnnualVirtualStorage(VirtualStorage):
         self.reset_to_initial_volume = kwargs.pop("reset_to_initial_volume", False)
         self._last_reset_year = None
 
+        for node in kwargs["nodes"]:
+            if isinstance(node, LossLink):
+                raise TypeError(
+                    f"You cannot use the node '{node.name}' as it is a compound node"
+                )
+
         super(AnnualVirtualStorage, self).__init__(*args, **kwargs)
 
     def reset(self):


### PR DESCRIPTION
If a `LossLink ` is used as node in `AnnualVirtualStorage`, GPLK raises the following exception:

    pywr.solvers.cython_glpk.GLPKError: Attempting to set a constraint row with zero entries. This should not happen. It is likely caused by invalid or unsupported network configuration, but should generally be caught earlier by Pywr. If you experience this error please report it to the Pywr developers.

I'm implemented a quick fix for it, but shall we check the other compound nodes too (for example DelayNode)?