### PR TITLE
fix: prevent tags from being passed to load_parameter_values function

### DIFF
--- a/pywr/parameters/_parameters.pyx
+++ b/pywr/parameters/_parameters.pyx
@@ -2314,6 +2314,7 @@ def load_parameter(model, data, parameter_name=None):
         parameter = data
     else:
         # parameter is dynamic
+        tags = data.pop("tags", None)
 
         try:
              parameter_type = data['type']
@@ -2333,6 +2334,9 @@ def load_parameter(model, data, parameter_name=None):
         if "name" in kwargs:
             del(kwargs["name"])
         parameter = cls.load(model, kwargs)
+
+        if tags is not None:
+            parameter.tags = tags
 
     if parameter_name is not None:
         # TODO FIXME: memory leak if parameter is subsequently removed from the model

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -142,7 +142,7 @@ class TestConstantParameter:
 
 def test_load_parameter_tags_with_url(model):
     """Check that tags are not passed to load_parameter_values when loading a parameter with a url"""
-    
+
     model.path = os.path.join(TEST_DIR, "models")
 
     data = {

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -140,6 +140,22 @@ class TestConstantParameter:
             p.get_integer_variables()
 
 
+def test_load_parameter_tags_with_url(model):
+    """Check that tags are not passed to load_parameter_values when loading a parameter with a url"""
+    
+    model.path = os.path.join(TEST_DIR, "models")
+
+    data = {
+        "type": "dailyprofileparameter",
+        "url": "control_curve.csv",
+        "column": "Control Curve",
+        "tags": {"tag1": "val1", "tag2": "val2"},
+    }
+    parameter = load_parameter(model, data)
+
+    assert parameter.tags == {"tag1": "val1", "tag2": "val2"}
+
+
 def test_parameter_array_indexed(simple_linear_model):
     """
     Test ArrayIndexedParameter


### PR DESCRIPTION
This prevents the tags from being potentially passed to Pandas functions to read data from files resulting in an unexpected keyword error.